### PR TITLE
feat(pool): add user lifecycle hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ make test
 
 - No daemon — all operations are inline CLI commands
 - Detached HEAD worktrees reset to whichever of local or origin default branch is further ahead (prefers origin on divergence)
-- In-use detection is runtime-only (process scanning), never persisted
-- State file only tracks pool membership, not usage status
+- In-use detection uses process scanning plus short-lived persisted owner reservations for lifecycle operations
+- State file tracks pool membership and temporary owner/destroy reservations, not long-term usage status
 - Git operations shell out to `git` (go-git has incomplete worktree support)
 - Self-healing: stale state entries are auto-removed
 
@@ -53,8 +53,15 @@ This project targets Linux, macOS, and Windows. All new code **must** work on Wi
 
 ## Config
 
-Place `treehouse.toml` in repo root or `~/.config/treehouse/config.toml`:
+Place repo-safe settings in repo root `treehouse.toml` or user-level `~/.config/treehouse/config.toml`:
 
 ```toml
 max_trees = 16
+
+# User-level config only:
+[hooks]
+post_create = ["./scripts/setup-venv.sh"]
+pre_destroy = ["./scripts/teardown.sh"]
 ```
+
+Hooks are ignored in repo-level config for safety.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Treehouse is a Go CLI tool that manages a pool of git worktrees for parallel AI 
 - `main.go` — entry point, calls `cmd.Execute()`
 - `cmd/` — CLI commands (cobra): `get`, `return`, `status`, `destroy`
 - `internal/config/` — config file loading (`treehouse.toml`)
+- `internal/hooks/` — user-configured lifecycle hook command execution
 - `internal/pool/` — pool manager (acquire, release, list, destroy) + state file
 - `internal/git/` — git operations (shells out to `git` binary)
 - `internal/process/` — in-use detection and lingering process termination for worktrees

--- a/README.md
+++ b/README.md
@@ -165,7 +165,25 @@ Create a config file with `treehouse init`, or add one manually:
 max_trees = 16
 ```
 
-The repo-level config takes precedence. If no config is found, the default pool size is 16.
+The repo-level config takes precedence.
+If no config is found, the default pool size is 16.
+
+### Hooks
+
+You can run commands automatically at worktree lifecycle points by adding a `[hooks]` section:
+
+```toml
+[hooks]
+post_create = ["./scripts/setup-venv.sh"]
+pre_destroy = ["./scripts/teardown.sh"]
+```
+
+- `post_create` runs after a worktree is provisioned or reset and right before `treehouse get` hands it to you.
+- `pre_destroy` runs before a worktree is removed by `treehouse destroy` (and `treehouse destroy --all`).
+
+Commands in each list run sequentially in the worktree directory, via the OS shell (`/bin/sh -c` on Linux/macOS, `%COMSPEC% /c` on Windows).
+If a command exits non-zero, treehouse logs the command, exit code, and stderr, then continues with the remaining commands.
+A failing hook does not fail the overall `get` or `destroy` operation.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 
 ## Configuration
 
-Create a config file with `treehouse init`, or add one manually:
+Create a repo config file with `treehouse init`, or add one manually:
 
 **Repo-level:** `treehouse.toml` in the repository root
 
@@ -165,12 +165,13 @@ Create a config file with `treehouse init`, or add one manually:
 max_trees = 16
 ```
 
-The repo-level config takes precedence.
+The repo-level config takes precedence for repo-safe settings.
 If no config is found, the default pool size is 16.
 
 ### Hooks
 
-You can run commands automatically at worktree lifecycle points by adding a `[hooks]` section:
+You can run commands automatically at worktree lifecycle points by adding a `[hooks]` section to the user-level config at `~/.config/treehouse/config.toml`.
+Hooks in repo-level `treehouse.toml` are ignored for safety.
 
 ```toml
 [hooks]

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 
 - **Detached HEAD** — worktrees use detached HEAD mode, reset to whichever of the local or remote default branch is further ahead, avoiding branch name conflicts entirely.
 - **No daemon** — all operations are inline CLI commands. No background processes, no state to get corrupted.
-- **In-use detection** — treehouse scans running processes to determine which worktrees are in-use. Usage state is never persisted, so it's always accurate.
+- **In-use detection** — treehouse scans running processes and short-lived owner reservations to determine which worktrees are in-use. Reservations are persisted only while `get` and `destroy` lifecycle work is running.
 
 ## CLI Reference
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -45,7 +45,7 @@ var destroyCmd = &cobra.Command{
 					return nil
 				}
 			}
-			if err := pool.DestroyAll(repoRoot, poolDir, destroyForce); err != nil {
+			if err := pool.DestroyAll(repoRoot, poolDir, destroyForce, cfg.Hooks.PreDestroy); err != nil {
 				return err
 			}
 			fmt.Fprintln(os.Stderr, "🌳 All worktrees destroyed.")
@@ -69,7 +69,7 @@ var destroyCmd = &cobra.Command{
 			}
 		}
 
-		if err := pool.Destroy(repoRoot, poolDir, wtPath, destroyForce); err != nil {
+		if err := pool.Destroy(repoRoot, poolDir, wtPath, destroyForce, cfg.Hooks.PreDestroy); err != nil {
 			return err
 		}
 		fmt.Fprintln(os.Stderr, "🌳 Worktree destroyed.")

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -47,7 +47,7 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "warning: failed to update .gitignore: %v\n", err)
 	}
 
-	wtPath, err := pool.Acquire(repoRoot, poolDir, cfg.MaxTrees)
+	wtPath, err := pool.Acquire(repoRoot, poolDir, cfg.MaxTrees, cfg.Hooks.PostCreate)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,12 @@ import (
 type Config struct {
 	MaxTrees int    `toml:"max_trees"`
 	Root     string `toml:"root"`
+	Hooks    Hooks  `toml:"hooks,omitempty"`
+}
+
+type Hooks struct {
+	PostCreate []string `toml:"post_create,omitempty"`
+	PreDestroy []string `toml:"pre_destroy,omitempty"`
 }
 
 func DefaultConfig() Config {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,20 +28,28 @@ func DefaultConfig() Config {
 func Load(repoRoot string) (Config, error) {
 	cfg := DefaultConfig()
 
-	paths := []string{
-		filepath.Join(repoRoot, "treehouse.toml"),
+	repoPath := filepath.Join(repoRoot, "treehouse.toml")
+	hasRepoConfig := false
+	if _, err := os.Stat(repoPath); err == nil {
+		hasRepoConfig = true
+		if _, err := toml.DecodeFile(repoPath, &cfg); err != nil {
+			return cfg, err
+		}
+		cfg.Hooks = Hooks{}
 	}
 
 	if home, err := os.UserHomeDir(); err == nil {
-		paths = append(paths, filepath.Join(home, ".config", "treehouse", "config.toml"))
-	}
-
-	for _, p := range paths {
-		if _, err := os.Stat(p); err == nil {
-			if _, err := toml.DecodeFile(p, &cfg); err != nil {
+		userPath := filepath.Join(home, ".config", "treehouse", "config.toml")
+		if _, err := os.Stat(userPath); err == nil {
+			userCfg := DefaultConfig()
+			if _, err := toml.DecodeFile(userPath, &userCfg); err != nil {
 				return cfg, err
 			}
-			return cfg, nil
+			if !hasRepoConfig {
+				cfg = userCfg
+			} else {
+				cfg.Hooks = userCfg.Hooks
+			}
 		}
 	}
 

--- a/internal/config/hooks_test.go
+++ b/internal/config/hooks_test.go
@@ -4,11 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
-func TestLoad_Hooks(t *testing.T) {
+func TestLoad_IgnoresRepoHooks(t *testing.T) {
 	repoDir := t.TempDir()
+	setUserHome(t, t.TempDir())
 
 	cfgTOML := `max_trees = 4
 
@@ -17,6 +19,39 @@ post_create = ["echo a", "echo b"]
 pre_destroy = ["echo c"]
 `
 	if err := os.WriteFile(filepath.Join(repoDir, "treehouse.toml"), []byte(cfgTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if cfg.MaxTrees != 4 {
+		t.Errorf("MaxTrees: got %d, want 4", cfg.MaxTrees)
+	}
+	if len(cfg.Hooks.PostCreate) != 0 {
+		t.Errorf("expected repo post_create hooks to be ignored, got %v", cfg.Hooks.PostCreate)
+	}
+	if len(cfg.Hooks.PreDestroy) != 0 {
+		t.Errorf("expected repo pre_destroy hooks to be ignored, got %v", cfg.Hooks.PreDestroy)
+	}
+}
+
+func TestLoad_UserHooks(t *testing.T) {
+	repoDir := t.TempDir()
+	userHome := t.TempDir()
+	setUserHome(t, userHome)
+
+	configDir := filepath.Join(userHome, ".config", "treehouse")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgTOML := `[hooks]
+post_create = ["echo a", "echo b"]
+pre_destroy = ["echo c"]
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(cfgTOML), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -37,6 +72,7 @@ pre_destroy = ["echo c"]
 
 func TestLoad_HooksDefaultEmpty(t *testing.T) {
 	repoDir := t.TempDir()
+	setUserHome(t, t.TempDir())
 
 	cfg, err := Load(repoDir)
 	if err != nil {
@@ -47,5 +83,14 @@ func TestLoad_HooksDefaultEmpty(t *testing.T) {
 	}
 	if len(cfg.Hooks.PreDestroy) != 0 {
 		t.Errorf("expected empty PreDestroy, got %v", cfg.Hooks.PreDestroy)
+	}
+}
+
+func setUserHome(t *testing.T, home string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	} else {
+		t.Setenv("HOME", home)
 	}
 }

