### PR TITLE
fix(cmd): detach worktrees before pool reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 
 | Command   | Flag      | Description                       |
 | --------- | --------- | --------------------------------- |
-| `return`  | `--force` | Skip dirty-check prompt           |
+| `return`  | `--force` | Clean, reset, and return without prompting |
 | `destroy` | `--force` | Force destroy even if in-use      |
 | `destroy` | `--all`   | Destroy all worktrees in the pool |
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -452,6 +452,52 @@ func TestReturnForceCleansAndDetachesCheckedOutBranch(t *testing.T) {
 	}
 }
 
+func TestReturnForceCleansConflictedWorktree(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	gitCmd(t, repoDir, "checkout", "-b", "feature")
+
+	env := []string{"SHELL=" + exitShellBin}
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+
+	gitCmd(t, repoDir, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repoDir, "commit", "-am", "change main")
+	gitCmd(t, repoDir, "push", "origin", "main")
+
+	gitCmd(t, wtPath, "checkout", "-b", "conflict")
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("worktree change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, wtPath, "commit", "-am", "change worktree")
+	if out, err := gitCmdResult(t, wtPath, "merge", "origin/main"); err == nil {
+		t.Fatalf("expected merge conflict, got success:\n%s", out)
+	}
+
+	_, returnErr, code := runTreehouse(t, repoDir, homeDir, nil, "return", "--force", wtPath)
+	if code != 0 {
+		t.Fatalf("return --force failed (code %d): %s", code, returnErr)
+	}
+
+	if branch, err := gitCmdResult(t, wtPath, "symbolic-ref", "--short", "-q", "HEAD"); err == nil {
+		t.Fatalf("expected returned worktree HEAD to be detached, got branch %q", branch)
+	}
+	if status := gitCmd(t, wtPath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected return --force to clean conflicted worktree, got status:\n%s", status)
+	}
+	if out, err := gitCmdResult(t, repoDir, "checkout", "main"); err != nil {
+		t.Fatalf("expected main repo to checkout main after return --force, got: %v\n%s", err, out)
+	}
+}
+
 func TestDestroySpecific(t *testing.T) {
 	repoDir, homeDir := setupTestRepo(t)
 	env := []string{"SHELL=" + exitShellBin}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	treehouseBin string
-	exitShellBin string
+	treehouseBin      string
+	exitShellBin      string
+	dirtyMainShellBin string
 )
 
 func TestMain(m *testing.M) {
@@ -58,6 +59,45 @@ func TestMain(m *testing.M) {
 	buildShell.Stderr = os.Stderr
 	if err := buildShell.Run(); err != nil {
 		panic("failed to build exit-shell: " + err.Error())
+	}
+
+	dirtyMainShellBin = filepath.Join(buildDir, "dirty-main-shell")
+	if runtime.GOOS == "windows" {
+		dirtyMainShellBin += ".exe"
+	}
+	dirtyMainSrcDir := filepath.Join(buildDir, "dirty-main-shell-src")
+	if err := os.MkdirAll(dirtyMainSrcDir, 0o755); err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirtyMainSrcDir, "go.mod"), []byte("module dirty-main-shell\n\ngo 1.21\n"), 0o644); err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirtyMainSrcDir, "main.go"), []byte(`package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func main() {
+	cmd := exec.Command("git", "checkout", "main")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		os.Exit(1)
+	}
+	if err := os.WriteFile("README.md", []byte("dirty\n"), 0o644); err != nil {
+		os.Exit(1)
+	}
+}
+`), 0o644); err != nil {
+		panic(err)
+	}
+	buildDirtyMainShell := exec.Command("go", "build", "-o", dirtyMainShellBin, ".")
+	buildDirtyMainShell.Dir = dirtyMainSrcDir
+	buildDirtyMainShell.Stderr = os.Stderr
+	if err := buildDirtyMainShell.Run(); err != nil {
+		panic("failed to build dirty-main-shell: " + err.Error())
 	}
 
 	code := m.Run()
