### PR TITLE
feat(prune): add safe stale worktree pruning

### DIFF
--- a/.no-mistakes/evidence/fm/th-prune-cmd-p8/prune-cli-e2e-transcript.md
+++ b/.no-mistakes/evidence/fm/th-prune-cmd-p8/prune-cli-e2e-transcript.md
@@ -1,0 +1,110 @@
+# treehouse prune CLI evidence
+
+Temporary fixture root: `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid`
+
+This transcript exercises the real CLI from a disposable git repo with a bare `origin` and isolated fake home.
+
+## Setup
+
+$ go build -o /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/treehouse .
+
+$ git init --bare --initial-branch=main /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/remote.git
+Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/remote.git/
+
+$ git init --initial-branch=main /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo
+Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo/.git/
+[main (root-commit) 59b1b76] initial commit
+ 1 file changed, 1 insertion(+)
+ create mode 100644 README.md
+To /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/remote.git
+ * [new branch]      main -> main
+branch 'main' set up to track 'origin/main'.
+
+$ cat > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.config/treehouse/config.toml
+[hooks]
+pre_destroy = ["pwd > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/pre-destroy-hook-pwd.txt"]
+
+## Dry-run lists stale idle worktree without deleting it
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home SHELL=true treehouse get
+🌳 Setting up worktree...
+🌳 Entered worktree at ~/.treehouse/repo-87406e/1/repo. Type 'exit' to return.
+🌳 Worktree returned to pool.
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home treehouse prune
+🌳 Dry run: would prune 1 stale worktree and reclaim 335 B.
+1     335 B  ~/.treehouse/repo-87406e/1/repo
+🌳 Re-run with --yes to delete these worktrees.
+
+Filesystem check: dry-run preserved `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo`.
+
+## --yes deletes the stale idle worktree and runs pre_destroy hook
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home treehouse prune --yes
+🌳 Pruned 1 stale worktree and freed 335 B.
+1     335 B  ~/.treehouse/repo-87406e/1/repo
+
+$ cat /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/pre-destroy-hook-pwd.txt
+/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo
+
+Filesystem check: --yes removed `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo`, and pre_destroy ran in that worktree before deletion.
+
+## Dirty idle worktree is skipped and preserved
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home SHELL=true treehouse get
+🌳 Setting up worktree...
+🌳 Entered worktree at ~/.treehouse/repo-87406e/1/repo. Type 'exit' to return.
+🌳 Worktree returned to pool.
+
+$ printf local-edit > /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo/uncommitted.txt
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home treehouse prune --yes
+🌳 No stale worktrees pruned.
+🌳 Skipped 1 unsafe idle worktree:
+1     uncommitted changes  ~/.treehouse/repo-87406e/1/repo
+
+Filesystem check: dirty worktree remained at `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo`, and pre_destroy did not run for the skipped worktree.
+
+## Clean worktree with unmerged commit is skipped and preserved
+
+$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo clean -fd
+Removing uncommitted.txt
+
+$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo switch -c evidence-unmerged
+Switched to a new branch 'evidence-unmerged'
+
+$ git -C /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo commit -am "unmerged evidence"
+[evidence-unmerged 2cfa7ec] unmerged evidence
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home treehouse prune --yes
+🌳 No stale worktrees pruned.
+🌳 Skipped 1 unsafe idle worktree:
+1     HEAD is not merged into refs/remotes/origin/main  ~/.treehouse/repo-87406e/1/repo
+
+Filesystem check: unmerged worktree remained at `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/1/repo`, and pre_destroy did not run for the skipped worktree.
+
+## In-use worktree is ignored by prune and preserved
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home SHELL=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/active-shell.sh treehouse get &
+🌳 Setting up worktree...
+🌳 Entered worktree at ~/.treehouse/repo-87406e/2/repo. Type 'exit' to return.
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home treehouse status
+1     dirty        ~/.treehouse/repo-87406e/1/repo
+2     in-use       ~/.treehouse/repo-87406e/2/repo
+                   sh (71992)
+
+$ cd /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/repo && HOME=/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home treehouse prune --yes
+🌳 No stale worktrees pruned.
+🌳 Skipped 1 unsafe idle worktree:
+1     uncommitted changes  ~/.treehouse/repo-87406e/1/repo
+
+Filesystem check: active worktree remained at `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/tmp.rPtQnkbTid/home/.treehouse/repo-87406e/2/repo` while prune ran, and pre_destroy did not run.
+
+$ wait for active treehouse get to exit
+🌳 Setting up worktree...
+🌳 Entered worktree at ~/.treehouse/repo-87406e/2/repo. Type 'exit' to return.
+🌳 Worktree returned to pool.
+
+Evidence result: PASS - dry-run listed reclaimable stale worktrees, --yes deleted only the stale idle worktree, pre_destroy ran only for that deletion, and dirty, unmerged, and in-use worktrees were preserved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Treehouse is a Go CLI tool that manages a pool of git worktrees for parallel AI 
 - `cmd/` - CLI commands (cobra): `get`, `return`, `status`, `prune`, `destroy`
 - `internal/config/` - config file loading (`treehouse.toml`)
 - `internal/hooks/` - user-configured lifecycle hook command execution
-- `internal/pool/` - pool manager (acquire, release, list, destroy) + state file
+- `internal/pool/` - pool manager (acquire, release, list, destroy, prune) + state file
 - `internal/git/` - git operations (shells out to `git` binary)
 - `internal/process/` - in-use detection and lingering process termination for worktrees
 - `internal/shell/` - subshell spawning
@@ -37,6 +37,7 @@ make test
 - No daemon - all operations are inline CLI commands
 - Detached HEAD worktrees reset to whichever of local or origin default branch is further ahead (prefers origin on divergence)
 - In-use detection uses process scanning plus short-lived persisted owner reservations for lifecycle operations
+- Dirty checks include untracked files even when repository config hides them from normal `git status` output
 - Prune deletes only idle managed worktrees that are clean and whose HEAD is merged into the default branch; dry run is the default
 - State file tracks pool membership and temporary owner/destroy reservations, not long-term usage status
 - Git operations shell out to `git` (go-git has incomplete worktree support)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Treehouse — Agent Guide
+# Treehouse - Agent Guide
 
 ## What is this?
 
@@ -6,15 +6,15 @@ Treehouse is a Go CLI tool that manages a pool of git worktrees for parallel AI 
 
 ## Project Structure
 
-- `main.go` — entry point, calls `cmd.Execute()`
-- `cmd/` — CLI commands (cobra): `get`, `return`, `status`, `destroy`
-- `internal/config/` — config file loading (`treehouse.toml`)
-- `internal/hooks/` — user-configured lifecycle hook command execution
-- `internal/pool/` — pool manager (acquire, release, list, destroy) + state file
-- `internal/git/` — git operations (shells out to `git` binary)
-- `internal/process/` — in-use detection and lingering process termination for worktrees
-- `internal/shell/` — subshell spawning
-- `internal/ui/` — Y/n confirmation prompts
+- `main.go` - entry point, calls `cmd.Execute()`
+- `cmd/` - CLI commands (cobra): `get`, `return`, `status`, `prune`, `destroy`
+- `internal/config/` - config file loading (`treehouse.toml`)
+- `internal/hooks/` - user-configured lifecycle hook command execution
+- `internal/pool/` - pool manager (acquire, release, list, destroy) + state file
+- `internal/git/` - git operations (shells out to `git` binary)
+- `internal/process/` - in-use detection and lingering process termination for worktrees
+- `internal/shell/` - subshell spawning
+- `internal/ui/` - Y/n confirmation prompts
 
 ## Building
 
@@ -34,9 +34,10 @@ make test
 
 ## Key Design Decisions
 
-- No daemon — all operations are inline CLI commands
+- No daemon - all operations are inline CLI commands
 - Detached HEAD worktrees reset to whichever of local or origin default branch is further ahead (prefers origin on divergence)
 - In-use detection uses process scanning plus short-lived persisted owner reservations for lifecycle operations
+- Prune deletes only idle managed worktrees that are clean and whose HEAD is merged into the default branch; dry run is the default
 - State file tracks pool membership and temporary owner/destroy reservations, not long-term usage status
 - Git operations shell out to `git` (go-git has incomplete worktree support)
 - Self-healing: stale state entries are auto-removed
@@ -50,7 +51,7 @@ This project targets Linux, macOS, and Windows. All new code **must** work on Wi
 - **Syscalls**: Unix-only syscalls (e.g., `syscall.Flock`) must be isolated behind build tags (`//go:build !windows` / `//go:build windows`). See `internal/pool/lock_unix.go` and `lock_windows.go` for the pattern.
 - **Build tags**: Follow the existing `_unix.go` / `_windows.go` naming convention (see also `internal/updater/sysproc_*.go`).
 - **CI**: The CI matrix runs tests on `ubuntu`, `macOS`, and `windows`. Cross-compile locally with `GOOS=windows go build ./...` to catch issues early.
-- **Process detection**: `gopsutil` is cross-platform — no special handling needed, but avoid importing platform-specific process APIs directly.
+- **Process detection**: `gopsutil` is cross-platform - no special handling needed, but avoid importing platform-specific process APIs directly.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 
 - **Detached HEAD** — worktrees use detached HEAD mode, reset to whichever of the local or remote default branch is further ahead, avoiding branch name conflicts entirely.
 - **No daemon** — all operations are inline CLI commands. No background processes, no state to get corrupted.
-- **In-use detection** — treehouse scans running processes and short-lived owner reservations to determine which worktrees are in-use. Reservations are persisted only while `get` and `destroy` lifecycle work is running.
+- **In-use detection** — treehouse scans running processes and short-lived owner reservations to determine which worktrees are in-use. Reservations are persisted only while `get`, `destroy`, and `prune` lifecycle work is running.
+- **Dirty detection** - treehouse treats tracked changes and untracked files as dirty, even when repository config hides untracked files from normal `git status` output.
 - **Safe pruning** - `treehouse prune` removes only idle managed worktrees whose HEAD is already merged into the default branch and whose working tree is clean.
   It is a dry run unless you pass `--yes`.
 
@@ -155,6 +156,17 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 | `prune`   | `--yes`   | Delete stale idle worktrees instead of doing a dry run |
 | `destroy` | `--force` | Force destroy even if in-use      |
 | `destroy` | `--all`   | Destroy all worktrees in the pool |
+
+### Pruning stale worktrees
+
+`treehouse prune` is a dry run by default.
+It lists stale idle managed worktrees that would be deleted and shows the reclaimable disk space.
+Pass `treehouse prune --yes` to delete those worktrees.
+
+Prune ignores worktrees that are currently in use or reserved by another lifecycle operation.
+It skips idle worktrees that are unsafe to remove and prints the skip reason, such as uncommitted tracked or untracked changes, or a HEAD commit that is not merged into the default branch.
+When `origin` exists, prune fetches it and proves each HEAD against the current remote default branch tracking ref.
+Without `origin`, prune uses the local default branch ref.
 
 ## Configuration
 