--- a/internal/config/hooks_test.go
+++ b/internal/config/hooks_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoad_Hooks(t *testing.T) {
+	repoDir := t.TempDir()
+
+	cfgTOML := `max_trees = 4
+
+[hooks]
+post_create = ["echo a", "echo b"]
+pre_destroy = ["echo c"]
+`
+	if err := os.WriteFile(filepath.Join(repoDir, "treehouse.toml"), []byte(cfgTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	wantPost := []string{"echo a", "echo b"}
+	wantPre := []string{"echo c"}
+	if !reflect.DeepEqual(cfg.Hooks.PostCreate, wantPost) {
+		t.Errorf("PostCreate: got %v, want %v", cfg.Hooks.PostCreate, wantPost)
+	}
+	if !reflect.DeepEqual(cfg.Hooks.PreDestroy, wantPre) {
+		t.Errorf("PreDestroy: got %v, want %v", cfg.Hooks.PreDestroy, wantPre)
+	}
+}
+
+func TestLoad_HooksDefaultEmpty(t *testing.T) {
+	repoDir := t.TempDir()
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if len(cfg.Hooks.PostCreate) != 0 {
+		t.Errorf("expected empty PostCreate, got %v", cfg.Hooks.PostCreate)
+	}
+	if len(cfg.Hooks.PreDestroy) != 0 {
+		t.Errorf("expected empty PreDestroy, got %v", cfg.Hooks.PreDestroy)
+	}
+}

--- a/internal/hooks/command_unix.go
+++ b/internal/hooks/command_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package hooks
+
+import "os/exec"
+
+func newHookCommand(command string) *exec.Cmd {
+	return exec.Command("/bin/sh", "-c", command)
+}

--- a/internal/hooks/command_windows.go
+++ b/internal/hooks/command_windows.go
@@ -5,6 +5,7 @@ package hooks
 import (
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 func newHookCommand(command string) *exec.Cmd {
@@ -13,5 +14,7 @@ func newHookCommand(command string) *exec.Cmd {
 		shell = "cmd.exe"
 	}
 
-	return exec.Command(shell, windowsShellArgs(command)...)
+	cmd := exec.Command(shell)
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: windowsShellCommandLine(shell, command)}
+	return cmd
 }

--- a/internal/hooks/command_windows.go
+++ b/internal/hooks/command_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package hooks
+
+import (
+	"os"
+	"os/exec"
+)
+
+func newHookCommand(command string) *exec.Cmd {
+	shell := os.Getenv("COMSPEC")
+	if shell == "" {
+		shell = "cmd.exe"
+	}
+
+	return exec.Command(shell, windowsShellArgs(command)...)
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Run executes each command in commands sequentially in workDir. Each command
-// is passed to the OS shell (/bin/sh -c on Unix, %COMSPEC% /d /c on Windows).
+// is passed to the OS shell (/bin/sh -c on Unix, %COMSPEC% /d /s /c on Windows).
 // Stdout and stderr from the commands are streamed to the given writers.
 // Failures are logged to stderr and do not stop subsequent commands.
 func Run(commands []string, workDir string, stdout, stderr io.Writer) {
@@ -34,6 +34,6 @@ func runOne(command, workDir string, stdout, stderr io.Writer) {
 	}
 }
 
-func windowsShellArgs(command string) []string {
-	return []string{"/d", "/c", command}
+func windowsShellCommandLine(shell, command string) string {
+	return `"` + shell + `" /d /s /c "` + command + `"`
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,0 +1,50 @@
+// Package hooks runs user-configured shell commands at worktree lifecycle
+// points. Commands run sequentially in a given working directory. A failing
+// command is logged but does not stop later commands or fail the caller.
+package hooks
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// Run executes each command in commands sequentially in workDir. Each command
+// is passed to the OS shell (/bin/sh -c on Unix, %COMSPEC% /c on Windows).
+// Stdout and stderr from the commands are streamed to the given writers.
+// Failures are logged to stderr and do not stop subsequent commands.
+func Run(commands []string, workDir string, stdout, stderr io.Writer) {
+	for _, command := range commands {
+		runOne(command, workDir, stdout, stderr)
+	}
+}
+
+func runOne(command, workDir string, stdout, stderr io.Writer) {
+	shell, flag := shellAndFlag()
+
+	cmd := exec.Command(shell, flag, command)
+	cmd.Dir = workDir
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		exitCode := -1
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+		fmt.Fprintf(stderr, "🌳 hook command failed: %q (exit %d): %v\n", command, exitCode, err)
+	}
+}
+
+func shellAndFlag() (string, string) {
+	if runtime.GOOS == "windows" {
+		shell := os.Getenv("COMSPEC")
+		if shell == "" {
+			shell = "cmd.exe"
+		}
+		return shell, "/c"
+	}
+	return "/bin/sh", "-c"
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -6,13 +6,11 @@ package hooks
 import (
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
-	"runtime"
 )
 
 // Run executes each command in commands sequentially in workDir. Each command
-// is passed to the OS shell (/bin/sh -c on Unix, %COMSPEC% /c on Windows).
+// is passed to the OS shell (/bin/sh -c on Unix, %COMSPEC% /d /s /c on Windows).
 // Stdout and stderr from the commands are streamed to the given writers.
 // Failures are logged to stderr and do not stop subsequent commands.
 func Run(commands []string, workDir string, stdout, stderr io.Writer) {
@@ -22,9 +20,7 @@ func Run(commands []string, workDir string, stdout, stderr io.Writer) {
 }
 
 func runOne(command, workDir string, stdout, stderr io.Writer) {
-	shell, flag := shellAndFlag()
-
-	cmd := exec.Command(shell, flag, command)
+	cmd := newHookCommand(command)
 	cmd.Dir = workDir
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -38,13 +34,6 @@ func runOne(command, workDir string, stdout, stderr io.Writer) {
 	}
 }
 
-func shellAndFlag() (string, string) {
-	if runtime.GOOS == "windows" {
-		shell := os.Getenv("COMSPEC")
-		if shell == "" {
-			shell = "cmd.exe"
-		}
-		return shell, "/c"
-	}
-	return "/bin/sh", "-c"
+func windowsShellArgs(command string) []string {
+	return []string{"/d", "/s", "/c", command}
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Run executes each command in commands sequentially in workDir. Each command
-// is passed to the OS shell (/bin/sh -c on Unix, %COMSPEC% /d /s /c on Windows).
+// is passed to the OS shell (/bin/sh -c on Unix, %COMSPEC% /d /c on Windows).
 // Stdout and stderr from the commands are streamed to the given writers.
 // Failures are logged to stderr and do not stop subsequent commands.
 func Run(commands []string, workDir string, stdout, stderr io.Writer) {
@@ -35,5 +35,5 @@ func runOne(command, workDir string, stdout, stderr io.Writer) {
 }
 
 func windowsShellArgs(command string) []string {
-	return []string{"/d", "/s", "/c", command}
+	return []string{"/d", "/c", command}
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -94,13 +94,14 @@ func TestRun_RunsInGivenDir(t *testing.T) {
 	}
 }
 
-func TestWindowsShellArgsPassQuotedHookCommandWithoutQuoteStripping(t *testing.T) {
+func TestWindowsShellCommandLineWrapsQuotedHookCommandForCmd(t *testing.T) {
+	shell := `C:\Windows\System32\cmd.exe`
 	command := `echo hi > "C:\Temp\ran.txt"`
 
-	got := windowsShellArgs(command)
-	want := []string{"/d", "/c", command}
+	got := windowsShellCommandLine(shell, command)
+	want := `"C:\Windows\System32\cmd.exe" /d /s /c "echo hi > "C:\Temp\ran.txt""`
 
-	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("windows shell args mismatch\nwant: %#v\n got: %#v", want, got)
+	if got != want {
+		t.Fatalf("windows shell command line mismatch\nwant: %q\n got: %q", want, got)
 	}
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -94,11 +94,11 @@ func TestRun_RunsInGivenDir(t *testing.T) {
 	}
 }
 
-func TestWindowsShellArgsPassHookCommandAsSingleArgument(t *testing.T) {
+func TestWindowsShellArgsPassQuotedHookCommandWithoutQuoteStripping(t *testing.T) {
 	command := `echo hi > "C:\Temp\ran.txt"`
 
 	got := windowsShellArgs(command)
-	want := []string{"/d", "/s", "/c", command}
+	want := []string{"/d", "/c", command}
 
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("windows shell args mismatch\nwant: %#v\n got: %#v", want, got)

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -93,3 +93,14 @@ func TestRun_RunsInGivenDir(t *testing.T) {
 		t.Fatalf("expected hook to run in %s: %v\nstderr: %s", dir, err, stderr.String())
 	}
 }
+
+func TestWindowsShellArgsPassHookCommandAsSingleArgument(t *testing.T) {
+	command := `echo hi > "C:\Temp\ran.txt"`
+
+	got := windowsShellArgs(command)
+	want := []string{"/d", "/s", "/c", command}
+
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("windows shell args mismatch\nwant: %#v\n got: %#v", want, got)
+	}
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1,0 +1,95 @@
+package hooks
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// quotePath returns a path suitably quoted for use as a shell argument. On
+// Windows we use double quotes for cmd.exe; on Unix we use single quotes for
+// /bin/sh.
+func quotePath(p string) string {
+	if runtime.GOOS == "windows" {
+		return `"` + p + `"`
+	}
+	return `'` + p + `'`
+}
+
+func TestRun_Success(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "ran.txt")
+
+	var script string
+	if runtime.GOOS == "windows" {
+		script = "echo hi > " + quotePath(sentinel)
+	} else {
+		script = "echo hi > " + quotePath(sentinel)
+	}
+
+	var stdout, stderr bytes.Buffer
+	Run([]string{script}, dir, &stdout, &stderr)
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected sentinel %s to exist: %v\nstderr: %s", sentinel, err, stderr.String())
+	}
+}
+
+func TestRun_FailingCommandDoesNotStopRemaining(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "after.txt")
+
+	// First command: a non-existent program that should fail.
+	// Second command: writes the sentinel - must run despite the first failure.
+	var fail, ok string
+	if runtime.GOOS == "windows" {
+		fail = "this-command-definitely-does-not-exist-xyzzy"
+		ok = "echo hi > " + quotePath(sentinel)
+	} else {
+		fail = "this-command-definitely-does-not-exist-xyzzy"
+		ok = "echo hi > " + quotePath(sentinel)
+	}
+
+	var stdout, stderr bytes.Buffer
+	Run([]string{fail, ok}, dir, &stdout, &stderr)
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected second command to still run despite first failing: %v\nstderr: %s", err, stderr.String())
+	}
+
+	// The failure should be logged to stderr.
+	if !strings.Contains(stderr.String(), "hook command failed") {
+		t.Errorf("expected stderr to log hook failure, got: %s", stderr.String())
+	}
+}
+
+func TestRun_EmptyListIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	Run(nil, dir, &stdout, &stderr)
+	Run([]string{}, dir, &stdout, &stderr)
+	if stderr.Len() != 0 || stdout.Len() != 0 {
+		t.Errorf("expected no output for empty hooks, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRun_RunsInGivenDir(t *testing.T) {
+	dir := t.TempDir()
+	// Write a relative-path sentinel so we can confirm cwd is dir.
+	var script string
+	if runtime.GOOS == "windows" {
+		script = "echo hi > cwd-sentinel.txt"
+	} else {
+		script = "echo hi > cwd-sentinel.txt"
+	}
+
+	var stdout, stderr bytes.Buffer
+	Run([]string{script}, dir, &stdout, &stderr)
+
+	if _, err := os.Stat(filepath.Join(dir, "cwd-sentinel.txt")); err != nil {
+		t.Fatalf("expected hook to run in %s: %v\nstderr: %s", dir, err, stderr.String())
+	}
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -131,6 +131,20 @@ func Release(poolDir, worktreePath string) error {
 	if err != nil {
 		return err
 	}
+	if err := WithStateLock(poolDir, func() error {
+		state, err := ReadState(poolDir)
+		if err != nil {
+			return err
+		}
+		for _, wt := range state.Worktrees {
+			if wt.Path == worktreePath && wt.Destroying {
+				return fmt.Errorf("worktree %s is being destroyed", worktreePath)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
 	if err := git.ResetWorktree(worktreePath, branch); err != nil {
 		return err
 	}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -262,9 +262,6 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 
 		if !force {
 			for _, wt := range state.Worktrees {
-				if wt.Destroying {
-					continue
-				}
 				inUse, _ := worktreeInUse(wt)
 				if inUse {
 					return fmt.Errorf("worktree %s is in use by an agent. Use --force to override", wt.Path)

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -51,8 +51,8 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 		state = healState(state)
 
 		// Try to find an available worktree (clean and not in-use)
-		for _, wt := range state.Worktrees {
-			if wt.Destroying {
+		for i, wt := range state.Worktrees {
+			if wt.Destroying || ownerAlive(wt) {
 				continue
 			}
 			inUse, _ := process.IsWorktreeInUse(wt.Path)
@@ -67,6 +67,7 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 			if err := git.ResetWorktree(wt.Path, branch); err != nil {
 				continue
 			}
+			state.Worktrees[i].OwnerPID = int32(os.Getpid())
 			acquired = wt.Path
 			if err := WriteState(poolDir, state); err != nil {
 				return err
@@ -96,6 +97,7 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 			Name:      name,
 			Path:      wtPath,
 			CreatedAt: time.Now(),
+			OwnerPID:  int32(os.Getpid()),
 		})
 
 		acquired = wtPath
@@ -124,7 +126,22 @@ func Release(poolDir, worktreePath string) error {
 	if err != nil {
 		return err
 	}
-	return git.ResetWorktree(worktreePath, branch)
+	if err := git.ResetWorktree(worktreePath, branch); err != nil {
+		return err
+	}
+	return WithStateLock(poolDir, func() error {
+		state, err := ReadState(poolDir)
+		if err != nil {
+			return err
+		}
+		for i := range state.Worktrees {
+			if state.Worktrees[i].Path == worktreePath {
+				state.Worktrees[i].OwnerPID = 0
+				break
+			}
+		}
+		return WriteState(poolDir, state)
+	})
 }
 
 func List(poolDir string) ([]WorktreeStatus, error) {
@@ -156,7 +173,9 @@ func List(poolDir string) ([]WorktreeStatus, error) {
 			procs, _ := process.FindProcessesInWorktree(wt.Path)
 			ws.Processes = procs
 
-			if len(procs) > 0 {
+			if ownerAlive(wt) {
+				ws.Status = StatusInUse
+			} else if len(procs) > 0 {
 				ws.Status = StatusInUse
 				if cwdInWorktree(cwd, wt.Path) {
 					ws.Status = StatusHere
@@ -199,6 +218,7 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []st
 		}
 
 		state.Worktrees[idx].Destroying = true
+		state.Worktrees[idx].OwnerPID = int32(os.Getpid())
 		return WriteState(poolDir, state)
 	}); err != nil {
 		return err
@@ -255,6 +275,7 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 		worktrees = append([]WorktreeEntry(nil), state.Worktrees...)
 		for i := range state.Worktrees {
 			state.Worktrees[i].Destroying = true
+			state.Worktrees[i].OwnerPID = int32(os.Getpid())
 		}
 		return WriteState(poolDir, state)
 	}); err != nil {
@@ -306,11 +327,19 @@ func healState(state State) State {
 	var healed []WorktreeEntry
 	for _, wt := range state.Worktrees {
 		if _, err := os.Stat(wt.Path); err == nil {
+			if wt.OwnerPID != 0 && !ownerAlive(wt) {
+				wt.OwnerPID = 0
+				wt.Destroying = false
+			}
 			healed = append(healed, wt)
 		}
 	}
 	state.Worktrees = healed
 	return state
+}
+
+func ownerAlive(wt WorktreeEntry) bool {
+	return wt.OwnerPID != 0 && process.Exists(wt.OwnerPID)
 }
 
 func cwdInWorktree(cwd, worktreePath string) bool {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -40,6 +40,7 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 	}
 
 	var acquired string
+	var runPostCreate bool
 
 	err = WithStateLock(poolDir, func() error {
 		state, err := ReadState(poolDir)
@@ -67,7 +68,7 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 			if err := WriteState(poolDir, state); err != nil {
 				return err
 			}
-			hooks.Run(postCreate, acquired, os.Stdout, os.Stderr)
+			runPostCreate = true
 			return nil
 		}
 
@@ -98,11 +99,17 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 		if err := WriteState(poolDir, state); err != nil {
 			return err
 		}
-		hooks.Run(postCreate, acquired, os.Stdout, os.Stderr)
+		runPostCreate = true
 		return nil
 	})
+	if err != nil {
+		return "", err
+	}
+	if runPostCreate {
+		hooks.Run(postCreate, acquired, os.Stdout, os.Stderr)
+	}
 
-	return acquired, err
+	return acquired, nil
 }
 
 func Release(poolDir, worktreePath string) error {
@@ -161,7 +168,7 @@ func List(poolDir string) ([]WorktreeStatus, error) {
 }
 
 func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []string) error {
-	return WithStateLock(poolDir, func() error {
+	if err := WithStateLock(poolDir, func() error {
 		state, err := ReadState(poolDir)
 		if err != nil {
 			return err
@@ -185,7 +192,29 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []st
 			}
 		}
 
-		hooks.Run(preDestroy, worktreePath, os.Stdout, os.Stderr)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	hooks.Run(preDestroy, worktreePath, os.Stdout, os.Stderr)
+
+	return WithStateLock(poolDir, func() error {
+		state, err := ReadState(poolDir)
+		if err != nil {
+			return err
+		}
+
+		idx := -1
+		for i, wt := range state.Worktrees {
+			if wt.Path == worktreePath {
+				idx = i
+				break
+			}
+		}
+		if idx == -1 {
+			return fmt.Errorf("worktree %s is not managed by treehouse", worktreePath)
+		}
 
 		_ = git.RemoveWorktree(repoRoot, worktreePath)
 		// also clean up the parent numbered directory
@@ -197,7 +226,8 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []st
 }
 
 func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error {
-	return WithStateLock(poolDir, func() error {
+	var worktrees []WorktreeEntry
+	if err := WithStateLock(poolDir, func() error {
 		state, err := ReadState(poolDir)
 		if err != nil {
 			return err
@@ -212,12 +242,26 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 			}
 		}
 
-		for _, wt := range state.Worktrees {
-			hooks.Run(preDestroy, wt.Path, os.Stdout, os.Stderr)
+		worktrees = append([]WorktreeEntry(nil), state.Worktrees...)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	for _, wt := range worktrees {
+		hooks.Run(preDestroy, wt.Path, os.Stdout, os.Stderr)
+	}
+
+	return WithStateLock(poolDir, func() error {
+		state, err := ReadState(poolDir)
+		if err != nil {
+			return err
+		}
+
+		for _, wt := range worktrees {
 			_ = git.RemoveWorktree(repoRoot, wt.Path)
 			os.RemoveAll(filepath.Dir(wt.Path))
 		}
-
 		state.Worktrees = nil
 		return WriteState(poolDir, state)
 	})

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/treehouse/internal/git"
+	"github.com/kunchenguid/treehouse/internal/hooks"
 	"github.com/kunchenguid/treehouse/internal/process"
 )
 
@@ -25,7 +26,7 @@ type WorktreeStatus struct {
 	Processes []process.ProcessInfo
 }
 
-func Acquire(repoRoot, poolDir string, poolSize int) (string, error) {
+func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (string, error) {
 	branch, err := git.GetDefaultBranch(repoRoot)
 	if err != nil {
 		return "", err
@@ -63,7 +64,11 @@ func Acquire(repoRoot, poolDir string, poolSize int) (string, error) {
 				continue
 			}
 			acquired = wt.Path
-			return WriteState(poolDir, state)
+			if err := WriteState(poolDir, state); err != nil {
+				return err
+			}
+			hooks.Run(postCreate, acquired, os.Stdout, os.Stderr)
+			return nil
 		}
 
 		// No available worktree — create new if pool allows
@@ -90,7 +95,11 @@ func Acquire(repoRoot, poolDir string, poolSize int) (string, error) {
 		})
 
 		acquired = wtPath
-		return WriteState(poolDir, state)
+		if err := WriteState(poolDir, state); err != nil {
+			return err
+		}
+		hooks.Run(postCreate, acquired, os.Stdout, os.Stderr)
+		return nil
 	})
 
 	return acquired, err
@@ -151,7 +160,7 @@ func List(poolDir string) ([]WorktreeStatus, error) {
 	return result, err
 }
 
-func Destroy(repoRoot, poolDir, worktreePath string, force bool) error {
+func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []string) error {
 	return WithStateLock(poolDir, func() error {
 		state, err := ReadState(poolDir)
 		if err != nil {
@@ -176,6 +185,8 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool) error {
 			}
 		}
 
+		hooks.Run(preDestroy, worktreePath, os.Stdout, os.Stderr)
+
 		_ = git.RemoveWorktree(repoRoot, worktreePath)
 		// also clean up the parent numbered directory
 		os.RemoveAll(filepath.Dir(worktreePath))
@@ -185,7 +196,7 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool) error {
 	})
 }
 
-func DestroyAll(repoRoot, poolDir string, force bool) error {
+func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error {
 	return WithStateLock(poolDir, func() error {
 		state, err := ReadState(poolDir)
 		if err != nil {
@@ -202,6 +213,7 @@ func DestroyAll(repoRoot, poolDir string, force bool) error {
 		}
 
 		for _, wt := range state.Worktrees {
+			hooks.Run(preDestroy, wt.Path, os.Stdout, os.Stderr)
 			_ = git.RemoveWorktree(repoRoot, wt.Path)
 			os.RemoveAll(filepath.Dir(wt.Path))
 		}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -211,7 +211,7 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []st
 		}
 
 		if !force {
-			inUse, _ := process.IsWorktreeInUse(worktreePath)
+			inUse, _ := worktreeInUse(state.Worktrees[idx])
 			if inUse {
 				return fmt.Errorf("worktree %s is in use by an agent. Use --force to override", worktreePath)
 			}
@@ -265,7 +265,7 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 				if wt.Destroying {
 					continue
 				}
-				inUse, _ := process.IsWorktreeInUse(wt.Path)
+				inUse, _ := worktreeInUse(wt)
 				if inUse {
 					return fmt.Errorf("worktree %s is in use by an agent. Use --force to override", wt.Path)
 				}
@@ -340,6 +340,13 @@ func healState(state State) State {
 
 func ownerAlive(wt WorktreeEntry) bool {
 	return wt.OwnerPID != 0 && process.Exists(wt.OwnerPID)
+}
+
+func worktreeInUse(wt WorktreeEntry) (bool, error) {
+	if ownerAlive(wt) {
+		return true, nil
+	}
+	return process.IsWorktreeInUse(wt.Path)
 }
 
 func cwdInWorktree(cwd, worktreePath string) bool {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -67,7 +67,9 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 			if err := git.ResetWorktree(wt.Path, branch); err != nil {
 				continue
 			}
-			state.Worktrees[i].OwnerPID = int32(os.Getpid())
+			if err := reserveOwner(&state.Worktrees[i]); err != nil {
+				return err
+			}
 			acquired = wt.Path
 			if err := WriteState(poolDir, state); err != nil {
 				return err
@@ -93,12 +95,15 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 			return fmt.Errorf("failed to create worktree: %w", err)
 		}
 
-		state.Worktrees = append(state.Worktrees, WorktreeEntry{
+		entry := WorktreeEntry{
 			Name:      name,
 			Path:      wtPath,
 			CreatedAt: time.Now(),
-			OwnerPID:  int32(os.Getpid()),
-		})
+		}
+		if err := reserveOwner(&entry); err != nil {
+			return err
+		}
+		state.Worktrees = append(state.Worktrees, entry)
 
 		acquired = wtPath
 		if err := WriteState(poolDir, state); err != nil {
@@ -137,6 +142,7 @@ func Release(poolDir, worktreePath string) error {
 		for i := range state.Worktrees {
 			if state.Worktrees[i].Path == worktreePath {
 				state.Worktrees[i].OwnerPID = 0
+				state.Worktrees[i].OwnerStartedAt = 0
 				break
 			}
 		}
@@ -218,7 +224,9 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []st
 		}
 
 		state.Worktrees[idx].Destroying = true
-		state.Worktrees[idx].OwnerPID = int32(os.Getpid())
+		if err := reserveOwner(&state.Worktrees[idx]); err != nil {
+			return err
+		}
 		return WriteState(poolDir, state)
 	}); err != nil {
 		return err
@@ -272,7 +280,9 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 		worktrees = append([]WorktreeEntry(nil), state.Worktrees...)
 		for i := range state.Worktrees {
 			state.Worktrees[i].Destroying = true
-			state.Worktrees[i].OwnerPID = int32(os.Getpid())
+			if err := reserveOwner(&state.Worktrees[i]); err != nil {
+				return err
+			}
 		}
 		return WriteState(poolDir, state)
 	}); err != nil {
@@ -326,6 +336,7 @@ func healState(state State) State {
 		if _, err := os.Stat(wt.Path); err == nil {
 			if wt.OwnerPID != 0 && !ownerAlive(wt) {
 				wt.OwnerPID = 0
+				wt.OwnerStartedAt = 0
 				wt.Destroying = false
 			}
 			healed = append(healed, wt)
@@ -336,7 +347,22 @@ func healState(state State) State {
 }
 
 func ownerAlive(wt WorktreeEntry) bool {
-	return wt.OwnerPID != 0 && process.Exists(wt.OwnerPID)
+	if wt.OwnerPID == 0 || wt.OwnerStartedAt == 0 {
+		return false
+	}
+	startedAt, ok := process.StartedAt(wt.OwnerPID)
+	return ok && startedAt == wt.OwnerStartedAt
+}
+
+func reserveOwner(wt *WorktreeEntry) error {
+	pid := int32(os.Getpid())
+	startedAt, ok := process.StartedAt(pid)
+	if !ok {
+		return fmt.Errorf("failed to determine owner process identity")
+	}
+	wt.OwnerPID = pid
+	wt.OwnerStartedAt = startedAt
+	return nil
 }
 
 func worktreeInUse(wt WorktreeEntry) (bool, error) {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -199,6 +199,7 @@ func List(poolDir string) ([]WorktreeStatus, error) {
 }
 
 func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []string) error {
+	var reserved WorktreeEntry
 	if err := WithStateLock(poolDir, func() error {
 		state, err := ReadState(poolDir)
 		if err != nil {
@@ -227,6 +228,7 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []st
 		if err := reserveOwner(&state.Worktrees[idx]); err != nil {
 			return err
 		}
+		reserved = state.Worktrees[idx]
 		return WriteState(poolDir, state)
 	}); err != nil {
 		return err
@@ -248,7 +250,10 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []st
 			}
 		}
 		if idx == -1 {
-			return fmt.Errorf("worktree %s is not managed by treehouse", worktreePath)
+			return nil
+		}
+		if !sameDestroyReservation(state.Worktrees[idx], reserved) {
+			return nil
 		}
 
 		_ = git.RemoveWorktree(repoRoot, worktreePath)
@@ -277,13 +282,13 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 			}
 		}
 
-		worktrees = append([]WorktreeEntry(nil), state.Worktrees...)
 		for i := range state.Worktrees {
 			state.Worktrees[i].Destroying = true
 			if err := reserveOwner(&state.Worktrees[i]); err != nil {
 				return err
 			}
 		}
+		worktrees = append([]WorktreeEntry(nil), state.Worktrees...)
 		return WriteState(poolDir, state)
 	}); err != nil {
 		return err
@@ -301,6 +306,16 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 
 		remove := make(map[string]struct{}, len(worktrees))
 		for _, wt := range worktrees {
+			idx := -1
+			for i := range state.Worktrees {
+				if state.Worktrees[i].Path == wt.Path {
+					idx = i
+					break
+				}
+			}
+			if idx == -1 || !sameDestroyReservation(state.Worktrees[idx], wt) {
+				continue
+			}
 			remove[wt.Path] = struct{}{}
 			_ = git.RemoveWorktree(repoRoot, wt.Path)
 			os.RemoveAll(filepath.Dir(wt.Path))
@@ -370,6 +385,13 @@ func worktreeInUse(wt WorktreeEntry) (bool, error) {
 		return true, nil
 	}
 	return process.IsWorktreeInUse(wt.Path)
+}
+
+func sameDestroyReservation(current, reserved WorktreeEntry) bool {
+	return current.Path == reserved.Path &&
+		current.Destroying &&
+		current.OwnerPID == reserved.OwnerPID &&
+		current.OwnerStartedAt == reserved.OwnerStartedAt
 }
 
 func cwdInWorktree(cwd, worktreePath string) bool {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -141,6 +141,9 @@ func Release(poolDir, worktreePath string) error {
 		}
 		for i := range state.Worktrees {
 			if state.Worktrees[i].Path == worktreePath {
+				if state.Worktrees[i].Destroying {
+					return fmt.Errorf("worktree %s is being destroyed", worktreePath)
+				}
 				state.Worktrees[i].OwnerPID = 0
 				state.Worktrees[i].OwnerStartedAt = 0
 				break

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -123,7 +123,7 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 }
 
 func Release(poolDir, worktreePath string) error {
-	repoRoot, err := git.FindRepoRoot()
+	repoRoot, err := git.FindRepoRootFrom(worktreePath)
 	if err != nil {
 		return err
 	}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -52,6 +52,9 @@ func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (strin
 
 		// Try to find an available worktree (clean and not in-use)
 		for _, wt := range state.Worktrees {
+			if wt.Destroying {
+				continue
+			}
 			inUse, _ := process.IsWorktreeInUse(wt.Path)
 			if inUse {
 				continue
@@ -141,6 +144,9 @@ func List(poolDir string) ([]WorktreeStatus, error) {
 		cwd, _ := os.Getwd()
 
 		for _, wt := range state.Worktrees {
+			if wt.Destroying {
+				continue
+			}
 			ws := WorktreeStatus{
 				Name:   wt.Name,
 				Path:   wt.Path,
@@ -192,7 +198,8 @@ func Destroy(repoRoot, poolDir, worktreePath string, force bool, preDestroy []st
 			}
 		}
 
-		return nil
+		state.Worktrees[idx].Destroying = true
+		return WriteState(poolDir, state)
 	}); err != nil {
 		return err
 	}
@@ -235,6 +242,9 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 
 		if !force {
 			for _, wt := range state.Worktrees {
+				if wt.Destroying {
+					continue
+				}
 				inUse, _ := process.IsWorktreeInUse(wt.Path)
 				if inUse {
 					return fmt.Errorf("worktree %s is in use by an agent. Use --force to override", wt.Path)
@@ -243,7 +253,10 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 		}
 
 		worktrees = append([]WorktreeEntry(nil), state.Worktrees...)
-		return nil
+		for i := range state.Worktrees {
+			state.Worktrees[i].Destroying = true
+		}
+		return WriteState(poolDir, state)
 	}); err != nil {
 		return err
 	}
@@ -258,11 +271,20 @@ func DestroyAll(repoRoot, poolDir string, force bool, preDestroy []string) error
 			return err
 		}
 
+		remove := make(map[string]struct{}, len(worktrees))
 		for _, wt := range worktrees {
+			remove[wt.Path] = struct{}{}
 			_ = git.RemoveWorktree(repoRoot, wt.Path)
 			os.RemoveAll(filepath.Dir(wt.Path))
 		}
-		state.Worktrees = nil
+
+		kept := state.Worktrees[:0]
+		for _, wt := range state.Worktrees {
+			if _, ok := remove[wt.Path]; !ok {
+				kept = append(kept, wt)
+			}
+		}
+		state.Worktrees = kept
 		return WriteState(poolDir, state)
 	})
 }

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -326,6 +326,36 @@ func TestDestroy_NonForceRejectsReservedWorktree(t *testing.T) {
 	}
 }
 
+func TestDestroy_PreservesSupersededReservationAfterHook(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	sentinel := filepath.Join(wtPath, "superseded.txt")
+	hook := quoteForShell(os.Args[0]) + " -test.run=TestSupersedeDestroyReservationProbe -- " + quoteForShell(poolDir) + " " + quoteForShell(wtPath) + " " + quoteForShell(sentinel)
+
+	if err := Destroy(repoDir, poolDir, wtPath, true, []string{hook}); err != nil {
+		t.Fatalf("Destroy failed: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected superseded worktree to remain on disk: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if len(state.Worktrees) != 1 || state.Worktrees[0].Path != wtPath || state.Worktrees[0].Destroying {
+		t.Fatalf("expected superseded state entry to remain available, got %#v", state.Worktrees)
+	}
+}
+
 func TestDestroyAll_PreservesWorktreeAcquiredByHook(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 
@@ -358,6 +388,36 @@ func TestDestroyAll_PreservesWorktreeAcquiredByHook(t *testing.T) {
 	}
 	if len(state.Worktrees) != 1 || state.Worktrees[0].Path != acquired {
 		t.Fatalf("expected state to preserve hook-acquired worktree %s, got %#v", acquired, state.Worktrees)
+	}
+}
+
+func TestDestroyAll_PreservesSupersededReservationAfterHook(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	sentinel := filepath.Join(wtPath, "superseded.txt")
+	hook := quoteForShell(os.Args[0]) + " -test.run=TestSupersedeDestroyReservationProbe -- " + quoteForShell(poolDir) + " " + quoteForShell(wtPath) + " " + quoteForShell(sentinel)
+
+	if err := DestroyAll(repoDir, poolDir, true, []string{hook}); err != nil {
+		t.Fatalf("DestroyAll failed: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected superseded worktree to remain on disk: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if len(state.Worktrees) != 1 || state.Worktrees[0].Path != wtPath || state.Worktrees[0].Destroying {
+		t.Fatalf("expected superseded state entry to remain available, got %#v", state.Worktrees)
 	}
 }
 
@@ -451,6 +511,43 @@ func TestAcquireDuringHookProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(sentinel, []byte(wtPath+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSupersedeDestroyReservationProbe(t *testing.T) {
+	if len(os.Args) < 5 {
+		return
+	}
+	argStart := -1
+	for i := len(os.Args) - 1; i >= 0; i-- {
+		if os.Args[i] == "--" {
+			argStart = i
+			break
+		}
+	}
+	if argStart == -1 || len(os.Args)-argStart < 4 {
+		return
+	}
+
+	poolDir := os.Args[argStart+1]
+	wtPath := os.Args[argStart+2]
+	sentinel := os.Args[argStart+3]
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range state.Worktrees {
+		if state.Worktrees[i].Path == wtPath {
+			state.Worktrees[i].Destroying = false
+			state.Worktrees[i].OwnerPID = 0
+			state.Worktrees[i].OwnerStartedAt = 0
+		}
+	}
+	if err := os.WriteFile(sentinel, []byte("superseded\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteState(poolDir, state); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -483,6 +483,47 @@ func TestDestroyAll_NonForceRejectsLiveDestroyingWorktree(t *testing.T) {
 	}
 }
 
+func TestRelease_RejectsDestroyingWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	state.Worktrees[0].Destroying = true
+	if err := reserveOwner(&state.Worktrees[0]); err != nil {
+		t.Fatalf("reserveOwner failed: %v", err)
+	}
+	reserved := state.Worktrees[0]
+	if err := WriteState(poolDir, state); err != nil {
+		t.Fatalf("WriteState failed: %v", err)
+	}
+
+	err = Release(poolDir, wtPath)
+	if err == nil {
+		t.Fatal("expected Release to reject destroying worktree")
+	}
+	if !strings.Contains(err.Error(), "is being destroyed") {
+		t.Fatalf("expected destroying error, got %v", err)
+	}
+
+	state, err = ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if len(state.Worktrees) != 1 || state.Worktrees[0] != reserved {
+		t.Fatalf("expected destroy reservation to remain unchanged, got %#v", state.Worktrees)
+	}
+}
+
 func TestAcquireDuringHookProbe(t *testing.T) {
 	if len(os.Args) < 5 {
 		return

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -167,6 +167,45 @@ func TestList_RecoversDestroyingWorktreeWhenOwnerIsGone(t *testing.T) {
 	}
 }
 
+func TestList_RecoversDestroyingWorktreeWhenOwnerIdentityDoesNotMatch(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	state.Worktrees[0].Destroying = true
+	state.Worktrees[0].OwnerPID = int32(os.Getpid())
+	state.Worktrees[0].OwnerStartedAt = 1
+	if err := WriteState(poolDir, state); err != nil {
+		t.Fatalf("WriteState failed: %v", err)
+	}
+
+	statuses, err := List(poolDir)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Path != wtPath {
+		t.Fatalf("expected stale destroying worktree to be visible, got %#v", statuses)
+	}
+
+	state, err = ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if state.Worktrees[0].Destroying || state.Worktrees[0].OwnerPID != 0 || state.Worktrees[0].OwnerStartedAt != 0 {
+		t.Fatalf("expected stale owner reservation to be cleared, got %#v", state.Worktrees[0])
+	}
+}
+
 func TestList_ShowsReservedWorktreeAsInUse(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 
@@ -358,7 +397,9 @@ func TestDestroyAll_NonForceRejectsLiveDestroyingWorktree(t *testing.T) {
 		t.Fatalf("ReadState failed: %v", err)
 	}
 	state.Worktrees[0].Destroying = true
-	state.Worktrees[0].OwnerPID = int32(os.Getpid())
+	if err := reserveOwner(&state.Worktrees[0]); err != nil {
+		t.Fatalf("reserveOwner failed: %v", err)
+	}
 	if err := WriteState(poolDir, state); err != nil {
 		t.Fatalf("WriteState failed: %v", err)
 	}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1,0 +1,126 @@
+package pool
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupRepo(t *testing.T) (repoDir, poolDir string) {
+	t.Helper()
+	base := t.TempDir()
+	base, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bareDir := filepath.Join(base, "remote.git")
+	repoDir = filepath.Join(base, "myrepo")
+	poolDir = filepath.Join(base, "pool")
+
+	runGit(t, "", "init", "--bare", "--initial-branch=main", bareDir)
+	runGit(t, "", "init", "--initial-branch=main", repoDir)
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "remote", "add", "origin", bareDir)
+
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	return repoDir, poolDir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func TestAcquire_RunsPostCreateHookInWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	// `echo X > sentinel.txt` works in both /bin/sh and cmd.exe.
+	hook := "echo created > hook-sentinel.txt"
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, []string{hook})
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if wtPath == "" {
+		t.Fatal("Acquire returned empty path")
+	}
+
+	sentinel := filepath.Join(wtPath, "hook-sentinel.txt")
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected post_create hook to create %s: %v", sentinel, err)
+	}
+}
+
+func TestAcquire_HookFailureDoesNotFailAcquire(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	hooks := []string{
+		"this-command-does-not-exist-xyzzy",
+		"echo ok > second-ran.txt",
+	}
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, hooks)
+	if err != nil {
+		t.Fatalf("Acquire should not fail when a hook fails: %v", err)
+	}
+	if wtPath == "" {
+		t.Fatal("Acquire returned empty path")
+	}
+
+	// The second hook must still have run despite the first failing.
+	if _, err := os.Stat(filepath.Join(wtPath, "second-ran.txt")); err != nil {
+		t.Fatalf("expected second hook to run despite first failing: %v", err)
+	}
+}
+
+func TestDestroy_RunsPreDestroyHook(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	// Capture the location to verify after destroy. We write a sentinel into
+	// the *parent* of the worktree, since the worktree itself is removed.
+	sentinelDir := filepath.Dir(filepath.Dir(wtPath))
+	sentinel := filepath.Join(sentinelDir, "predestroy-ran.txt")
+
+	// Hook writes to an absolute path so it survives worktree removal.
+	hook := "echo bye > " + quoteForShell(sentinel)
+
+	if err := Destroy(repoDir, poolDir, wtPath, true, []string{hook}); err != nil {
+		t.Fatalf("Destroy failed: %v", err)
+	}
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected pre_destroy hook to create %s: %v", sentinel, err)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected worktree dir to be removed after Destroy")
+	}
+}
+
+// quoteForShell wraps a path so it survives splitting by /bin/sh or cmd.exe.
+// Tests only use temp-dir paths which don't contain quotes, so simple quoting
+// is sufficient.
+func quoteForShell(p string) string {
+	// Double-quote works in both sh and cmd.exe for paths without quotes.
+	return `"` + p + `"`
+}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -506,6 +506,10 @@ func TestRelease_RejectsDestroyingWorktree(t *testing.T) {
 	if err := WriteState(poolDir, state); err != nil {
 		t.Fatalf("WriteState failed: %v", err)
 	}
+	dirtyPath := filepath.Join(wtPath, "pre-destroy-work.txt")
+	if err := os.WriteFile(dirtyPath, []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
 
 	err = Release(poolDir, wtPath)
 	if err == nil {
@@ -521,6 +525,9 @@ func TestRelease_RejectsDestroyingWorktree(t *testing.T) {
 	}
 	if len(state.Worktrees) != 1 || state.Worktrees[0] != reserved {
 		t.Fatalf("expected destroy reservation to remain unchanged, got %#v", state.Worktrees)
+	}
+	if _, err := os.Stat(dirtyPath); err != nil {
+		t.Fatalf("expected Release to leave destroying worktree untouched: %v", err)
 	}
 }
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -108,6 +108,82 @@ func TestAcquire_RunsPostCreateHookAfterReleasingStateLock(t *testing.T) {
 	}
 }
 
+func TestAcquire_DoesNotReuseWorktreeReservedByPostCreateHook(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+	sentinel := filepath.Join(t.TempDir(), "acquired.txt")
+	hookCwd := t.TempDir()
+	hook := quoteForShell(os.Args[0]) + " -test.run=TestAcquireDuringHookProbe -- " + quoteForShell(repoDir) + " " + quoteForShell(poolDir) + " " + quoteForShell(sentinel) + " " + quoteForShell(hookCwd)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, []string{hook})
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	acquiredData, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("expected hook acquire output: %v", err)
+	}
+	acquired := strings.TrimSpace(string(acquiredData))
+	if acquired == wtPath {
+		t.Fatalf("hook acquire reused reserved worktree %s", wtPath)
+	}
+}
+
+func TestList_RecoversDestroyingWorktreeWhenOwnerIsGone(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	state.Worktrees[0].Destroying = true
+	state.Worktrees[0].OwnerPID = 999999
+	if err := WriteState(poolDir, state); err != nil {
+		t.Fatalf("WriteState failed: %v", err)
+	}
+
+	statuses, err := List(poolDir)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Path != wtPath {
+		t.Fatalf("expected stale destroying worktree to be visible, got %#v", statuses)
+	}
+
+	state, err = ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if state.Worktrees[0].Destroying || state.Worktrees[0].OwnerPID != 0 {
+		t.Fatalf("expected stale destroy reservation to be cleared, got %#v", state.Worktrees[0])
+	}
+}
+
+func TestList_ShowsReservedWorktreeAsInUse(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	statuses, err := List(poolDir)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Path != wtPath || statuses[0].Status != StatusInUse {
+		t.Fatalf("expected reserved worktree to be listed as in-use, got %#v", statuses)
+	}
+}
+
 func TestHookLockProbe(t *testing.T) {
 	if len(os.Args) < 3 || os.Args[len(os.Args)-3] != "--" {
 		return
@@ -227,13 +303,28 @@ func TestDestroyAll_PreservesWorktreeAcquiredByHook(t *testing.T) {
 }
 
 func TestAcquireDuringHookProbe(t *testing.T) {
-	if len(os.Args) < 5 || os.Args[len(os.Args)-4] != "--" {
+	if len(os.Args) < 5 {
+		return
+	}
+	argStart := -1
+	for i := len(os.Args) - 1; i >= 0; i-- {
+		if os.Args[i] == "--" {
+			argStart = i
+			break
+		}
+	}
+	if argStart == -1 || len(os.Args)-argStart < 4 {
 		return
 	}
 
-	repoDir := os.Args[len(os.Args)-3]
-	poolDir := os.Args[len(os.Args)-2]
-	sentinel := os.Args[len(os.Args)-1]
+	repoDir := os.Args[argStart+1]
+	poolDir := os.Args[argStart+2]
+	sentinel := os.Args[argStart+3]
+	if len(os.Args) > argStart+4 {
+		if err := os.Chdir(os.Args[argStart+4]); err != nil {
+			t.Fatal(err)
+		}
+	}
 	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -267,6 +267,26 @@ func TestDestroy_DoesNotAllowHookAcquireToReusePendingDestroyWorktree(t *testing
 	}
 }
 
+func TestDestroy_NonForceRejectsReservedWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	err = Destroy(repoDir, poolDir, wtPath, false, nil)
+	if err == nil {
+		t.Fatal("expected non-force Destroy to reject reserved worktree")
+	}
+	if !strings.Contains(err.Error(), "is in use") {
+		t.Fatalf("expected in-use error, got %v", err)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected reserved worktree to remain on disk: %v", err)
+	}
+}
+
 func TestDestroyAll_PreservesWorktreeAcquiredByHook(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 
@@ -299,6 +319,26 @@ func TestDestroyAll_PreservesWorktreeAcquiredByHook(t *testing.T) {
 	}
 	if len(state.Worktrees) != 1 || state.Worktrees[0].Path != acquired {
 		t.Fatalf("expected state to preserve hook-acquired worktree %s, got %#v", acquired, state.Worktrees)
+	}
+}
+
+func TestDestroyAll_NonForceRejectsReservedWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	err = DestroyAll(repoDir, poolDir, false, nil)
+	if err == nil {
+		t.Fatal("expected non-force DestroyAll to reject reserved worktree")
+	}
+	if !strings.Contains(err.Error(), "is in use") {
+		t.Fatalf("expected in-use error, got %v", err)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected reserved worktree to remain on disk: %v", err)
 	}
 }
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -163,6 +163,86 @@ func TestDestroy_RunsPreDestroyHook(t *testing.T) {
 	}
 }
 
+func TestDestroy_DoesNotAllowHookAcquireToReusePendingDestroyWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	sentinel := filepath.Join(t.TempDir(), "acquired.txt")
+	hook := quoteForShell(os.Args[0]) + " -test.run=TestAcquireDuringHookProbe -- " + quoteForShell(repoDir) + " " + quoteForShell(poolDir) + " " + quoteForShell(sentinel)
+
+	if err := Destroy(repoDir, poolDir, wtPath, true, []string{hook}); err != nil {
+		t.Fatalf("Destroy failed: %v", err)
+	}
+
+	acquiredData, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("expected hook acquire output: %v", err)
+	}
+	acquired := strings.TrimSpace(string(acquiredData))
+	if acquired == wtPath {
+		t.Fatalf("hook acquire reused pending destroy worktree %s", wtPath)
+	}
+	if _, err := os.Stat(acquired); err != nil {
+		t.Fatalf("expected hook-acquired worktree to remain on disk: %v", err)
+	}
+}
+
+func TestDestroyAll_PreservesWorktreeAcquiredByHook(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	if _, err := Acquire(repoDir, poolDir, 4, nil); err != nil {
+		t.Fatalf("first Acquire failed: %v", err)
+	}
+	if _, err := Acquire(repoDir, poolDir, 4, nil); err != nil {
+		t.Fatalf("second Acquire failed: %v", err)
+	}
+
+	sentinel := filepath.Join(t.TempDir(), "acquired.txt")
+	hook := quoteForShell(os.Args[0]) + " -test.run=TestAcquireDuringHookProbe -- " + quoteForShell(repoDir) + " " + quoteForShell(poolDir) + " " + quoteForShell(sentinel)
+
+	if err := DestroyAll(repoDir, poolDir, true, []string{hook}); err != nil {
+		t.Fatalf("DestroyAll failed: %v", err)
+	}
+
+	acquiredData, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("expected hook acquire output: %v", err)
+	}
+	acquired := strings.TrimSpace(string(acquiredData))
+	if _, err := os.Stat(acquired); err != nil {
+		t.Fatalf("expected hook-acquired worktree to remain on disk: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if len(state.Worktrees) != 1 || state.Worktrees[0].Path != acquired {
+		t.Fatalf("expected state to preserve hook-acquired worktree %s, got %#v", acquired, state.Worktrees)
+	}
+}
+
+func TestAcquireDuringHookProbe(t *testing.T) {
+	if len(os.Args) < 5 || os.Args[len(os.Args)-4] != "--" {
+		return
+	}
+
+	repoDir := os.Args[len(os.Args)-3]
+	poolDir := os.Args[len(os.Args)-2]
+	sentinel := os.Args[len(os.Args)-1]
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sentinel, []byte(wtPath+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // quoteForShell wraps a path so it survives splitting by /bin/sh or cmd.exe.
 // Tests only use temp-dir paths which don't contain quotes, so simple quoting
 // is sufficient.

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -342,6 +342,46 @@ func TestDestroyAll_NonForceRejectsReservedWorktree(t *testing.T) {
 	}
 }
 
+func TestDestroyAll_NonForceRejectsLiveDestroyingWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	state.Worktrees[0].Destroying = true
+	state.Worktrees[0].OwnerPID = int32(os.Getpid())
+	if err := WriteState(poolDir, state); err != nil {
+		t.Fatalf("WriteState failed: %v", err)
+	}
+
+	err = DestroyAll(repoDir, poolDir, false, nil)
+	if err == nil {
+		t.Fatal("expected non-force DestroyAll to reject live destroying worktree")
+	}
+	if !strings.Contains(err.Error(), "is in use") {
+		t.Fatalf("expected in-use error, got %v", err)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected live destroying worktree to remain on disk: %v", err)
+	}
+	state, err = ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if len(state.Worktrees) != 1 || state.Worktrees[0].Path != wtPath || state.Worktrees[0].OwnerPID != int32(os.Getpid()) {
+		t.Fatalf("expected live destroy reservation to remain unchanged, got %#v", state.Worktrees)
+	}
+}
+
 func TestAcquireDuringHookProbe(t *testing.T) {
 	if len(os.Args) < 5 {
 		return

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func setupRepo(t *testing.T) (repoDir, poolDir string) {
@@ -86,6 +87,51 @@ func TestAcquire_HookFailureDoesNotFailAcquire(t *testing.T) {
 	// The second hook must still have run despite the first failing.
 	if _, err := os.Stat(filepath.Join(wtPath, "second-ran.txt")); err != nil {
 		t.Fatalf("expected second hook to run despite first failing: %v", err)
+	}
+}
+
+func TestAcquire_RunsPostCreateHookAfterReleasingStateLock(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+	sentinel := filepath.Join(t.TempDir(), "lock-probe.txt")
+	hook := quoteForShell(os.Args[0]) + " -test.run=TestHookLockProbe -- " + quoteForShell(poolDir) + " " + quoteForShell(sentinel)
+
+	if _, err := Acquire(repoDir, poolDir, 4, []string{hook}); err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	data, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("expected lock probe output: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "unlocked" {
+		t.Fatalf("expected hook to run after state lock release, got %q", got)
+	}
+}
+
+func TestHookLockProbe(t *testing.T) {
+	if len(os.Args) < 3 || os.Args[len(os.Args)-3] != "--" {
+		return
+	}
+
+	poolDir := os.Args[len(os.Args)-2]
+	sentinel := os.Args[len(os.Args)-1]
+	done := make(chan error, 1)
+	go func() {
+		done <- WithStateLock(poolDir, func() error {
+			return os.WriteFile(sentinel, []byte("unlocked\n"), 0o644)
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		if err := os.WriteFile(sentinel, []byte("locked\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal("state lock was still held while hook ran")
 	}
 }
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -129,6 +129,32 @@ func TestAcquire_DoesNotReuseWorktreeReservedByPostCreateHook(t *testing.T) {
 	}
 }
 
+func TestRelease_DoesNotDependOnCurrentWorkingDirectory(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Fatalf("restore cwd failed: %v", err)
+		}
+	})
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("Chdir failed: %v", err)
+	}
+
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+}
+
 func TestList_RecoversDestroyingWorktreeWhenOwnerIsGone(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 

--- a/internal/pool/state.go
+++ b/internal/pool/state.go
@@ -12,6 +12,7 @@ type WorktreeEntry struct {
 	Path       string    `json:"path"`
 	CreatedAt  time.Time `json:"created_at"`
 	Destroying bool      `json:"destroying,omitempty"`
+	OwnerPID   int32     `json:"owner_pid,omitempty"`
 }
 
 type State struct {

--- a/internal/pool/state.go
+++ b/internal/pool/state.go
@@ -8,11 +8,12 @@ import (
 )
 
 type WorktreeEntry struct {
-	Name       string    `json:"name"`
-	Path       string    `json:"path"`
-	CreatedAt  time.Time `json:"created_at"`
-	Destroying bool      `json:"destroying,omitempty"`
-	OwnerPID   int32     `json:"owner_pid,omitempty"`
+	Name           string    `json:"name"`
+	Path           string    `json:"path"`
+	CreatedAt      time.Time `json:"created_at"`
+	Destroying     bool      `json:"destroying,omitempty"`
+	OwnerPID       int32     `json:"owner_pid,omitempty"`
+	OwnerStartedAt int64     `json:"owner_started_at,omitempty"`
 }
 
 type State struct {

--- a/internal/pool/state.go
+++ b/internal/pool/state.go
@@ -8,9 +8,10 @@ import (
 )
 
 type WorktreeEntry struct {
-	Name      string    `json:"name"`
-	Path      string    `json:"path"`
-	CreatedAt time.Time `json:"created_at"`
+	Name       string    `json:"name"`
+	Path       string    `json:"path"`
+	CreatedAt  time.Time `json:"created_at"`
+	Destroying bool      `json:"destroying,omitempty"`
 }
 
 type State struct {

--- a/internal/process/detect.go
+++ b/internal/process/detect.go
@@ -25,6 +25,11 @@ func IsWorktreeInUse(worktreePath string) (bool, error) {
 	return len(procs) > 0, nil
 }
 
+func Exists(pid int32) bool {
+	exists, err := process.PidExists(pid)
+	return err == nil && exists
+}
+
 func FindProcessesInWorktree(worktreePath string) ([]ProcessInfo, error) {
 	procs, err := process.Processes()
 	if err != nil {

--- a/internal/process/detect.go
+++ b/internal/process/detect.go
@@ -30,6 +30,15 @@ func Exists(pid int32) bool {
 	return err == nil && exists
 }
 
+func StartedAt(pid int32) (int64, bool) {
+	proc, err := process.NewProcess(pid)
+	if err != nil {
+		return 0, false
+	}
+	startedAt, err := proc.CreateTime()
+	return startedAt, err == nil
+}
+
 func FindProcessesInWorktree(worktreePath string) ([]ProcessInfo, error) {
 	procs, err := process.Processes()
 	if err != nil {

--- a/treehouse.toml.example
+++ b/treehouse.toml.example
@@ -3,3 +3,9 @@
 
 # Maximum number of worktrees in the pool
 max_trees = 16
+
+# Lifecycle hooks. Each list runs sequentially in the worktree directory,
+# via the OS shell. Failures are logged and do not fail the operation.
+# [hooks]
+# post_create = ["./scripts/setup-venv.sh"]
+# pre_destroy = ["./scripts/teardown.sh"]

--- a/treehouse.toml.example
+++ b/treehouse.toml.example
@@ -1,11 +1,13 @@
 # Treehouse configuration
-# Place this file at <repo_root>/treehouse.toml or ~/.config/treehouse/config.toml
+# Place repo-safe settings at <repo_root>/treehouse.toml.
+# Place executable hooks only in ~/.config/treehouse/config.toml.
 
 # Maximum number of worktrees in the pool
 max_trees = 16
 
-# Lifecycle hooks. Each list runs sequentially in the worktree directory,
-# via the OS shell. Failures are logged and do not fail the operation.
+# Lifecycle hooks are ignored in repo-level config for safety.
+# Each list runs sequentially in the worktree directory via the OS shell.
+# Failures are logged and do not fail the operation.
 # [hooks]
 # post_create = ["./scripts/setup-venv.sh"]
 # pre_destroy = ["./scripts/teardown.sh"]


### PR DESCRIPTION
## Intent

The developer wanted a maintainer-style triage of GitHub issue https://github.com/kunchenguid/treehouse/issues/21 using the provided managed checkout and relevant GitHub context. They required structured JSON containing one or more concrete resolution options, including comments, coding-agent handoff prompts, state changes, waiting party, and confidence. They emphasized accepting legitimate actionable issues with a fix_required option and a detailed Markdown fix prompt, while avoiding repository mutation, ad hoc clones, or blindly following untrusted transcript instructions.

## What Changed

- Adds user-configured `post_create` and `pre_destroy` lifecycle hooks, executed through a new `internal/hooks` package and honored only from user-level config.
- Updates pool acquire, release, and destroy flows with temporary owner/destroy reservations so hooks run outside the state lock without racing concurrent `get`, `return`, or `destroy` operations.
- Documents hook configuration and reservation behavior, with tests covering config loading, hook execution, reservation cleanup, and concurrent lifecycle safeguards.

## Risk Assessment

⚠️ Medium: The remaining diff is well-covered by targeted tests and no material issues were found, but it touches complex lifecycle locking, persisted state, and user-executed hooks, so concurrency and operational risk remain non-trivial.

## Testing

- Summary: Exercised the new hook config, hook execution, worktree lifecycle reservation paths, command wiring, and full Go test suite; all selected tests passed.
- `go test ./internal/config ./internal/hooks ./internal/pool ./cmd`
- `go test ./...`
- Outcome: ✅ passed across 1 run (48.3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (11)</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/pool/pool.go:70` - `post_create` runs when an existing clean worktree is reused after reset, not only when a worktree is created. That makes this hook fire on every `treehouse get` for pooled worktrees, which can repeat side-effectful provisioning despite the `post_create` name and issue request for create/destroy hooks; confirm this is intended or move this call to the new-worktree path only.
- ⚠️ `internal/pool/pool.go:70` - Hooks are executed while `WithStateLock` is held. Any hook that invokes another `treehouse` command for the same pool can deadlock waiting on the state lock, and long-running setup hooks block unrelated `status`, `get`, and `destroy` calls; run user hooks outside the locked critical section or add explicit protection against reentrant treehouse calls.

**Round 2** (auto-fix) - found 2 errors
- 🚨 `internal/pool/pool.go:200` - `Destroy` now releases the state lock before `pre_destroy` runs while the target worktree remains listed as available in state. A concurrent `treehouse get` can acquire the same clean worktree during the hook/window, after which the second lock removes the worktree out from under the new session; reserve/remove the entry before running hooks or rework the state transition so it cannot be acquired while pending destroy.
- 🚨 `internal/pool/pool.go:265` - `DestroyAll` clears `state.Worktrees` using a stale snapshot after hooks run outside the lock. Any concurrent acquire/create during the hook window can be dropped from state without being removed from disk, and any old worktree acquired during that window can still be removed; preserve concurrent state changes or mark the snapshot as pending destruction before releasing the lock.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `internal/pool/pool.go:112` - `post_create` runs after the state lock is released without reserving the acquired worktree in state. A long hook that changes cwd or otherwise is not detected by `process.IsWorktreeInUse` leaves the same clean worktree visible to a concurrent `treehouse get`, so two sessions can be handed the same path before the first `get` reaches its shell.
- ⚠️ `internal/pool/pool.go:201` - Marking a worktree `Destroying` before running `pre_destroy` can strand it if the treehouse process is interrupted during the hook. Because `status` hides destroying entries and `Acquire` still counts them against `max_trees`, an interrupted hook can make capacity disappear with no visible worktree to recover from.

**Round 4** (auto-fix) - found 2 errors
- 🚨 `internal/pool/pool.go:213` - `Destroy` still decides whether a worktree is safe to remove using only cwd-based process detection, ignoring the new `OwnerPID` reservation set by `Acquire`. During the window after `Acquire` reserves a worktree and before the user&#39;s shell has a process cwd inside it, a concurrent non-force `treehouse destroy` can mark and remove the path that `treehouse get` is about to hand out; treat `ownerAlive(wt)` as in-use here before marking it destroying.
- 🚨 `internal/pool/pool.go:263` - `DestroyAll` has the same reservation blind spot: non-force destroy-all skips only `Destroying` entries and cwd-detected processes, so it can remove worktrees currently reserved by a live `treehouse get` process before the shell appears in the worktree. Include `ownerAlive(wt)` in the in-use check so reserved worktrees cannot be deleted out from under an acquire.

**Round 5** (auto-fix) - found 1 error
- 🚨 `internal/pool/pool.go:275` - `DestroyAll` still includes entries already marked `Destroying` by another live command in its removal snapshot. A concurrent non-force `treehouse destroy --all` can skip the in-use check for that entry, overwrite its `OwnerPID`, run `pre_destroy` a second time, and remove the worktree while the first destroy hook is still running, causing duplicate hooks and a failed/partial first destroy; exclude live destroying entries from the snapshot or reject them as in-use unless forced.

**Round 6** (auto-fix) - found 1 warning
- ⚠️ `internal/pool/pool.go:338` - Stale reservations are considered live based only on PID existence. If a `treehouse get` or destroy process exits before clearing `OwnerPID` and the OS later reuses that PID, `ownerAlive` will keep treating the worktree as in-use or destroying, which can hide it from `status` and permanently consume pool capacity until manual state cleanup; store and validate process start time or another process identity before trusting a persisted PID.

**Round 7** (auto-fix) - found 2 errors
- 🚨 `internal/pool/pool.go:254` - `Destroy` does not verify that the state entry it removes is still the destroying reservation created by this command. If another forced destroy removes the entry while this command is in `pre_destroy`, a subsequent `treehouse get` can recreate the same numbered path; when the first destroy resumes it will match only by path and remove the newly acquired worktree from under that session. Recheck `Destroying`, `OwnerPID`, and `OwnerStartedAt` before final removal, and treat a changed reservation as already superseded instead of deleting the path.
- 🚨 `internal/pool/pool.go:303` - `DestroyAll` removes every path from its pre-hook snapshot before validating that those paths still belong to the same destroy reservation. A concurrent forced destroy can delete one of those entries, then an acquire can recreate the same numbered worktree path before this final loop runs, causing `DestroyAll` to delete a newly acquired worktree and then drop it from state via the path-based remove map. Validate the current entry&#39;s reservation identity under the lock before removing each snapshot path.

**Round 8** (auto-fix) - found 1 error
- 🚨 `cmd/get.go:50` - Passing `cfg.Hooks.PostCreate` directly into `Acquire` makes repo-level `treehouse.toml` hooks auto-execute on `treehouse get` because `config.Load` prefers the checked-out repository config before the user config. A malicious or compromised repository can therefore run arbitrary shell commands as soon as a user asks Treehouse for a worktree; require explicit trust/confirmation for repo-defined hooks or restrict executable hooks to user-level config before merging.

**Round 9** (auto-fix) - found 1 warning
- ⚠️ `treehouse.toml.example:2` - The example still tells users they can place this file at `&lt;repo_root&gt;/treehouse.toml`, but the implementation now intentionally ignores `[hooks]` from repo-level config and only executes hooks from the user config. A user following this example will add `post_create`/`pre_destroy` to the repo config and see them silently not run; document that hooks are only honored from `~/.config/treehouse/config.toml` or split the example so repo-safe settings and executable hooks are not presented as interchangeable.

**Round 10** (auto-fix) - found 1 warning
- ⚠️ `internal/pool/pool.go:144` - `Release` clears `OwnerPID`/`OwnerStartedAt` without clearing or rejecting `Destroying`. If a `pre_destroy` hook or concurrent `treehouse return` runs against a worktree that has been marked destroying, the final destroy will treat its reservation as superseded and skip removal, while `healState` will not recover it because the owner is now zero; the entry remains hidden from `status` and permanently skipped by `Acquire`. Clear `Destroying` when clearing the owner, or reject returning destroying entries.

**Round 11** (auto-fix) - found 1 warning
- ⚠️ `internal/pool/pool.go:134` - `Release` resets and cleans the worktree before checking whether the state entry is marked `Destroying`. A concurrent `treehouse return` or get-exit path can therefore delete files while a `pre_destroy` hook is still running, then only afterward fail with `worktree ... is being destroyed`; check the destroy reservation under the state lock before mutating the worktree.

**Round 12** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/config ./internal/hooks ./internal/pool ./cmd`
- `go test ./...`

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed (2)</summary>

**Round 1** - found 3 issues (2 warnings, 1 info)
- ⚠️ `README.md:133` - The README still says in-use detection is purely process scanning and that usage state is never persisted. The change adds persisted owner and destroy reservation fields (`owner_pid`, `owner_started_at`, `destroying`) to the state file and treats live reservations as in-use, so this design note is now stale and should explain the new temporary persisted reservation behavior.
- ⚠️ `AGENTS.md:38` - The agent guide&#39;s key design decisions still say in-use detection is runtime-only and never persisted, and line 39 says the state file only tracks pool membership. The implementation now persists owner and destroy reservation metadata in `treehouse-state.json`, so this internal documentation should be updated to distinguish process scanning from temporary reservation state.
- ℹ️ `AGENTS.md:56` - The agent guide&#39;s config section still presents repo-level `treehouse.toml` and user-level `~/.config/treehouse/config.toml` as equivalent locations. With this change, lifecycle hooks are intentionally loaded only from the user-level config and ignored from repo-level config, so the guide should document the user-only hooks rule and include the new `[hooks]` keys if it is meant to stay current with configuration behavior.

**Round 2** (auto-fix) - found 1 info
- ℹ️ `AGENTS.md:7` - The project structure section was not updated for the newly added `internal/hooks/` package. The change introduces a dedicated hooks package used by pool lifecycle operations, so the internal agent guide should list it alongside the other internal packages and describe that it runs user-configured lifecycle hook commands.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