@@ -179,6 +219,16 @@ func gitCmd(t *testing.T, dir string, args ...string) string {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func gitCmdResult(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
 }
 
 // extractWorktreePath parses the worktree path from "treehouse get" stderr.
@@ -339,6 +389,66 @@ func TestReturnFromInsideWorktreeDoesNotTerminateCaller(t *testing.T) {
 	}
 	if strings.Contains(returnErr, "Terminated lingering processes") && strings.Contains(returnErr, "treehouse") {
 		t.Fatalf("return should not terminate its own process chain: %s", returnErr)
+	}
+}
+
+func TestGetDetachesWorktreeWhenLeavingDirty(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	gitCmd(t, repoDir, "checkout", "-b", "feature")
+
+	env := []string{"SHELL=" + dirtyMainShellBin}
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+	if !strings.Contains(getErr, "Worktree left dirty") {
+		t.Fatalf("expected get to leave dirty worktree for this regression, got: %s", getErr)
+	}
+
+	if branch, err := gitCmdResult(t, wtPath, "symbolic-ref", "--short", "-q", "HEAD"); err == nil {
+		t.Fatalf("expected worktree HEAD to be detached, got branch %q", branch)
+	}
+	if out, err := gitCmdResult(t, repoDir, "checkout", "main"); err != nil {
+		t.Fatalf("expected main repo to checkout main after dirty worktree exit, got: %v\n%s", err, out)
+	}
+}
+
+func TestReturnForceCleansAndDetachesCheckedOutBranch(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	gitCmd(t, repoDir, "checkout", "-b", "feature")
+
+	env := []string{"SHELL=" + exitShellBin}
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+
+	gitCmd(t, wtPath, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, returnErr, code := runTreehouse(t, repoDir, homeDir, nil, "return", "--force", wtPath)
+	if code != 0 {
+		t.Fatalf("return --force failed (code %d): %s", code, returnErr)
+	}
+
+	if branch, err := gitCmdResult(t, wtPath, "symbolic-ref", "--short", "-q", "HEAD"); err == nil {
+		t.Fatalf("expected returned worktree HEAD to be detached, got branch %q", branch)
+	}
+	if status := gitCmd(t, wtPath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected return --force to clean tracked changes, got status:\n%s", status)
+	}
+	if out, err := gitCmdResult(t, repoDir, "checkout", "main"); err != nil {
+		t.Fatalf("expected main repo to checkout main after return --force, got: %v\n%s", err, out)
 	}
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -60,6 +60,10 @@ func getRunE(cmd *cobra.Command, args []string) error {
 	_, err = shell.Spawn(wtPath, env)
 
 	// Subshell exited — handle return
+	if err := git.DetachWorktree(wtPath); err != nil {
+		fmt.Fprintf(os.Stderr, "🌳 Warning: failed to detach worktree HEAD: %v\n", err)
+	}
+
 	dirty, _ := git.IsDirty(wtPath)
 	if dirty {
 		fmt.Fprintf(os.Stderr, "🌳 Worktree has uncommitted changes.\n")

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -44,10 +44,6 @@ var returnCmd = &cobra.Command{
 			return fmt.Errorf("worktree %s is not managed by treehouse", wtPath)
 		}
 
-		if err := git.DetachWorktree(wtPath); err != nil {
-			return fmt.Errorf("failed to detach worktree HEAD: %w", err)
-		}
-
 		if !returnForce {
 			dirty, _ := git.IsDirty(wtPath)
 			if dirty {
@@ -56,6 +52,10 @@ var returnCmd = &cobra.Command{
 					fmt.Fprintln(os.Stderr, "🌳 Aborted.")
 					return nil
 				}
+			}
+
+			if err := git.DetachWorktree(wtPath); err != nil {
+				return fmt.Errorf("failed to detach worktree HEAD: %w", err)
 			}
 		}
 

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -44,6 +44,10 @@ var returnCmd = &cobra.Command{
 			return fmt.Errorf("worktree %s is not managed by treehouse", wtPath)
 		}
 
+		if err := git.DetachWorktree(wtPath); err != nil {
+			return fmt.Errorf("failed to detach worktree HEAD: %w", err)
+		}
+
 		if !returnForce {
 			dirty, _ := git.IsDirty(wtPath)
 			if dirty {

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -71,7 +71,7 @@ var returnCmd = &cobra.Command{
 }
 
 func init() {
-	returnCmd.Flags().BoolVar(&returnForce, "force", false, "Skip dirty check prompt")
+	returnCmd.Flags().BoolVar(&returnForce, "force", false, "Clean, reset, and return without prompting")
 	rootCmd.AddCommand(returnCmd)
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -136,10 +136,18 @@ func ResetWorktree(worktreePath, branch string) error {
 		repoRoot = worktreePath
 	}
 	ref := branchRef(repoRoot, branch)
-	if _, err := runGit(worktreePath, "checkout", "--detach", ref); err != nil {
+	if _, err := runGit(worktreePath, "checkout", "--detach", "--force", ref); err != nil {
+		return err
+	}
+	if _, err := runGit(worktreePath, "reset", "--hard", ref); err != nil {
 		return err
 	}
 	_, err = runGit(worktreePath, "clean", "-fd")
+	return err
+}
+
+func DetachWorktree(worktreePath string) error {
+	_, err := runGit(worktreePath, "checkout", "--detach")
 	return err
 }
 


### PR DESCRIPTION
## Summary
- Detach worktrees when acquiring and returning them so dirty or branch-checked-out trees can be safely reset for reuse.
- Make `treehouse return --force` recover conflicted or dirty worktrees through forced cleanup instead of failing before reset.
- Update README and CLI help text to make the destructive `--force` cleanup behavior explicit, with e2e coverage for the detach and forced-return cases.

## Risk Assessment

✅ Low: The change is narrowly scoped to detaching worktree HEADs before reuse/return and adds focused regression coverage, with no material issues found in the changed code.

## Testing

- Summary: Exercised the new dirty-worktree detach regressions plus the full Go test suite; all tests passed.
- `go test ./cmd`
- `go test ./cmd -run 'Test(GetDetachesWorktreeWhenLeavingDirty|ReturnForceCleansAndDetachesCheckedOutBranch|ReturnForceCleansConflictedWorktree)$' -count=1`
- `go test ./... -count=1`
- Outcome: ✅ passed across 1 run (28.6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 error
- 🚨 `cmd/return_cmd.go:47` - `treehouse return --force` now runs a non-forced `git checkout --detach` before cleanup. A dirty worktree with an unmerged/conflicted index can make this detach fail before `pool.Release` reaches `ResetWorktree`&#39;s forced checkout/reset, so `--force` can no longer recover and clean that state. Move the detach until after the non-force confirmation, or let the forced reset path handle detaching for `--force`.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./cmd`
- `go test ./cmd -run 'Test(GetDetachesWorktreeWhenLeavingDirty|ReturnForceCleansAndDetachesCheckedOutBranch|ReturnForceCleansConflictedWorktree)$' -count=1`
- `go test ./... -count=1`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 info
- ℹ️ `README.md:151` - The `return --force` documentation still describes the flag only as skipping the dirty-check prompt, but the changed behavior now force-detaches and hard-resets/cleans worktrees so it can recover checked-out branches and conflicted states. Update the flag description to make the destructive cleanup behavior explicit, such as noting that it cleans/resets the worktree and returns it without prompting.

**Round 2** (auto-fix) - found 1 info
- ℹ️ `cmd/return_cmd.go:74` - The Cobra help text for `treehouse return --force` still says `Skip dirty check prompt`, but the changed behavior now force-cleans/resets and detaches the worktree before returning it. Update the flag description used by `treehouse return --help` so the built-in CLI documentation matches the README and the new destructive cleanup behavior.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