@@ -188,7 +200,7 @@ pre_destroy = ["./scripts/teardown.sh"]
 
 Commands in each list run sequentially in the worktree directory, via the OS shell (`/bin/sh -c` on Linux/macOS, `%COMSPEC% /c` on Windows).
 If a command exits non-zero, treehouse logs the command, exit code, and stderr, then continues with the remaining commands.
-A failing hook does not fail the overall `get` or `destroy` operation.
+A failing hook does not fail the overall `get`, `destroy`, or `prune` operation.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ pre_destroy = ["./scripts/teardown.sh"]
 ```
 
 - `post_create` runs after a worktree is provisioned or reset and right before `treehouse get` hands it to you.
-- `pre_destroy` runs before a worktree is removed by `treehouse destroy` (and `treehouse destroy --all`).
+- `pre_destroy` runs before a worktree is removed by `treehouse destroy`, `treehouse destroy --all`, or `treehouse prune --yes`.
 
 Commands in each list run sequentially in the worktree directory, via the OS shell (`/bin/sh -c` on Linux/macOS, `%COMSPEC% /c` on Windows).
 If a command exits non-zero, treehouse logs the command, exit code, and stderr, then continues with the remaining commands.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 - **Detached HEAD** — worktrees use detached HEAD mode, reset to whichever of the local or remote default branch is further ahead, avoiding branch name conflicts entirely.
 - **No daemon** — all operations are inline CLI commands. No background processes, no state to get corrupted.
 - **In-use detection** — treehouse scans running processes and short-lived owner reservations to determine which worktrees are in-use. Reservations are persisted only while `get` and `destroy` lifecycle work is running.
+- **Safe pruning** - `treehouse prune` removes only idle managed worktrees whose HEAD is already merged into the default branch and whose working tree is clean.
+  It is a dry run unless you pass `--yes`.
 
 ## CLI Reference
 
@@ -140,6 +142,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 | `treehouse get`            | Acquire a worktree from the pool                     |
 | `treehouse status`         | Show pool status (highlights your current worktree)  |
 | `treehouse return [path]`  | Terminate lingering worktree processes and return it to the pool |
+| `treehouse prune`          | Dry-run removal of stale idle worktrees to reclaim disk space |
 | `treehouse destroy [path]` | Remove a worktree from the pool                      |
 | `treehouse init`           | Create a default `treehouse.toml` config file        |
 | `treehouse update`         | Update treehouse to the latest version               |
@@ -149,6 +152,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 | Command   | Flag      | Description                       |
 | --------- | --------- | --------------------------------- |
 | `return`  | `--force` | Clean, reset, and return without prompting |
+| `prune`   | `--yes`   | Delete stale idle worktrees instead of doing a dry run |
 | `destroy` | `--force` | Force destroy even if in-use      |
 | `destroy` | `--all`   | Destroy all worktrees in the pool |
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -688,3 +688,44 @@ func TestPruneRefreshesOriginBeforeMergeSafety(t *testing.T) {
 		t.Fatalf("worktree with remotely unmerged HEAD was removed: %v", err)
 	}
 }
+
+func TestPruneUsesCurrentRemoteDefaultBranch(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+
+	base := filepath.Dir(repoDir)
+	remoteDir := filepath.Join(base, "remote.git")
+	rewriteDir := filepath.Join(base, "default-renamer")
+	gitCmd(t, "", "clone", remoteDir, rewriteDir)
+	gitCmd(t, rewriteDir, "config", "user.email", "test@test.com")
+	gitCmd(t, rewriteDir, "config", "user.name", "Test")
+	gitCmd(t, rewriteDir, "checkout", "--orphan", "trunk")
+	gitCmd(t, rewriteDir, "rm", "-rf", ".")
+	if err := os.WriteFile(filepath.Join(rewriteDir, "README.md"), []byte("new default\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, rewriteDir, "add", ".")
+	gitCmd(t, rewriteDir, "commit", "-m", "new default")
+	gitCmd(t, rewriteDir, "push", "origin", "trunk")
+	gitCmd(t, remoteDir, "symbolic-ref", "HEAD", "refs/heads/trunk")
+
+	pruneOut, pruneErr, code := runTreehouse(t, repoDir, homeDir, nil, "prune", "--yes")
+	if code != 0 {
+		t.Fatalf("prune --yes failed after remote default rename (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "not merged") || !strings.Contains(pruneOut, "origin/trunk") {
+		t.Fatalf("expected prune to use current remote default, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("worktree unmerged into current remote default was removed: %v", err)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -603,6 +603,34 @@ func TestPruneDryRunAndYes(t *testing.T) {
 	}
 }
 
+func TestPruneRejectsPositionalArgs(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	_, pruneErr, code := runTreehouse(t, repoDir, homeDir, nil, "prune", "/some/path", "--yes")
+	if code == 0 {
+		t.Fatal("expected prune with positional arg to fail")
+	}
+	if !strings.Contains(pruneErr, `unknown command "/some/path" for "treehouse prune"`) {
+		t.Fatalf("expected positional arg error, got stderr:\n%s", pruneErr)
+	}
+}
+
+func TestPruneEmptyPoolDoesNotRequireOrigin(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	remoteDir := filepath.Join(filepath.Dir(repoDir), "remote.git")
+	if err := os.RemoveAll(remoteDir); err != nil {
+		t.Fatal(err)
+	}
+
+	pruneOut, pruneErr, code := runTreehouse(t, repoDir, homeDir, nil, "prune")
+	if code != 0 {
+		t.Fatalf("prune dry run failed on empty pool with offline origin (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "No stale worktrees to prune") {
+		t.Fatalf("expected empty prune output, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+}
+
 func TestPruneSkipsUnsafeWorktrees(t *testing.T) {
 	repoDir, homeDir := setupTestRepo(t)
 	env := []string{"SHELL=" + exitShellBin}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -176,10 +176,11 @@ func runTreehouseFromDir(t *testing.T, repoDir, workDir, homeDir string, extraEn
 // HOME/USERPROFILE to the test homeDir and suppressing update checks.
 func buildEnv(homeDir string, extra ...string) []string {
 	skip := map[string]bool{
-		"HOME":        true,
-		"USERPROFILE": true,
-		"HOMEDRIVE":   true,
-		"HOMEPATH":    true,
+		"HOME":          true,
+		"USERPROFILE":   true,
+		"HOMEDRIVE":     true,
+		"HOMEPATH":      true,
+		"TREEHOUSE_DIR": true,
 	}
 	for _, kv := range extra {
 		if k, _, ok := strings.Cut(kv, "="); ok {
@@ -559,5 +560,91 @@ func TestDestroyNoArgs(t *testing.T) {
 	_, _, code := runTreehouse(t, repoDir, homeDir, nil, "destroy")
 	if code == 0 {
 		t.Fatal("expected destroy with no args and no --all to fail")
+	}
+}
+
+func TestPruneDryRunAndYes(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+
+	pruneOut, pruneErr, code := runTreehouse(t, repoDir, homeDir, nil, "prune")
+	if code != 0 {
+		t.Fatalf("prune dry run failed (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "Dry run") || !strings.Contains(pruneOut, "would prune 1 stale worktree") {
+		t.Fatalf("expected dry-run prune summary, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	prettyWtPath := "~" + wtPath[len(homeDir):]
+	if !strings.Contains(pruneOut, prettyWtPath) {
+		t.Fatalf("expected dry run to list %s, got:\n%s", prettyWtPath, pruneOut)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("dry run removed worktree %s: %v", wtPath, err)
+	}
+
+	pruneOut, pruneErr, code = runTreehouse(t, repoDir, homeDir, nil, "prune", "--yes")
+	if code != 0 {
+		t.Fatalf("prune --yes failed (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "Pruned 1 stale worktree") || !strings.Contains(pruneOut, "freed") {
+		t.Fatalf("expected prune --yes summary, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected worktree to be removed after prune --yes, stat err: %v", err)
+	}
+}
+
+func TestPruneSkipsUnsafeWorktrees(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "uncommitted.txt"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pruneOut, pruneErr, code := runTreehouse(t, repoDir, homeDir, nil, "prune", "--yes")
+	if code != 0 {
+		t.Fatalf("prune --yes failed on dirty worktree (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "uncommitted changes") {
+		t.Fatalf("expected dirty worktree skip, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("dirty worktree was removed: %v", err)
+	}
+
+	gitCmd(t, wtPath, "clean", "-fd")
+	gitCmd(t, wtPath, "checkout", "-b", "unmerged-work")
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("unmerged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, wtPath, "commit", "-am", "unmerged work")
+
+	pruneOut, pruneErr, code = runTreehouse(t, repoDir, homeDir, nil, "prune", "--yes")
+	if code != 0 {
+		t.Fatalf("prune --yes failed on unmerged worktree (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "not merged") {
+		t.Fatalf("expected unmerged worktree skip, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("unmerged worktree was removed: %v", err)
 	}
 }

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -616,6 +616,7 @@ func TestPruneSkipsUnsafeWorktrees(t *testing.T) {
 		t.Fatal("could not extract worktree path")
 	}
 
+	gitCmd(t, wtPath, "config", "status.showUntrackedFiles", "no")
 	if err := os.WriteFile(filepath.Join(wtPath, "uncommitted.txt"), []byte("keep me\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -646,5 +647,44 @@ func TestPruneSkipsUnsafeWorktrees(t *testing.T) {
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("unmerged worktree was removed: %v", err)
+	}
+}
+
+func TestPruneRefreshesOriginBeforeMergeSafety(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+
+	base := filepath.Dir(repoDir)
+	rewriteDir := filepath.Join(base, "rewriter")
+	gitCmd(t, "", "clone", filepath.Join(base, "remote.git"), rewriteDir)
+	gitCmd(t, rewriteDir, "config", "user.email", "test@test.com")
+	gitCmd(t, rewriteDir, "config", "user.name", "Test")
+	gitCmd(t, rewriteDir, "checkout", "--orphan", "replacement")
+	gitCmd(t, rewriteDir, "rm", "-rf", ".")
+	if err := os.WriteFile(filepath.Join(rewriteDir, "README.md"), []byte("replacement\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, rewriteDir, "add", ".")
+	gitCmd(t, rewriteDir, "commit", "-m", "replacement")
+	gitCmd(t, rewriteDir, "push", "--force", "origin", "replacement:main")
+
+	pruneOut, pruneErr, code := runTreehouse(t, repoDir, homeDir, nil, "prune", "--yes")
+	if code != 0 {
+		t.Fatalf("prune --yes failed after remote rewrite (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "not merged") {
+		t.Fatalf("expected stale local origin to be refreshed, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("worktree with remotely unmerged HEAD was removed: %v", err)
 	}
 }

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kunchenguid/treehouse/internal/config"
+	"github.com/kunchenguid/treehouse/internal/git"
+	"github.com/kunchenguid/treehouse/internal/pool"
+	"github.com/kunchenguid/treehouse/internal/ui"
+)
+
+var pruneYes bool
+
+var pruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove stale idle worktrees from the pool",
+	Long: `Remove stale idle worktrees from the pool to reclaim disk space.
+
+A worktree is stale only when treehouse manages it, no owner reservation or
+running process is using it, it has no uncommitted changes, and its HEAD is
+already merged into the default branch.
+
+Prune is a dry run by default. Pass --yes to delete the listed worktrees.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repoRoot, err := git.FindRepoRoot()
+		if err != nil {
+			return fmt.Errorf("not in a git repository: %w", err)
+		}
+
+		cfg, err := config.Load(repoRoot)
+		if err != nil {
+			return fmt.Errorf("failed to load config: %w", err)
+		}
+
+		poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+		if err != nil {
+			return err
+		}
+
+		result, err := pool.Prune(repoRoot, poolDir, !pruneYes, cfg.Hooks.PreDestroy)
+		if err != nil {
+			return err
+		}
+
+		printPruneResult(os.Stdout, result, !pruneYes)
+		return nil
+	},
+}
+
+func init() {
+	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Delete stale worktrees instead of doing a dry run")
+	rootCmd.AddCommand(pruneCmd)
+}
+
+func printPruneResult(w io.Writer, result pool.PruneResult, dryRun bool) {
+	if dryRun {
+		if len(result.Candidates) == 0 {
+			fmt.Fprintln(w, "🌳 No stale worktrees to prune.")
+			printPruneSkipped(w, result.Skipped)
+			return
+		}
+
+		fmt.Fprintf(w, "🌳 Dry run: would prune %d stale %s and reclaim %s.\n",
+			len(result.Candidates),
+			plural("worktree", len(result.Candidates)),
+			formatBytes(result.ReclaimableBytes),
+		)
+		printPruneWorktrees(w, result.Candidates)
+		printPruneSkipped(w, result.Skipped)
+		fmt.Fprintln(w, "🌳 Re-run with --yes to delete these worktrees.")
+		return
+	}
+
+	if len(result.Pruned) == 0 {
+		fmt.Fprintln(w, "🌳 No stale worktrees pruned.")
+		printPruneSkipped(w, result.Skipped)
+		return
+	}
+
+	fmt.Fprintf(w, "🌳 Pruned %d stale %s and freed %s.\n",
+		len(result.Pruned),
+		plural("worktree", len(result.Pruned)),
+		formatBytes(result.FreedBytes),
+	)
+	printPruneWorktrees(w, result.Pruned)
+	printPruneSkipped(w, result.Skipped)
+}
+
+func printPruneWorktrees(w io.Writer, worktrees []pool.PruneWorktree) {
+	sizeWidth := 0
+	sizes := make([]string, len(worktrees))
+	for i, wt := range worktrees {
+		sizes[i] = formatBytes(wt.Bytes)
+		if len(sizes[i]) > sizeWidth {
+			sizeWidth = len(sizes[i])
+		}
+	}
+
+	for i, wt := range worktrees {
+		fmt.Fprintf(w, "%-4s  %*s  %s\n", wt.Name, sizeWidth, sizes[i], ui.PrettyPath(wt.Path))
+	}
+}
+
+func printPruneSkipped(w io.Writer, skipped []pool.PruneSkipped) {
+	if len(skipped) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "🌳 Skipped %d unsafe idle %s:\n", len(skipped), plural("worktree", len(skipped)))
+	reasonWidth := 0
+	for _, wt := range skipped {
+		if len(wt.Reason) > reasonWidth {
+			reasonWidth = len(wt.Reason)
+		}
+	}
+	for _, wt := range skipped {
+		fmt.Fprintf(w, "%-4s  %-*s  %s\n", wt.Name, reasonWidth, wt.Reason, ui.PrettyPath(wt.Path))
+	}
+}
+
+func plural(word string, count int) string {
+	if count == 1 {
+		return word
+	}
+	return word + "s"
+}
+
+func formatBytes(bytes int64) string {
+	if bytes < 1024 {
+		return fmt.Sprintf("%d B", bytes)
+	}
+
+	units := []string{"KiB", "MiB", "GiB", "TiB"}
+	value := float64(bytes)
+	unit := "B"
+	for _, next := range units {
+		value /= 1024
+		unit = next
+		if value < 1024 {
+			break
+		}
+	}
+
+	formatted := fmt.Sprintf("%.1f", value)
+	formatted = strings.TrimSuffix(strings.TrimSuffix(formatted, "0"), ".")
+	return formatted + " " + unit
+}

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -26,6 +26,7 @@ running process is using it, it has no uncommitted changes, and its HEAD is
 already merged into the default branch.
 
 Prune is a dry run by default. Pass --yes to delete the listed worktrees.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repoRoot, err := git.FindRepoRoot()
 		if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -17,11 +17,23 @@ func FindRepoRootFrom(dir string) (string, error) {
 }
 
 func GetDefaultBranch(repoRoot string) (string, error) {
-	// Resolve to the main repo if we're inside a worktree.
+	mainRoot := mainRepoRoot(repoRoot)
+
+	// Try remote HEAD first (most reliable when remote exists).
+	if HasRemote(mainRoot, "origin") {
+		if out, err := runGit(mainRoot, "symbolic-ref", "refs/remotes/origin/HEAD"); err == nil {
+			if branch, ok := strings.CutPrefix(out, "refs/remotes/origin/"); ok && branch != "" {
+				return branch, nil
+			}
+		}
+	}
+
+	return getLocalDefaultBranch(mainRoot)
+}
+
+func mainRepoRoot(repoRoot string) string {
 	mainRoot := repoRoot
 	if dir, err := runGit(repoRoot, "rev-parse", "--git-common-dir"); err == nil {
-		// --git-common-dir returns the .git dir of the main repo.
-		// Derive the working tree root from it.
 		if d, err2 := runGit(repoRoot, "rev-parse", "--path-format=absolute", "--git-common-dir"); err2 == nil {
 			dir = d
 		}
@@ -30,25 +42,16 @@ func GetDefaultBranch(repoRoot string) (string, error) {
 			mainRoot = strings.TrimSuffix(dir, gitSuffix)
 		}
 	}
+	return mainRoot
+}
 
-	// Try remote HEAD first (most reliable when remote exists).
-	if out, err := runGit(mainRoot, "symbolic-ref", "refs/remotes/origin/HEAD"); err == nil {
-		parts := strings.SplitN(out, "/", 4)
-		if len(parts) >= 4 {
-			return parts[3], nil
-		}
-	}
-
-	// Fall back to the local HEAD of the main repo.
+func getLocalDefaultBranch(mainRoot string) (string, error) {
 	if out, err := runGit(mainRoot, "symbolic-ref", "HEAD"); err == nil {
-		// output is like "refs/heads/main"
-		parts := strings.SplitN(out, "/", 3)
-		if len(parts) >= 3 {
-			return parts[2], nil
+		if branch, ok := strings.CutPrefix(out, "refs/heads/"); ok && branch != "" {
+			return branch, nil
 		}
 	}
 
-	// Fall back to git config init.defaultBranch.
 	if out, err := runGit(mainRoot, "config", "init.defaultBranch"); err == nil && out != "" {
 		return out, nil
 	}
@@ -162,13 +165,17 @@ func DetachWorktree(worktreePath string) error {
 
 func DefaultBranchMergeRef(repoRoot string) (string, error) {
 	if HasRemote(repoRoot, "origin") {
-		branch, err := remoteDefaultBranch(repoRoot, "origin")
+		branch, sha, err := remoteDefaultBranch(repoRoot, "origin")
 		if err != nil {
 			return "", err
 		}
 		ref := remoteTrackingRef("origin", branch)
-		if !refExists(repoRoot, ref) {
+		localSHA, err := refCommit(repoRoot, ref)
+		if err != nil {
 			return "", fmt.Errorf("%s is unavailable", ref)
+		}
+		if localSHA != sha {
+			return "", fmt.Errorf("%s is stale: expected %s, got %s", ref, sha, localSHA)
 		}
 		return ref, nil
 	}
@@ -177,29 +184,43 @@ func DefaultBranchMergeRef(repoRoot string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ref := branchRef(repoRoot, branch)
-	if !refExists(repoRoot, ref) {
+	ref := "refs/heads/" + branch
+	if _, err := refCommit(repoRoot, ref); err != nil {
 		return "", fmt.Errorf("%s is unavailable", ref)
 	}
 	return ref, nil
 }
 
-func remoteDefaultBranch(repoRoot, remote string) (string, error) {
+func refCommit(repoRoot, ref string) (string, error) {
+	return runGit(repoRoot, "rev-parse", "--verify", ref+"^{commit}")
+}
+
+func remoteDefaultBranch(repoRoot, remote string) (string, string, error) {
 	out, err := runGit(repoRoot, "ls-remote", "--symref", remote, "HEAD")
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
+	var branch string
+	var sha string
 	for _, line := range strings.Split(out, "\n") {
 		fields := strings.Fields(line)
-		if len(fields) != 3 || fields[0] != "ref:" || fields[2] != "HEAD" {
+		if len(fields) == 3 && fields[0] == "ref:" && fields[2] == "HEAD" {
+			if value, ok := strings.CutPrefix(fields[1], "refs/heads/"); ok {
+				branch = value
+			}
 			continue
 		}
-		branch, ok := strings.CutPrefix(fields[1], "refs/heads/")
-		if ok && branch != "" {
-			return branch, nil
+		if len(fields) == 2 && fields[1] == "HEAD" {
+			sha = fields[0]
 		}
 	}
-	return "", fmt.Errorf("cannot determine %s default branch", remote)
+	if branch == "" {
+		return "", "", fmt.Errorf("cannot determine %s default branch", remote)
+	}
+	if sha == "" {
+		return "", "", fmt.Errorf("cannot determine %s default branch commit", remote)
+	}
+	return branch, sha, nil
 }
 
 func IsHeadMergedIntoDefault(repoRoot, worktreePath string) (bool, string, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -129,6 +129,7 @@ func RemoveWorktree(repoRoot, path string) error {
 	return err
 }
 
+// RemoveCleanWorktree removes a clean git worktree without forcing deletion.
 func RemoveCleanWorktree(repoRoot, path string) error {
 	_, err := runGit(repoRoot, "worktree", "remove", path)
 	return err
@@ -163,6 +164,10 @@ func DetachWorktree(worktreePath string) error {
 	return err
 }
 
+// DefaultBranchMergeRef returns the fully qualified ref used for merge safety checks.
+// Repositories with origin use the current remote default tracking ref and fail
+// closed if that local tracking ref does not match remote HEAD; local-only
+// repositories use the local default branch ref.
 func DefaultBranchMergeRef(repoRoot string) (string, error) {
 	if HasRemote(repoRoot, "origin") {
 		branch, sha, err := remoteDefaultBranch(repoRoot, "origin")
@@ -223,6 +228,7 @@ func remoteDefaultBranch(repoRoot, remote string) (string, string, error) {
 	return branch, sha, nil
 }
 
+// IsHeadMergedIntoDefault reports whether HEAD is merged into DefaultBranchMergeRef.
 func IsHeadMergedIntoDefault(repoRoot, worktreePath string) (bool, string, error) {
 	ref, err := DefaultBranchMergeRef(repoRoot)
 	if err != nil {
@@ -233,6 +239,7 @@ func IsHeadMergedIntoDefault(repoRoot, worktreePath string) (bool, string, error
 	return merged, ref, err
 }
 
+// IsHeadMergedIntoRef reports whether worktreePath's HEAD is an ancestor of ref.
 func IsHeadMergedIntoRef(worktreePath, ref string) (bool, error) {
 	cmd := exec.Command("git", "merge-base", "--is-ancestor", "HEAD", ref)
 	cmd.Dir = worktreePath
@@ -246,6 +253,7 @@ func IsHeadMergedIntoRef(worktreePath, ref string) (bool, error) {
 	return false, fmt.Errorf("git merge-base --is-ancestor HEAD %s: %s", ref, strings.TrimSpace(string(out)))
 }
 
+// IsDirty reports tracked or untracked changes, ignoring status.showUntrackedFiles.
 func IsDirty(worktreePath string) (bool, error) {
 	out, err := runGit(worktreePath, "status", "--porcelain", "--untracked-files=all")
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -183,7 +183,7 @@ func IsHeadMergedIntoDefault(repoRoot, worktreePath string) (bool, string, error
 }
 
 func IsDirty(worktreePath string) (bool, error) {
-	out, err := runGit(worktreePath, "status", "--porcelain")
+	out, err := runGit(worktreePath, "status", "--porcelain", "--untracked-files=all")
 	if err != nil {
 		return false, err
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -151,6 +151,37 @@ func DetachWorktree(worktreePath string) error {
 	return err
 }
 
+func IsHeadMergedIntoDefault(repoRoot, worktreePath string) (bool, string, error) {
+	branch, err := GetDefaultBranch(repoRoot)
+	if err != nil {
+		return false, "", err
+	}
+
+	ref := ""
+	if HasRemote(repoRoot, "origin") {
+		ref = "origin/" + branch
+		if !refExists(repoRoot, ref) {
+			return false, ref, fmt.Errorf("%s is unavailable", ref)
+		}
+	} else {
+		ref = branchRef(repoRoot, branch)
+		if !refExists(repoRoot, ref) {
+			return false, ref, fmt.Errorf("%s is unavailable", ref)
+		}
+	}
+
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", "HEAD", ref)
+	cmd.Dir = worktreePath
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, ref, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return false, ref, nil
+	}
+	return false, ref, fmt.Errorf("git merge-base --is-ancestor HEAD %s: %s", ref, strings.TrimSpace(string(out)))
+}
+
 func IsDirty(worktreePath string) (bool, error) {
 	out, err := runGit(worktreePath, "status", "--porcelain")
 	if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -78,12 +78,12 @@ func refExists(repoRoot, ref string) bool {
 	return err == nil
 }
 
-// branchRef returns whichever of the local branch or origin/<branch> is
-// further ahead. If they have diverged (neither is an ancestor of the
-// other), it prefers origin. Falls back to whichever ref exists.
+// branchRef returns whichever of the local branch or remote-tracking branch is
+// further ahead. If they have diverged (neither is an ancestor of the other),
+// it prefers origin. Falls back to whichever ref exists.
 func branchRef(repoRoot, branch string) string {
 	local := "refs/heads/" + branch
-	remote := "origin/" + branch
+	remote := remoteTrackingRef("origin", branch)
 	hasLocal := refExists(repoRoot, local)
 	hasRemote := refExists(repoRoot, remote)
 
@@ -104,6 +104,10 @@ func branchRef(repoRoot, branch string) string {
 	default:
 		return remote
 	}
+}
+
+func remoteTrackingRef(remote, branch string) string {
+	return "refs/remotes/" + remote + "/" + branch
 }
 
 // isAncestor returns true if ref a is an ancestor of (or equal to) ref b.
@@ -162,7 +166,7 @@ func DefaultBranchMergeRef(repoRoot string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		ref := "origin/" + branch
+		ref := remoteTrackingRef("origin", branch)
 		if !refExists(repoRoot, ref) {
 			return "", fmt.Errorf("%s is unavailable", ref)
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -122,6 +122,11 @@ func RemoveWorktree(repoRoot, path string) error {
 	return err
 }
 
+func RemoveCleanWorktree(repoRoot, path string) error {
+	_, err := runGit(repoRoot, "worktree", "remove", path)
+	return err
+}
+
 func Fetch(repoRoot string) error {
 	if !HasRemote(repoRoot, "origin") {
 		return nil
@@ -151,35 +156,69 @@ func DetachWorktree(worktreePath string) error {
 	return err
 }
 
-func IsHeadMergedIntoDefault(repoRoot, worktreePath string) (bool, string, error) {
+func DefaultBranchMergeRef(repoRoot string) (string, error) {
+	if HasRemote(repoRoot, "origin") {
+		branch, err := remoteDefaultBranch(repoRoot, "origin")
+		if err != nil {
+			return "", err
+		}
+		ref := "origin/" + branch
+		if !refExists(repoRoot, ref) {
+			return "", fmt.Errorf("%s is unavailable", ref)
+		}
+		return ref, nil
+	}
+
 	branch, err := GetDefaultBranch(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	ref := branchRef(repoRoot, branch)
+	if !refExists(repoRoot, ref) {
+		return "", fmt.Errorf("%s is unavailable", ref)
+	}
+	return ref, nil
+}
+
+func remoteDefaultBranch(repoRoot, remote string) (string, error) {
+	out, err := runGit(repoRoot, "ls-remote", "--symref", remote, "HEAD")
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 3 || fields[0] != "ref:" || fields[2] != "HEAD" {
+			continue
+		}
+		branch, ok := strings.CutPrefix(fields[1], "refs/heads/")
+		if ok && branch != "" {
+			return branch, nil
+		}
+	}
+	return "", fmt.Errorf("cannot determine %s default branch", remote)
+}
+
+func IsHeadMergedIntoDefault(repoRoot, worktreePath string) (bool, string, error) {
+	ref, err := DefaultBranchMergeRef(repoRoot)
 	if err != nil {
 		return false, "", err
 	}
 
-	ref := ""
-	if HasRemote(repoRoot, "origin") {
-		ref = "origin/" + branch
-		if !refExists(repoRoot, ref) {
-			return false, ref, fmt.Errorf("%s is unavailable", ref)
-		}
-	} else {
-		ref = branchRef(repoRoot, branch)
-		if !refExists(repoRoot, ref) {
-			return false, ref, fmt.Errorf("%s is unavailable", ref)
-		}
-	}
+	merged, err := IsHeadMergedIntoRef(worktreePath, ref)
+	return merged, ref, err
+}
 
+func IsHeadMergedIntoRef(worktreePath, ref string) (bool, error) {
 	cmd := exec.Command("git", "merge-base", "--is-ancestor", "HEAD", ref)
 	cmd.Dir = worktreePath
 	out, err := cmd.CombinedOutput()
 	if err == nil {
-		return true, ref, nil
+		return true, nil
 	}
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-		return false, ref, nil
+		return false, nil
 	}
-	return false, ref, fmt.Errorf("git merge-base --is-ancestor HEAD %s: %s", ref, strings.TrimSpace(string(out)))
+	return false, fmt.Errorf("git merge-base --is-ancestor HEAD %s: %s", ref, strings.TrimSpace(string(out)))
 }
 
 func IsDirty(worktreePath string) (bool, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -37,12 +37,19 @@ func mainRepoRoot(repoRoot string) string {
 		if d, err2 := runGit(repoRoot, "rev-parse", "--path-format=absolute", "--git-common-dir"); err2 == nil {
 			dir = d
 		}
-		gitSuffix := string(filepath.Separator) + ".git"
-		if strings.HasSuffix(dir, gitSuffix) {
-			mainRoot = strings.TrimSuffix(dir, gitSuffix)
+		if root, ok := repoRootFromCommonGitDir(dir); ok {
+			mainRoot = root
 		}
 	}
 	return mainRoot
+}
+
+func repoRootFromCommonGitDir(dir string) (string, bool) {
+	cleaned := filepath.Clean(filepath.FromSlash(dir))
+	if filepath.Base(cleaned) != ".git" {
+		return "", false
+	}
+	return filepath.Dir(cleaned), true
 }
 
 func getLocalDefaultBranch(mainRoot string) (string, error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,49 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRemoveCleanWorktreeRejectsDirtyWorktree(t *testing.T) {
+	base := t.TempDir()
+	repoDir := filepath.Join(base, "repo")
+	wtPath := filepath.Join(base, "worktree")
+
+	mustGit(t, "", "init", "--initial-branch=main", repoDir)
+	mustGit(t, repoDir, "config", "user.email", "test@test.com")
+	mustGit(t, repoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repoDir, "add", ".")
+	mustGit(t, repoDir, "commit", "-m", "initial")
+	mustGit(t, repoDir, "worktree", "add", "--detach", wtPath, "main")
+
+	dirtyPath := filepath.Join(wtPath, "uncommitted.txt")
+	if err := os.WriteFile(dirtyPath, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveCleanWorktree(repoDir, wtPath); err == nil {
+		t.Fatal("expected clean worktree removal to reject dirty worktree")
+	}
+	if _, err := os.Stat(dirtyPath); err != nil {
+		t.Fatalf("expected dirty worktree to remain: %v", err)
+	}
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -8,6 +8,43 @@ import (
 	"testing"
 )
 
+func TestRepoRootFromCommonGitDirHandlesForwardSlashPath(t *testing.T) {
+	root, ok := repoRootFromCommonGitDir("C:/Users/runner/AppData/Local/Temp/repo/.git")
+	if !ok {
+		t.Fatal("expected .git common dir to resolve to a repo root")
+	}
+
+	want := filepath.Clean(filepath.FromSlash("C:/Users/runner/AppData/Local/Temp/repo"))
+	if root != want {
+		t.Fatalf("expected repo root %q, got %q", want, root)
+	}
+}
+
+func TestGetDefaultBranchFromDetachedLinkedWorktreeUsesMainRepoHead(t *testing.T) {
+	base := t.TempDir()
+	repoDir := filepath.Join(base, "repo")
+	wtPath := filepath.Join(base, "worktree")
+
+	mustGit(t, "", "init", "--initial-branch=main", repoDir)
+	mustGit(t, repoDir, "config", "user.email", "test@test.com")
+	mustGit(t, repoDir, "config", "user.name", "Test")
+	mustGit(t, repoDir, "config", "init.defaultBranch", "wrong")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repoDir, "add", ".")
+	mustGit(t, repoDir, "commit", "-m", "initial")
+	mustGit(t, repoDir, "worktree", "add", "--detach", wtPath, "main")
+
+	branch, err := GetDefaultBranch(wtPath)
+	if err != nil {
+		t.Fatalf("GetDefaultBranch failed: %v", err)
+	}
+	if branch != "main" {
+		t.Fatalf("expected default branch main from main repo HEAD, got %q", branch)
+	}
+}
+
 func TestRemoveCleanWorktreeRejectsDirtyWorktree(t *testing.T) {
 	base := t.TempDir()
 	repoDir := filepath.Join(base, "repo")

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -579,6 +579,7 @@ func TestPruneSkipsDirtyWorktree(t *testing.T) {
 	if err := Release(poolDir, wtPath); err != nil {
 		t.Fatalf("Release failed: %v", err)
 	}
+	runGit(t, wtPath, "config", "status.showUntrackedFiles", "no")
 	if err := os.WriteFile(filepath.Join(wtPath, "uncommitted.txt"), []byte("keep me\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
@@ -627,6 +628,46 @@ func TestPruneSkipsUnmergedCommit(t *testing.T) {
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("expected unmerged worktree to remain: %v", err)
+	}
+}
+
+func TestPruneRefreshesOriginBeforeMergeSafety(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	base := filepath.Dir(repoDir)
+	rewriteDir := filepath.Join(base, "rewriter")
+	runGit(t, "", "clone", filepath.Join(base, "remote.git"), rewriteDir)
+	runGit(t, rewriteDir, "config", "user.email", "test@test.com")
+	runGit(t, rewriteDir, "config", "user.name", "Test")
+	runGit(t, rewriteDir, "checkout", "--orphan", "replacement")
+	runGit(t, rewriteDir, "rm", "-rf", ".")
+	if err := os.WriteFile(filepath.Join(rewriteDir, "README.md"), []byte("replacement\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	runGit(t, rewriteDir, "add", ".")
+	runGit(t, rewriteDir, "commit", "-m", "replacement")
+	runGit(t, rewriteDir, "push", "--force", "origin", "replacement:main")
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 0 {
+		t.Fatalf("worktree with remotely unmerged HEAD must not be pruned, got %#v", result.Pruned)
+	}
+	if !hasSkippedReason(result.Skipped, wtPath, "not merged") {
+		t.Fatalf("expected unmerged worktree skip after fetch, got %#v", result.Skipped)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected remotely unmerged worktree to remain: %v", err)
 	}
 }
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -509,6 +509,127 @@ func TestDestroyAll_NonForceRejectsLiveDestroyingWorktree(t *testing.T) {
 	}
 }
 
+func TestPruneDryRunDoesNotDeleteAvailableWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	result, err := Prune(repoDir, poolDir, true, nil)
+	if err != nil {
+		t.Fatalf("Prune dry run failed: %v", err)
+	}
+	if len(result.Candidates) != 1 || result.Candidates[0].Path != wtPath {
+		t.Fatalf("expected dry run candidate %s, got %#v", wtPath, result.Candidates)
+	}
+	if len(result.Pruned) != 0 || result.ReclaimableBytes == 0 {
+		t.Fatalf("expected dry run to report reclaimable space without pruning, got %#v", result)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("dry run removed worktree %s: %v", wtPath, err)
+	}
+}
+
+func TestPruneRemovesAvailableWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 1 || result.Pruned[0].Path != wtPath {
+		t.Fatalf("expected pruned worktree %s, got %#v", wtPath, result.Pruned)
+	}
+	if result.FreedBytes == 0 {
+		t.Fatalf("expected freed bytes, got %#v", result)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected worktree to be removed, stat err: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if len(state.Worktrees) != 0 {
+		t.Fatalf("expected pruned worktree to be removed from state, got %#v", state.Worktrees)
+	}
+}
+
+func TestPruneSkipsDirtyWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "uncommitted.txt"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 0 {
+		t.Fatalf("dirty worktree must not be pruned, got %#v", result.Pruned)
+	}
+	if !hasSkippedReason(result.Skipped, wtPath, "uncommitted changes") {
+		t.Fatalf("expected dirty worktree skip, got %#v", result.Skipped)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected dirty worktree to remain: %v", err)
+	}
+}
+
+func TestPruneSkipsUnmergedCommit(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	runGit(t, wtPath, "checkout", "-b", "unmerged-work")
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("unmerged\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	runGit(t, wtPath, "commit", "-am", "unmerged work")
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 0 {
+		t.Fatalf("unmerged worktree must not be pruned, got %#v", result.Pruned)
+	}
+	if !hasSkippedReason(result.Skipped, wtPath, "not merged") {
+		t.Fatalf("expected unmerged worktree skip, got %#v", result.Skipped)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected unmerged worktree to remain: %v", err)
+	}
+}
+
 func TestRelease_RejectsDestroyingWorktree(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 
@@ -555,6 +676,15 @@ func TestRelease_RejectsDestroyingWorktree(t *testing.T) {
 	if _, err := os.Stat(dirtyPath); err != nil {
 		t.Fatalf("expected Release to leave destroying worktree untouched: %v", err)
 	}
+}
+
+func hasSkippedReason(skipped []PruneSkipped, path, reason string) bool {
+	for _, wt := range skipped {
+		if wt.Path == path && strings.Contains(wt.Reason, reason) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestAcquireDuringHookProbe(t *testing.T) {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -695,6 +695,47 @@ func TestPruneRefreshesOriginBeforeMergeSafety(t *testing.T) {
 	}
 }
 
+func TestPruneUsesRemoteTrackingDefaultRefNotShadowingBranch(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+	runGit(t, repoDir, "branch", "origin/main", "main")
+
+	base := filepath.Dir(repoDir)
+	rewriteDir := filepath.Join(base, "shadow-rewriter")
+	runGit(t, "", "clone", filepath.Join(base, "remote.git"), rewriteDir)
+	runGit(t, rewriteDir, "config", "user.email", "test@test.com")
+	runGit(t, rewriteDir, "config", "user.name", "Test")
+	runGit(t, rewriteDir, "checkout", "--orphan", "replacement")
+	runGit(t, rewriteDir, "rm", "-rf", ".")
+	if err := os.WriteFile(filepath.Join(rewriteDir, "README.md"), []byte("replacement\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	runGit(t, rewriteDir, "add", ".")
+	runGit(t, rewriteDir, "commit", "-m", "replacement")
+	runGit(t, rewriteDir, "push", "--force", "origin", "replacement:main")
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 0 {
+		t.Fatalf("shadowed default ref must not prune unmerged worktree, got %#v", result.Pruned)
+	}
+	if !hasSkippedReason(result.Skipped, wtPath, "not merged") {
+		t.Fatalf("expected unmerged worktree skip with shadowed ref, got %#v", result.Skipped)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected shadowed-ref worktree to remain: %v", err)
+	}
+}
+
 func TestRelease_RejectsDestroyingWorktree(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -36,6 +36,29 @@ func setupRepo(t *testing.T) (repoDir, poolDir string) {
 	return repoDir, poolDir
 }
 
+func setupLocalRepo(t *testing.T) (repoDir, poolDir string) {
+	t.Helper()
+	base := t.TempDir()
+	base, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repoDir = filepath.Join(base, "myrepo")
+	poolDir = filepath.Join(base, "pool")
+
+	runGit(t, "", "init", "--initial-branch=main", repoDir)
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	return repoDir, poolDir
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -733,6 +756,118 @@ func TestPruneUsesRemoteTrackingDefaultRefNotShadowingBranch(t *testing.T) {
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("expected shadowed-ref worktree to remain: %v", err)
+	}
+}
+
+func TestPruneUsesFullLocalDefaultRefWithoutOrigin(t *testing.T) {
+	repoDir, poolDir := setupLocalRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	runGit(t, repoDir, "tag", "main", "HEAD")
+	runGit(t, repoDir, "checkout", "--orphan", "replacement")
+	runGit(t, repoDir, "rm", "-rf", ".")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("replacement\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "replacement")
+	runGit(t, repoDir, "branch", "-M", "main")
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 0 {
+		t.Fatalf("local shadowed default ref must not prune unmerged worktree, got %#v", result.Pruned)
+	}
+	if !hasSkippedReason(result.Skipped, wtPath, "refs/heads/main") {
+		t.Fatalf("expected local default branch skip, got %#v", result.Skipped)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected local shadowed-ref worktree to remain: %v", err)
+	}
+}
+
+func TestPruneIgnoresStaleOriginHeadWhenOriginIsAbsent(t *testing.T) {
+	repoDir, poolDir := setupLocalRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	runGit(t, repoDir, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runGit(t, repoDir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runGit(t, repoDir, "checkout", "--orphan", "trunk")
+	runGit(t, repoDir, "rm", "-rf", ".")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("trunk\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "trunk")
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 0 {
+		t.Fatalf("stale origin HEAD must not choose local main, got %#v", result.Pruned)
+	}
+	if !hasSkippedReason(result.Skipped, wtPath, "refs/heads/trunk") {
+		t.Fatalf("expected local HEAD branch skip, got %#v", result.Skipped)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected stale origin HEAD worktree to remain: %v", err)
+	}
+}
+
+func TestPruneFailsClosedWhenRemoteDefaultTrackingRefIsStale(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	runGit(t, repoDir, "branch", "side")
+	runGit(t, repoDir, "push", "origin", "side")
+	runGit(t, repoDir, "config", "--unset-all", "remote.origin.fetch")
+	runGit(t, repoDir, "config", "--add", "remote.origin.fetch", "+refs/heads/side:refs/remotes/origin/side")
+
+	base := filepath.Dir(repoDir)
+	rewriteDir := filepath.Join(base, "stale-default-rewriter")
+	runGit(t, "", "clone", filepath.Join(base, "remote.git"), rewriteDir)
+	runGit(t, rewriteDir, "config", "user.email", "test@test.com")
+	runGit(t, rewriteDir, "config", "user.name", "Test")
+	runGit(t, rewriteDir, "checkout", "--orphan", "replacement")
+	runGit(t, rewriteDir, "rm", "-rf", ".")
+	if err := os.WriteFile(filepath.Join(rewriteDir, "README.md"), []byte("replacement\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	runGit(t, rewriteDir, "add", ".")
+	runGit(t, rewriteDir, "commit", "-m", "replacement")
+	runGit(t, rewriteDir, "push", "--force", "origin", "replacement:main")
+
+	if _, err := Prune(repoDir, poolDir, false, nil); err == nil {
+		t.Fatal("expected Prune to reject stale remote default tracking ref")
+	} else if !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("expected stale remote default error, got %v", err)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected stale remote default worktree to remain: %v", err)
 	}
 }
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -569,6 +569,30 @@ func TestPruneRemovesAvailableWorktree(t *testing.T) {
 	}
 }
 
+func TestPruneInUseWorktreeDoesNotRequireOrigin(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	remoteDir := filepath.Join(filepath.Dir(repoDir), "remote.git")
+	if err := os.RemoveAll(remoteDir); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed on in-use worktree with offline origin: %v", err)
+	}
+	if len(result.Candidates) != 0 || len(result.Pruned) != 0 || len(result.Skipped) != 0 {
+		t.Fatalf("expected in-use worktree to be ignored, got %#v", result)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected in-use worktree to remain: %v", err)
+	}
+}
+
 func TestPruneSkipsDirtyWorktree(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -11,18 +11,22 @@ import (
 	"github.com/kunchenguid/treehouse/internal/process"
 )
 
+// PruneWorktree describes a stale worktree that prune can remove or did remove.
 type PruneWorktree struct {
 	Name  string
 	Path  string
 	Bytes int64
 }
 
+// PruneSkipped describes a worktree that prune left in place for safety.
 type PruneSkipped struct {
 	Name   string
 	Path   string
 	Reason string
 }
 
+// PruneResult describes dry-run candidates, removed worktrees, skipped worktrees,
+// and the corresponding byte counts.
 type PruneResult struct {
 	Candidates       []PruneWorktree
 	Pruned           []PruneWorktree
@@ -31,6 +35,10 @@ type PruneResult struct {
 	FreedBytes       int64
 }
 
+// Prune finds stale idle managed worktrees and optionally deletes them.
+// A stale worktree is clean, unused, unreserved, and merged into the default
+// branch ref selected by git.DefaultBranchMergeRef.
+// In dryRun mode Prune reports candidates and reclaimable bytes without deleting.
 func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
 	entries, err := pruneSnapshot(poolDir)
 	if err != nil {

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -32,6 +32,10 @@ type PruneResult struct {
 }
 
 func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
+	if err := git.Fetch(repoRoot); err != nil {
+		return PruneResult{}, fmt.Errorf("refresh origin before prune: %w", err)
+	}
+
 	entries, err := pruneSnapshot(poolDir)
 	if err != nil {
 		return PruneResult{}, err

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -32,20 +32,15 @@ type PruneResult struct {
 }
 
 func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
-	if err := git.Fetch(repoRoot); err != nil {
-		return PruneResult{}, fmt.Errorf("refresh origin before prune: %w", err)
-	}
-	defaultRef, err := git.DefaultBranchMergeRef(repoRoot)
-	if err != nil {
-		return PruneResult{}, fmt.Errorf("resolve default branch before prune: %w", err)
-	}
-
 	entries, err := pruneSnapshot(poolDir)
 	if err != nil {
 		return PruneResult{}, err
 	}
 
-	plan := planPrune(defaultRef, entries)
+	plan, defaultRef, err := planPrune(repoRoot, entries)
+	if err != nil {
+		return PruneResult{}, err
+	}
 	if dryRun || len(plan.Candidates) == 0 {
 		return plan, nil
 	}
@@ -72,10 +67,26 @@ func pruneSnapshot(poolDir string) ([]WorktreeEntry, error) {
 	return entries, err
 }
 
-func planPrune(defaultRef string, entries []WorktreeEntry) PruneResult {
+func planPrune(repoRoot string, entries []WorktreeEntry) (PruneResult, string, error) {
 	var result PruneResult
+	var defaultRef string
+	resolveDefaultRef := func() (string, error) {
+		if defaultRef != "" {
+			return defaultRef, nil
+		}
+		ref, err := resolvePruneDefaultRef(repoRoot)
+		if err != nil {
+			return "", err
+		}
+		defaultRef = ref
+		return defaultRef, nil
+	}
+
 	for _, wt := range entries {
-		worktree, skipped, stale := analyzePruneCandidate(defaultRef, wt)
+		worktree, skipped, stale, err := analyzePruneCandidate(resolveDefaultRef, wt)
+		if err != nil {
+			return PruneResult{}, "", err
+		}
 		if !stale {
 			continue
 		}
@@ -86,7 +97,18 @@ func planPrune(defaultRef string, entries []WorktreeEntry) PruneResult {
 		result.Candidates = append(result.Candidates, worktree)
 		result.ReclaimableBytes += worktree.Bytes
 	}
-	return result
+	return result, defaultRef, nil
+}
+
+func resolvePruneDefaultRef(repoRoot string) (string, error) {
+	if err := git.Fetch(repoRoot); err != nil {
+		return "", fmt.Errorf("refresh origin before prune: %w", err)
+	}
+	defaultRef, err := git.DefaultBranchMergeRef(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve default branch before prune: %w", err)
+	}
+	return defaultRef, nil
 }
 
 func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDestroy []string) (PruneResult, error) {
@@ -113,7 +135,10 @@ func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDes
 				continue
 			}
 
-			worktree, skipped, stale := analyzePruneCandidate(defaultRef, state.Worktrees[i])
+			worktree, skipped, stale, err := analyzePruneCandidate(fixedPruneDefaultRef(defaultRef), state.Worktrees[i])
+			if err != nil {
+				return err
+			}
 			if !stale {
 				continue
 			}
@@ -211,22 +236,30 @@ func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDes
 	return result, nil
 }
 
-func analyzePruneCandidate(defaultRef string, wt WorktreeEntry) (PruneWorktree, PruneSkipped, bool) {
+type pruneRefResolver func() (string, error)
+
+func fixedPruneDefaultRef(defaultRef string) pruneRefResolver {
+	return func() (string, error) {
+		return defaultRef, nil
+	}
+}
+
+func analyzePruneCandidate(resolveDefaultRef pruneRefResolver, wt WorktreeEntry) (PruneWorktree, PruneSkipped, bool, error) {
 	worktree := PruneWorktree{Name: wt.Name, Path: wt.Path}
 	skipped := PruneSkipped{Name: wt.Name, Path: wt.Path}
 
 	if wt.Destroying || ownerAlive(wt) {
-		return worktree, skipped, false
+		return worktree, skipped, false, nil
 	}
 	inUse, err := process.IsWorktreeInUse(wt.Path)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot check processes: %v", err)
-		return worktree, skipped, true
+		return worktree, skipped, true, nil
 	}
 	if inUse {
-		return worktree, skipped, false
+		return worktree, skipped, false, nil
 	}
-	return analyzeIdleWorktree(defaultRef, worktree, skipped)
+	return analyzeIdleWorktree(resolveDefaultRef, worktree, skipped)
 }
 
 func finalPruneSafetyCheck(defaultRef string, wt WorktreeEntry) (PruneWorktree, PruneSkipped) {
@@ -242,38 +275,46 @@ func finalPruneSafetyCheck(defaultRef string, wt WorktreeEntry) (PruneWorktree, 
 		skipped.Reason = "in use"
 		return worktree, skipped
 	}
-	worktree, skipped, _ = analyzeIdleWorktree(defaultRef, worktree, skipped)
+	worktree, skipped, _, err = analyzeIdleWorktree(fixedPruneDefaultRef(defaultRef), worktree, skipped)
+	if err != nil {
+		skipped.Reason = fmt.Sprintf("cannot prove HEAD is merged into default branch: %v", err)
+	}
 	return worktree, skipped
 }
 
-func analyzeIdleWorktree(defaultRef string, worktree PruneWorktree, skipped PruneSkipped) (PruneWorktree, PruneSkipped, bool) {
+func analyzeIdleWorktree(resolveDefaultRef pruneRefResolver, worktree PruneWorktree, skipped PruneSkipped) (PruneWorktree, PruneSkipped, bool, error) {
 	dirty, err := git.IsDirty(worktree.Path)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot check status: %v", err)
-		return worktree, skipped, true
+		return worktree, skipped, true, nil
 	}
 	if dirty {
 		skipped.Reason = "uncommitted changes"
-		return worktree, skipped, true
+		return worktree, skipped, true, nil
+	}
+
+	defaultRef, err := resolveDefaultRef()
+	if err != nil {
+		return worktree, skipped, true, err
 	}
 
 	merged, err := git.IsHeadMergedIntoRef(worktree.Path, defaultRef)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot prove HEAD is merged into default branch: %v", err)
-		return worktree, skipped, true
+		return worktree, skipped, true, nil
 	}
 	if !merged {
 		skipped.Reason = fmt.Sprintf("HEAD is not merged into %s", defaultRef)
-		return worktree, skipped, true
+		return worktree, skipped, true, nil
 	}
 
 	bytes, err := dirSize(filepath.Dir(worktree.Path))
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot measure size: %v", err)
-		return worktree, skipped, true
+		return worktree, skipped, true, nil
 	}
 	worktree.Bytes = bytes
-	return worktree, skipped, true
+	return worktree, skipped, true, nil
 }
 
 func clearReservation(wt *WorktreeEntry) {

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -1,0 +1,291 @@
+package pool
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/kunchenguid/treehouse/internal/git"
+	"github.com/kunchenguid/treehouse/internal/hooks"
+	"github.com/kunchenguid/treehouse/internal/process"
+)
+
+type PruneWorktree struct {
+	Name  string
+	Path  string
+	Bytes int64
+}
+
+type PruneSkipped struct {
+	Name   string
+	Path   string
+	Reason string
+}
+
+type PruneResult struct {
+	Candidates       []PruneWorktree
+	Pruned           []PruneWorktree
+	Skipped          []PruneSkipped
+	ReclaimableBytes int64
+	FreedBytes       int64
+}
+
+func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
+	entries, err := pruneSnapshot(poolDir)
+	if err != nil {
+		return PruneResult{}, err
+	}
+
+	plan := planPrune(repoRoot, entries)
+	if dryRun || len(plan.Candidates) == 0 {
+		return plan, nil
+	}
+
+	return executePrune(repoRoot, poolDir, plan, preDestroy)
+}
+
+func pruneSnapshot(poolDir string) ([]WorktreeEntry, error) {
+	var entries []WorktreeEntry
+	err := WithStateLock(poolDir, func() error {
+		state, err := ReadState(poolDir)
+		if err != nil {
+			return err
+		}
+
+		state = healState(state)
+		if err := WriteState(poolDir, state); err != nil {
+			return err
+		}
+
+		entries = append([]WorktreeEntry(nil), state.Worktrees...)
+		return nil
+	})
+	return entries, err
+}
+
+func planPrune(repoRoot string, entries []WorktreeEntry) PruneResult {
+	var result PruneResult
+	for _, wt := range entries {
+		worktree, skipped, stale := analyzePruneCandidate(repoRoot, wt)
+		if !stale {
+			continue
+		}
+		if skipped.Reason != "" {
+			result.Skipped = append(result.Skipped, skipped)
+			continue
+		}
+		result.Candidates = append(result.Candidates, worktree)
+		result.ReclaimableBytes += worktree.Bytes
+	}
+	return result
+}
+
+func executePrune(repoRoot, poolDir string, plan PruneResult, preDestroy []string) (PruneResult, error) {
+	result := PruneResult{
+		Skipped: append([]PruneSkipped(nil), plan.Skipped...),
+	}
+
+	planned := make(map[string]PruneWorktree, len(plan.Candidates))
+	for _, wt := range plan.Candidates {
+		planned[wt.Path] = wt
+	}
+
+	var reserved []WorktreeEntry
+	if err := WithStateLock(poolDir, func() error {
+		state, err := ReadState(poolDir)
+		if err != nil {
+			return err
+		}
+		state = healState(state)
+
+		for i := range state.Worktrees {
+			plannedWorktree, ok := planned[state.Worktrees[i].Path]
+			if !ok {
+				continue
+			}
+
+			worktree, skipped, stale := analyzePruneCandidate(repoRoot, state.Worktrees[i])
+			if !stale {
+				continue
+			}
+			if skipped.Reason != "" {
+				result.Skipped = append(result.Skipped, skipped)
+				continue
+			}
+			worktree.Bytes = plannedWorktree.Bytes
+			state.Worktrees[i].Destroying = true
+			if err := reserveOwner(&state.Worktrees[i]); err != nil {
+				return err
+			}
+			reserved = append(reserved, state.Worktrees[i])
+			result.Candidates = append(result.Candidates, worktree)
+			result.ReclaimableBytes += worktree.Bytes
+		}
+
+		return WriteState(poolDir, state)
+	}); err != nil {
+		return PruneResult{}, err
+	}
+
+	for _, wt := range reserved {
+		hooks.Run(preDestroy, wt.Path, os.Stdout, os.Stderr)
+	}
+
+	if err := WithStateLock(poolDir, func() error {
+		state, err := ReadState(poolDir)
+		if err != nil {
+			return err
+		}
+
+		removed := make(map[string]struct{}, len(reserved))
+		for _, reservation := range reserved {
+			idx := -1
+			for i := range state.Worktrees {
+				if state.Worktrees[i].Path == reservation.Path {
+					idx = i
+					break
+				}
+			}
+			if idx == -1 || !sameDestroyReservation(state.Worktrees[idx], reservation) {
+				continue
+			}
+
+			worktree, skipped := finalPruneSafetyCheck(repoRoot, state.Worktrees[idx])
+			if skipped.Reason != "" {
+				clearReservation(&state.Worktrees[idx])
+				result.Skipped = append(result.Skipped, skipped)
+				continue
+			}
+
+			if worktree.Bytes == 0 {
+				if plannedWorktree, ok := planned[worktree.Path]; ok {
+					worktree.Bytes = plannedWorktree.Bytes
+				}
+			}
+
+			if err := git.RemoveWorktree(repoRoot, worktree.Path); err != nil {
+				clearReservation(&state.Worktrees[idx])
+				result.Skipped = append(result.Skipped, PruneSkipped{
+					Name:   worktree.Name,
+					Path:   worktree.Path,
+					Reason: fmt.Sprintf("remove failed: %v", err),
+				})
+				continue
+			}
+			if err := os.RemoveAll(filepath.Dir(worktree.Path)); err != nil {
+				clearReservation(&state.Worktrees[idx])
+				result.Skipped = append(result.Skipped, PruneSkipped{
+					Name:   worktree.Name,
+					Path:   worktree.Path,
+					Reason: fmt.Sprintf("cleanup failed: %v", err),
+				})
+				continue
+			}
+
+			removed[worktree.Path] = struct{}{}
+			result.Pruned = append(result.Pruned, worktree)
+			result.FreedBytes += worktree.Bytes
+		}
+
+		kept := state.Worktrees[:0]
+		for _, wt := range state.Worktrees {
+			if _, ok := removed[wt.Path]; !ok {
+				kept = append(kept, wt)
+			}
+		}
+		state.Worktrees = kept
+		return WriteState(poolDir, state)
+	}); err != nil {
+		return PruneResult{}, err
+	}
+
+	return result, nil
+}
+
+func analyzePruneCandidate(repoRoot string, wt WorktreeEntry) (PruneWorktree, PruneSkipped, bool) {
+	worktree := PruneWorktree{Name: wt.Name, Path: wt.Path}
+	skipped := PruneSkipped{Name: wt.Name, Path: wt.Path}
+
+	if wt.Destroying || ownerAlive(wt) {
+		return worktree, skipped, false
+	}
+	inUse, err := process.IsWorktreeInUse(wt.Path)
+	if err != nil {
+		skipped.Reason = fmt.Sprintf("cannot check processes: %v", err)
+		return worktree, skipped, true
+	}
+	if inUse {
+		return worktree, skipped, false
+	}
+	return analyzeIdleWorktree(repoRoot, worktree, skipped)
+}
+
+func finalPruneSafetyCheck(repoRoot string, wt WorktreeEntry) (PruneWorktree, PruneSkipped) {
+	worktree := PruneWorktree{Name: wt.Name, Path: wt.Path}
+	skipped := PruneSkipped{Name: wt.Name, Path: wt.Path}
+
+	inUse, err := process.IsWorktreeInUse(wt.Path)
+	if err != nil {
+		skipped.Reason = fmt.Sprintf("cannot check processes: %v", err)
+		return worktree, skipped
+	}
+	if inUse {
+		skipped.Reason = "in use"
+		return worktree, skipped
+	}
+	worktree, skipped, _ = analyzeIdleWorktree(repoRoot, worktree, skipped)
+	return worktree, skipped
+}
+
+func analyzeIdleWorktree(repoRoot string, worktree PruneWorktree, skipped PruneSkipped) (PruneWorktree, PruneSkipped, bool) {
+	dirty, err := git.IsDirty(worktree.Path)
+	if err != nil {
+		skipped.Reason = fmt.Sprintf("cannot check status: %v", err)
+		return worktree, skipped, true
+	}
+	if dirty {
+		skipped.Reason = "uncommitted changes"
+		return worktree, skipped, true
+	}
+
+	merged, ref, err := git.IsHeadMergedIntoDefault(repoRoot, worktree.Path)
+	if err != nil {
+		skipped.Reason = fmt.Sprintf("cannot prove HEAD is merged into default branch: %v", err)
+		return worktree, skipped, true
+	}
+	if !merged {
+		skipped.Reason = fmt.Sprintf("HEAD is not merged into %s", ref)
+		return worktree, skipped, true
+	}
+
+	bytes, err := dirSize(filepath.Dir(worktree.Path))
+	if err != nil {
+		skipped.Reason = fmt.Sprintf("cannot measure size: %v", err)
+		return worktree, skipped, true
+	}
+	worktree.Bytes = bytes
+	return worktree, skipped, true
+}
+
+func clearReservation(wt *WorktreeEntry) {
+	wt.Destroying = false
+	wt.OwnerPID = 0
+	wt.OwnerStartedAt = 0
+}
+
+func dirSize(root string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	return total, err
+}

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -35,18 +35,22 @@ func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneRes
 	if err := git.Fetch(repoRoot); err != nil {
 		return PruneResult{}, fmt.Errorf("refresh origin before prune: %w", err)
 	}
+	defaultRef, err := git.DefaultBranchMergeRef(repoRoot)
+	if err != nil {
+		return PruneResult{}, fmt.Errorf("resolve default branch before prune: %w", err)
+	}
 
 	entries, err := pruneSnapshot(poolDir)
 	if err != nil {
 		return PruneResult{}, err
 	}
 
-	plan := planPrune(repoRoot, entries)
+	plan := planPrune(defaultRef, entries)
 	if dryRun || len(plan.Candidates) == 0 {
 		return plan, nil
 	}
 
-	return executePrune(repoRoot, poolDir, plan, preDestroy)
+	return executePrune(repoRoot, poolDir, defaultRef, plan, preDestroy)
 }
 
 func pruneSnapshot(poolDir string) ([]WorktreeEntry, error) {
@@ -68,10 +72,10 @@ func pruneSnapshot(poolDir string) ([]WorktreeEntry, error) {
 	return entries, err
 }
 
-func planPrune(repoRoot string, entries []WorktreeEntry) PruneResult {
+func planPrune(defaultRef string, entries []WorktreeEntry) PruneResult {
 	var result PruneResult
 	for _, wt := range entries {
-		worktree, skipped, stale := analyzePruneCandidate(repoRoot, wt)
+		worktree, skipped, stale := analyzePruneCandidate(defaultRef, wt)
 		if !stale {
 			continue
 		}
@@ -85,7 +89,7 @@ func planPrune(repoRoot string, entries []WorktreeEntry) PruneResult {
 	return result
 }
 
-func executePrune(repoRoot, poolDir string, plan PruneResult, preDestroy []string) (PruneResult, error) {
+func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDestroy []string) (PruneResult, error) {
 	result := PruneResult{
 		Skipped: append([]PruneSkipped(nil), plan.Skipped...),
 	}
@@ -109,7 +113,7 @@ func executePrune(repoRoot, poolDir string, plan PruneResult, preDestroy []strin
 				continue
 			}
 
-			worktree, skipped, stale := analyzePruneCandidate(repoRoot, state.Worktrees[i])
+			worktree, skipped, stale := analyzePruneCandidate(defaultRef, state.Worktrees[i])
 			if !stale {
 				continue
 			}
@@ -155,7 +159,7 @@ func executePrune(repoRoot, poolDir string, plan PruneResult, preDestroy []strin
 				continue
 			}
 
-			worktree, skipped := finalPruneSafetyCheck(repoRoot, state.Worktrees[idx])
+			worktree, skipped := finalPruneSafetyCheck(defaultRef, state.Worktrees[idx])
 			if skipped.Reason != "" {
 				clearReservation(&state.Worktrees[idx])
 				result.Skipped = append(result.Skipped, skipped)
@@ -168,7 +172,7 @@ func executePrune(repoRoot, poolDir string, plan PruneResult, preDestroy []strin
 				}
 			}
 
-			if err := git.RemoveWorktree(repoRoot, worktree.Path); err != nil {
+			if err := git.RemoveCleanWorktree(repoRoot, worktree.Path); err != nil {
 				clearReservation(&state.Worktrees[idx])
 				result.Skipped = append(result.Skipped, PruneSkipped{
 					Name:   worktree.Name,
@@ -207,7 +211,7 @@ func executePrune(repoRoot, poolDir string, plan PruneResult, preDestroy []strin
 	return result, nil
 }
 
-func analyzePruneCandidate(repoRoot string, wt WorktreeEntry) (PruneWorktree, PruneSkipped, bool) {
+func analyzePruneCandidate(defaultRef string, wt WorktreeEntry) (PruneWorktree, PruneSkipped, bool) {
 	worktree := PruneWorktree{Name: wt.Name, Path: wt.Path}
 	skipped := PruneSkipped{Name: wt.Name, Path: wt.Path}
 
@@ -222,10 +226,10 @@ func analyzePruneCandidate(repoRoot string, wt WorktreeEntry) (PruneWorktree, Pr
 	if inUse {
 		return worktree, skipped, false
 	}
-	return analyzeIdleWorktree(repoRoot, worktree, skipped)
+	return analyzeIdleWorktree(defaultRef, worktree, skipped)
 }
 
-func finalPruneSafetyCheck(repoRoot string, wt WorktreeEntry) (PruneWorktree, PruneSkipped) {
+func finalPruneSafetyCheck(defaultRef string, wt WorktreeEntry) (PruneWorktree, PruneSkipped) {
 	worktree := PruneWorktree{Name: wt.Name, Path: wt.Path}
 	skipped := PruneSkipped{Name: wt.Name, Path: wt.Path}
 
@@ -238,11 +242,11 @@ func finalPruneSafetyCheck(repoRoot string, wt WorktreeEntry) (PruneWorktree, Pr
 		skipped.Reason = "in use"
 		return worktree, skipped
 	}
-	worktree, skipped, _ = analyzeIdleWorktree(repoRoot, worktree, skipped)
+	worktree, skipped, _ = analyzeIdleWorktree(defaultRef, worktree, skipped)
 	return worktree, skipped
 }
 
-func analyzeIdleWorktree(repoRoot string, worktree PruneWorktree, skipped PruneSkipped) (PruneWorktree, PruneSkipped, bool) {
+func analyzeIdleWorktree(defaultRef string, worktree PruneWorktree, skipped PruneSkipped) (PruneWorktree, PruneSkipped, bool) {
 	dirty, err := git.IsDirty(worktree.Path)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot check status: %v", err)
@@ -253,13 +257,13 @@ func analyzeIdleWorktree(repoRoot string, worktree PruneWorktree, skipped PruneS
 		return worktree, skipped, true
 	}
 
-	merged, ref, err := git.IsHeadMergedIntoDefault(repoRoot, worktree.Path)
+	merged, err := git.IsHeadMergedIntoRef(worktree.Path, defaultRef)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot prove HEAD is merged into default branch: %v", err)
 		return worktree, skipped, true
 	}
 	if !merged {
-		skipped.Reason = fmt.Sprintf("HEAD is not merged into %s", ref)
+		skipped.Reason = fmt.Sprintf("HEAD is not merged into %s", defaultRef)
 		return worktree, skipped, true
 	}
 

--- a/internal/process/detect.go
+++ b/internal/process/detect.go
@@ -39,6 +39,8 @@ func StartedAt(pid int32) (int64, bool) {
 	return startedAt, err == nil
 }
 
+// FindProcessesInWorktree returns processes whose current directory is the
+// worktree root or a descendant after absolute path and symlink resolution.
 func FindProcessesInWorktree(worktreePath string) ([]ProcessInfo, error) {
 	procs, err := process.Processes()
 	if err != nil {

--- a/internal/process/detect.go
+++ b/internal/process/detect.go
@@ -70,7 +70,7 @@ func FindProcessesInWorktree(worktreePath string) ([]ProcessInfo, error) {
 			continue
 		}
 
-		if !strings.HasPrefix(rel, "..") {
+		if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
 			name, _ := p.Name()
 			result = append(result, ProcessInfo{
 				PID:  p.Pid,

--- a/internal/process/detect_unix_test.go
+++ b/internal/process/detect_unix_test.go
@@ -50,3 +50,39 @@ func TestFindProcessesInWorktree_ResolvesSymlinks(t *testing.T) {
 			cmd.Process.Pid, linkDir, procs)
 	}
 }
+
+func TestFindProcessesInWorktree_IncludesDotDotPrefixedChild(t *testing.T) {
+	worktreeDir := t.TempDir()
+	childDir := filepath.Join(worktreeDir, "..cache")
+	if err := os.Mkdir(childDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sleep", "60")
+	cmd.Dir = childDir
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	procs, err := FindProcessesInWorktree(worktreeDir)
+	if err != nil {
+		t.Fatalf("FindProcessesInWorktree: %v", err)
+	}
+
+	var found bool
+	for _, p := range procs {
+		if int(p.PID) == cmd.Process.Pid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected to find pid %d in dot-dot-prefixed child, got %v", cmd.Process.Pid, procs)
+	}
+}


### PR DESCRIPTION
## Intent

Add a treehouse prune command to reclaim disk from stale worktrees in Treehouse's existing pool model. The command must be dry-run by default, list stale idle managed worktrees and reclaimable size, require an explicit --yes flag for deletion, and never remove worktrees that are in use, dirty, or contain commits not already merged into the default branch. It should fit existing Cobra command conventions, pool state locking and reservation patterns, hook behavior, output style, Windows compatibility rules, tests, README/docs, and release-please conventions, with no manual CHANGELOG edits and no agent co-author.

## What Changed

- Added a dry-run-by-default `treehouse prune` command that reports stale idle managed worktrees, reclaimable disk size, and deletes only with `--yes`.
- Implemented prune planning and deletion safeguards that skip in-use, dirty, locked, missing, and unmerged worktrees using refreshed default-branch merge checks and non-force worktree removal.
- Documented prune behavior and lifecycle hook effects, with focused E2E, pool, git, and process coverage for the new safety paths.

## Risk Assessment

⚠️ Medium: The remaining risk is mostly inherent to a destructive prune command that depends on git default-ref resolution, process detection, and state reservations, but I did not find a substantiated merge-blocking issue in the current diff.

## Testing

I inspected the change, ran targeted prune/pool/git/process tests and the full Go test suite, then captured reviewer-visible CLI evidence showing default dry-run, `--yes` deletion, hook execution only for deleted stale worktrees, and protection for dirty, unmerged, and in-use worktrees; after correcting one local harness cwd mistake, I removed its transient stale worktree metadata and confirmed the final worktree state was clean apart from the intentional evidence file.

- Evidence: [Prune CLI end-to-end transcript](https://github.com/kunchenguid/treehouse/blob/31ce940bf4eb8a63bfa247d092a7cc0da513c515/.no-mistakes/evidence/fm/th-prune-cmd-p8/prune-cli-e2e-transcript.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (5) ✅</summary>

- 🚨 `internal/pool/prune.go:242` - `prune --yes` relies on `git.IsDirty`, which runs `git status --porcelain` without forcing untracked-file reporting. If repo or user config sets `status.showUntrackedFiles=no`, an idle worktree with untracked files is treated as clean and can be deleted. Force untracked detection for this safety check, for example with `--untracked-files=all`.
- ⚠️ `cmd/prune.go:45` - Prune checks merge safety against `origin/&lt;default&gt;` when origin exists, but the command never fetches before planning or deleting. If the remote default branch was rewritten since the last fetch, a stale local `origin/&lt;default&gt;` can make an unmerged HEAD look safe and `--yes` can remove it. Refresh origin before the prune safety analysis and fail closed if it cannot be refreshed.
- ℹ️ `README.md:187` - The implementation runs `pre_destroy` hooks before pruning, but the hook docs still say this hook only runs for `destroy` and `destroy --all`. Mention `prune --yes` here so users are not surprised by hook side effects during prune.

🔧 Fix: Harden prune deletion safety
2 issues (1 error, 1 warning) still open:
- 🚨 `internal/pool/prune.go:171` - `git.RemoveWorktree` runs `git worktree remove --force`, so prune bypasses Git&#39;s final clean/locked-worktree protection at deletion time. Use a prune-specific non-force remove and treat Git&#39;s dirty or locked rejection as a skip.
- ⚠️ `internal/git/git.go:161` - Prune refreshes branch tips with a plain fetch, but the merge-safety check still trusts the local `origin/HEAD` default branch. If the remote default branch was renamed or deleted, this can validate against stale `origin/&lt;old-default&gt;` and prune a HEAD not merged into the current default. Refresh/prune the remote default ref or resolve it from the remote and fail closed when unavailable.

🔧 Fix: Harden prune deletion safety
2 warnings still open:
- ⚠️ `cmd/prune.go:18` - The new `prune` command has no positional-argument validator, so `treehouse prune /some/path --yes` silently ignores the path and prunes every stale worktree in the pool. Add `Args: cobra.NoArgs` so accidental or misunderstood arguments fail before deletion.
- ⚠️ `internal/pool/prune.go:35` - `Prune` refreshes origin and resolves the default branch before reading pool state, so an empty pool, or a pool with only in-use worktrees, can fail when origin is offline or has no resolvable HEAD even though no merge-safety analysis or deletion is needed. Snapshot the pool first and return early, or postpone the fetch/default-ref lookup until there is an idle candidate that actually needs ancestry validation.

🔧 Fix: Harden prune argument and origin handling
2 issues (1 error, 1 warning) still open:
- 🚨 `internal/git/git.go:165` - `DefaultBranchMergeRef` returns the shorthand `origin/&lt;branch&gt;` and the prune safety check passes that name to `git merge-base`. A local branch or tag named `origin/main`, or a stale remote-tracking ref left after the remote default is deleted, can make prune prove merge safety against the wrong commit and remove a HEAD that is not merged into the actual remote default. Verify/fetch the remote-advertised default branch and use an unambiguous full ref such as `refs/remotes/origin/&lt;branch&gt;`, or compare against the advertised HEAD SHA.
- ⚠️ `internal/pool/prune.go:269` - The final deletion gate relies on `process.IsWorktreeInUse`, whose path-boundary check treats any relative cwd starting with `..` as outside the worktree. A live process inside a valid tracked child like `&lt;worktree&gt;/..cache` is missed, so `prune --yes` can delete an in-use worktree. Tighten that helper to reject only `rel == &#34;..&#34;` or paths prefixed by `..` plus the path separator.

🔧 Fix: Harden prune safety checks
2 issues (1 error, 1 warning) still open:
- 🚨 `internal/git/git.go:180` - When there is no `origin`, `DefaultBranchMergeRef` still delegates to `branchRef`, which can return the shorthand `main` or a stale `refs/remotes/origin/main`. The prune merge check can then validate against a tag or stale remote-tracking ref instead of the actual local default branch and remove a worktree whose HEAD is not merged into `refs/heads/&lt;branch&gt;`. Return and verify the full local branch ref in this path.
- ⚠️ `internal/git/git.go:169` - The remote-default path parses only the branch name from `ls-remote --symref` and then trusts any existing local `refs/remotes/origin/&lt;branch&gt;`. Since `git fetch origin` does not prune deleted branches, a remote whose HEAD still points at a deleted default branch can leave prune checking a stale local ref. Require the advertised HEAD SHA and verify the local tracking ref matches it, or fail closed.

🔧 Fix: Harden prune default ref checks
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git status --short`
- `git diff --stat 7f8e436b972af8e1de57b7859c3eade45713a2bd..e3a58a5801100f0f4870202104100f76e4e2f2e1`
- `rg -n "prune|Prune|stale|reclaim|merged" -S .`
- `go test ./cmd -run 'TestPrune' -count=1`
- `go test ./internal/pool -run 'TestPrune' -count=1`
- <code>`go test ./internal/git -run &#39;Test(DefaultBranchMergeRef|IsHeadMergedIntoRef)&#39; -count=1` (selector matched no tests)</code>
- <code>`go test ./internal/process -run &#39;TestIsWorktreeInUseDetectsSubprocessOnUnix&#39; -count=1` (selector matched no tests)</code>
- `rg -n "func Test" internal/git internal/process`
- `go test ./... -count=1`
- <code>Manual CLI evidence harness: built a temporary `treehouse` binary, created a disposable repo with fake `HOME` and user `pre_destroy` hook, then ran `treehouse get`, `treehouse prune`, `treehouse prune --yes`, and `treehouse status` to verify dry-run, deletion, hook, dirty, unmerged, and in-use behavior. Transcript written to `.no-mistakes/evidence/fm/th-prune-cmd-p8/prune-cli-e2e-transcript.md`.</code>
- <code>`git worktree prune --verbose &amp;&amp; git branch -D evidence-unmerged &amp;&amp; git worktree list --porcelain` (cleanup for an initial harness run that used the wrong cwd)</code>
- `go test ./internal/git -run 'TestRemoveCleanWorktreeRejectsDirtyWorktree' -count=1`
- `go test ./internal/process -run 'TestFindProcessesInWorktree' -count=1`
- <code>Final cleanup checks: `git status --short` and `git worktree list --porcelain`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
