### PR TITLE
feat(cmd): add global prune mode

### DIFF
--- a/.no-mistakes/evidence/fm/th-prune-global-g3/global-prune-cli-transcript.md
+++ b/.no-mistakes/evidence/fm/th-prune-global-g3/global-prune-cli-transcript.md
@@ -1,0 +1,121 @@
+# treehouse global prune CLI evidence
+
+This transcript uses a fake HOME under `.no-mistakes/tmp`, four real git repositories, and one non-managed directory under the treehouse root.
+Commands marked outside were run from `./.no-mistakes/tmp/global-prune-e2e/outside` with `GIT_CEILING_DIRECTORIES` set to the project root, so Git treats that directory as outside any repository while all writes stay inside the worktree.
+
+## Managed Worktrees Created
+
+- safe candidate: `~/.treehouse/safe-repo-7af752/1/safe-repo`
+- dirty skip: `~/.treehouse/dirty-repo-f6c3a9/1/dirty-repo`
+- unmerged skip: `~/.treehouse/unmerged-repo-1cd186/1/unmerged-repo`
+- in-use/reserved skip: `~/.treehouse/inuse-repo-16607a/1/inuse-repo`
+- non-managed directory: `~/.treehouse/not-managed-pool/1/not-managed`
+
+## Help Shows Opt-In Global Flags
+
+```console
+$ treehouse prune --help
+Remove stale idle worktrees from the pool to reclaim disk space.
+
+A worktree is stale only when treehouse manages it, no owner reservation or
+running process is using it, it has no uncommitted changes, and its HEAD is
+already merged into the default branch.
+
+Prune is a dry run by default. Pass --yes to delete the listed worktrees.
+Pass --all to sweep every pool under the treehouse root from any directory.
+
+Usage:
+  treehouse prune [flags]
+
+Flags:
+      --all      Prune stale worktrees across every pool under the treehouse root
+      --global   Alias for --all
+  -h, --help     help for prune
+      --yes      Delete stale worktrees instead of doing a dry run
+[exit 0]
+```
+
+## No Flag Still Requires A Git Repository
+
+```console
+$ cd ./.no-mistakes/tmp/global-prune-e2e/outside
+$ treehouse prune
+not in a git repository: git rev-parse --show-toplevel: fatal: not a git repository (or any of the parent directories): .git
+[exit 1]
+```
+
+## Global Dry Run Works From Outside A Repo
+
+```console
+$ cd ./.no-mistakes/tmp/global-prune-e2e/outside
+$ treehouse prune --all
+🌳 Dry run: would prune 1 stale worktree across 4 pools and reclaim 401 B.
+1     401 B  ~/.treehouse/safe-repo-7af752/1/safe-repo
+🌳 Skipped 2 unsafe idle worktrees:
+1     uncommitted changes                               ~/.treehouse/dirty-repo-f6c3a9/1/dirty-repo
+1     HEAD is not merged into refs/remotes/origin/main  ~/.treehouse/unmerged-repo-1cd186/1/unmerged-repo
+🌳 Re-run with --all --yes to delete these worktrees.
+[exit 0]
+```
+
+## --global Alias Matches --all
+
+```console
+$ cd ./.no-mistakes/tmp/global-prune-e2e/outside
+$ treehouse prune --global
+🌳 Dry run: would prune 1 stale worktree across 4 pools and reclaim 401 B.
+1     401 B  ~/.treehouse/safe-repo-7af752/1/safe-repo
+🌳 Skipped 2 unsafe idle worktrees:
+1     uncommitted changes                               ~/.treehouse/dirty-repo-f6c3a9/1/dirty-repo
+1     HEAD is not merged into refs/remotes/origin/main  ~/.treehouse/unmerged-repo-1cd186/1/unmerged-repo
+🌳 Re-run with --all --yes to delete these worktrees.
+[exit 0]
+```
+
+## Repo-Scoped Prune Does Not Sweep Other Pools
+
+```console
+$ cd ./.no-mistakes/tmp/global-prune-e2e/repos/dirty-repo
+$ treehouse prune --yes
+🌳 No stale worktrees pruned.
+🌳 Skipped 1 unsafe idle worktree:
+1     uncommitted changes  ~/.treehouse/dirty-repo-f6c3a9/1/dirty-repo
+[exit 0]
+```
+
+safe_worktree_after_repo_scoped_dirty_prune=exists
+
+## In-Use Worktree Is Visible To Users
+
+```console
+$ cd ./.no-mistakes/tmp/global-prune-e2e/repos/inuse-repo
+$ treehouse status
+1     in-use       ~/.treehouse/inuse-repo-16607a/1/inuse-repo
+                   bash (42402), sleep (42422)
+[exit 0]
+```
+
+## Global --yes Deletes Only Safe Candidates
+
+```console
+$ cd ./.no-mistakes/tmp/global-prune-e2e/outside
+$ treehouse prune --all --yes
+🌳 Pruned 1 stale worktree across 4 pools and freed 401 B.
+1     401 B  ~/.treehouse/safe-repo-7af752/1/safe-repo
+🌳 Skipped 2 unsafe idle worktrees:
+1     uncommitted changes                               ~/.treehouse/dirty-repo-f6c3a9/1/dirty-repo
+1     HEAD is not merged into refs/remotes/origin/main  ~/.treehouse/unmerged-repo-1cd186/1/unmerged-repo
+[exit 0]
+```
+
+## Post-Prune State
+
+```text
+safe_after_global_yes=missing
+dirty_after_global_yes=exists
+unmerged_after_global_yes=exists
+inuse_after_global_yes=exists
+nonmanaged_after_global_yes=exists
+pre_destroy_hook_log:
+~/.treehouse/safe-repo-7af752/1/safe-repo
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ make test
 - In-use detection uses process scanning plus short-lived persisted owner reservations for lifecycle operations
 - Dirty checks include untracked files even when repository config hides them from normal `git status` output
 - Prune deletes only idle managed worktrees that are clean and whose HEAD is merged into the default branch; dry run is the default
+- Global prune enumerates managed pool directories under the treehouse root and derives each worktree's owning repository from git metadata instead of relying on the current directory
 - State file tracks pool membership and temporary owner/destroy reservations, not long-term usage status
 - Git operations shell out to `git` (go-git has incomplete worktree support)
 - Self-healing: stale state entries are auto-removed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ make test
 - In-use detection uses process scanning plus short-lived persisted owner reservations for lifecycle operations
 - Dirty checks include untracked files even when repository config hides them from normal `git status` output
 - Prune deletes only idle managed worktrees that are clean and whose HEAD is merged into the default branch; dry run is the default
-- Global prune enumerates managed pool directories under the treehouse root and derives each worktree's owning repository from git metadata instead of relying on the current directory
+- Global prune enumerates managed pool directories under the user-level treehouse root and derives each worktree's owning repository from git metadata instead of relying on the current directory
+- Global prune loads user-level config and hooks only because it can run without a repository context
 - State file tracks pool membership and temporary owner/destroy reservations, not long-term usage status
 - Git operations shell out to `git` (go-git has incomplete worktree support)
 - Self-healing: stale state entries are auto-removed
@@ -61,6 +62,10 @@ Place repo-safe settings in repo root `treehouse.toml` or user-level `~/.config/
 
 ```toml
 max_trees = 16
+
+# Optional worktree root.
+# Relative roots need a repo context; use an absolute user-level root for global prune.
+# root = "$HOME/worktrees"
 
 # User-level config only:
 [hooks]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 - **In-use detection** — treehouse scans running processes and short-lived owner reservations to determine which worktrees are in-use. Reservations are persisted only while `get`, `destroy`, and `prune` lifecycle work is running.
 - **Dirty detection** - treehouse treats tracked changes and untracked files as dirty, even when repository config hides untracked files from normal `git status` output.
 - **Safe pruning** - `treehouse prune` removes only idle managed worktrees whose HEAD is already merged into the default branch and whose working tree is clean.
+  `treehouse prune --all` applies the same safety checks across every repo pool under the treehouse root.
   It is a dry run unless you pass `--yes`.
 
 ## CLI Reference
@@ -143,7 +144,8 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 | `treehouse get`            | Acquire a worktree from the pool                     |
 | `treehouse status`         | Show pool status (highlights your current worktree)  |
 | `treehouse return [path]`  | Terminate lingering worktree processes and return it to the pool |
-| `treehouse prune`          | Dry-run removal of stale idle worktrees to reclaim disk space |
+| `treehouse prune`          | Dry-run removal of stale idle worktrees in the current repo pool |
+| `treehouse prune --all`    | Dry-run removal of stale idle worktrees across every repo pool |
 | `treehouse destroy [path]` | Remove a worktree from the pool                      |
 | `treehouse init`           | Create a default `treehouse.toml` config file        |
 | `treehouse update`         | Update treehouse to the latest version               |
@@ -154,6 +156,8 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 | --------- | --------- | --------------------------------- |
 | `return`  | `--force` | Clean, reset, and return without prompting |
 | `prune`   | `--yes`   | Delete stale idle worktrees instead of doing a dry run |
+| `prune`   | `--all`   | Sweep every repo pool under the treehouse root |
+| `prune`   | `--global` | Alias for `--all` |
 | `destroy` | `--force` | Force destroy even if in-use      |
 | `destroy` | `--all`   | Destroy all worktrees in the pool |
 
@@ -162,6 +166,11 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 `treehouse prune` is a dry run by default.
 It lists stale idle managed worktrees that would be deleted and shows the reclaimable disk space.
 Pass `treehouse prune --yes` to delete those worktrees.
+
+By default, prune only inspects the current repository's pool and must be run inside a git repo.
+Pass `treehouse prune --all` to inspect every pool under the treehouse root from any directory.
+Global prune still derives each worktree's owning repository from git metadata before fetching and checking merge safety.
+Pass `treehouse prune --all --yes` to delete only the globally safe candidates.
 
 Prune ignores worktrees that are currently in use or reserved by another lifecycle operation.
 It skips idle worktrees that are unsafe to remove and prints the skip reason, such as uncommitted tracked or untracked changes, or a HEAD commit that is not merged into the default branch.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ make install
 
 ## How It Works
 
-Treehouse manages a **pool of git worktrees** per repository, stored under `~/.treehouse/`.
+Treehouse manages a **pool of git worktrees** per repository, stored under the configured treehouse root.
+The default treehouse root is `~/.treehouse/`.
 
 ```
   treehouse
@@ -133,7 +134,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 - **In-use detection** — treehouse scans running processes and short-lived owner reservations to determine which worktrees are in-use. Reservations are persisted only while `get`, `destroy`, and `prune` lifecycle work is running.
 - **Dirty detection** - treehouse treats tracked changes and untracked files as dirty, even when repository config hides untracked files from normal `git status` output.
 - **Safe pruning** - `treehouse prune` removes only idle managed worktrees whose HEAD is already merged into the default branch and whose working tree is clean.
-  `treehouse prune --all` applies the same safety checks across every repo pool under the treehouse root.
+  `treehouse prune --all` applies the same safety checks across every managed pool under the user-level treehouse root.
   It is a dry run unless you pass `--yes`.
 
 ## CLI Reference
@@ -145,7 +146,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 | `treehouse status`         | Show pool status (highlights your current worktree)  |
 | `treehouse return [path]`  | Terminate lingering worktree processes and return it to the pool |
 | `treehouse prune`          | Dry-run removal of stale idle worktrees in the current repo pool |
-| `treehouse prune --all`    | Dry-run removal of stale idle worktrees across every repo pool |
+| `treehouse prune --all`    | Dry-run removal of stale idle worktrees across every managed pool |
 | `treehouse destroy [path]` | Remove a worktree from the pool                      |
 | `treehouse init`           | Create a default `treehouse.toml` config file        |
 | `treehouse update`         | Update treehouse to the latest version               |
@@ -156,7 +157,7 @@ Treehouse manages a **pool of git worktrees** per repository, stored under `~/.t
 | --------- | --------- | --------------------------------- |
 | `return`  | `--force` | Clean, reset, and return without prompting |
 | `prune`   | `--yes`   | Delete stale idle worktrees instead of doing a dry run |
-| `prune`   | `--all`   | Sweep every repo pool under the treehouse root |
+| `prune`   | `--all`   | Sweep every managed pool under the user-level treehouse root |
 | `prune`   | `--global` | Alias for `--all` |
 | `destroy` | `--force` | Force destroy even if in-use      |
 | `destroy` | `--all`   | Destroy all worktrees in the pool |
@@ -168,8 +169,8 @@ It lists stale idle managed worktrees that would be deleted and shows the reclai
 Pass `treehouse prune --yes` to delete those worktrees.
 
 By default, prune only inspects the current repository's pool and must be run inside a git repo.
-Pass `treehouse prune --all` to inspect every pool under the treehouse root from any directory.
-Global prune still derives each worktree's owning repository from git metadata before fetching and checking merge safety.
+Pass `treehouse prune --all` or `treehouse prune --global` to inspect every managed pool under the user-level treehouse root from any directory.
+Global prune reads the user-level config and hooks, derives each worktree's owning repository from git metadata, then fetches and checks merge safety against that repository.
 Pass `treehouse prune --all --yes` to delete only the globally safe candidates.
 
 Prune ignores worktrees that are currently in use or reserved by another lifecycle operation.
@@ -188,9 +189,16 @@ Create a repo config file with `treehouse init`, or add one manually:
 ```toml
 # Maximum number of worktrees in the pool
 max_trees = 16
+
+# Optional worktree root directory.
+# Empty uses $HOME/.treehouse.
+# Relative paths are resolved from the repo root for repo-scoped commands.
+# Use an absolute user-level root for treehouse prune --all.
+# root = "$HOME/worktrees"
 ```
 
 The repo-level config takes precedence for repo-safe settings.
+`treehouse prune --all` can run without a repository, so it uses only the user-level config and does not read per-repo `treehouse.toml` files while sweeping.
 If no config is found, the default pool size is 16.
 
 ### Hooks

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -142,6 +142,34 @@ func setupTestRepo(t *testing.T) (repoDir, homeDir string) {
 	return repoDir, homeDir
 }
 
+func setupTestRepoWithHome(t *testing.T, homeDir, repoName string) string {
+	t.Helper()
+
+	base := t.TempDir()
+	base, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bareDir := filepath.Join(base, repoName+"-remote.git")
+	repoDir := filepath.Join(base, repoName)
+
+	gitCmd(t, "", "init", "--bare", "--initial-branch=main", bareDir)
+	gitCmd(t, "", "init", "--initial-branch=main", repoDir)
+	gitCmd(t, repoDir, "config", "user.email", "test@test.com")
+	gitCmd(t, repoDir, "config", "user.name", "Test")
+	gitCmd(t, repoDir, "remote", "add", "origin", bareDir)
+
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repoDir, "add", ".")
+	gitCmd(t, repoDir, "commit", "-m", "initial commit")
+	gitCmd(t, repoDir, "push", "-u", "origin", "main")
+
+	return repoDir
+}
+
 // runTreehouse runs the treehouse binary as a subprocess with the given args.
 // HOME (or USERPROFILE on Windows) is set to homeDir so pool state is isolated.
 func runTreehouse(t *testing.T, repoDir, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
@@ -600,6 +628,111 @@ func TestPruneDryRunAndYes(t *testing.T) {
 	}
 	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
 		t.Fatalf("expected worktree to be removed after prune --yes, stat err: %v", err)
+	}
+}
+
+func TestPruneAllDryRunAndYesAcrossPoolsFromAnywhere(t *testing.T) {
+	repoA, homeDir := setupTestRepo(t)
+	repoB := setupTestRepoWithHome(t, homeDir, "otherrepo")
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErrA, code := runTreehouse(t, repoA, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo A get failed (code %d): %s", code, getErrA)
+	}
+	wtPathA := extractWorktreePath(getErrA, homeDir)
+	if wtPathA == "" {
+		t.Fatal("could not extract repo A worktree path")
+	}
+
+	_, getErrB, code := runTreehouse(t, repoB, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo B get failed (code %d): %s", code, getErrB)
+	}
+	wtPathB := extractWorktreePath(getErrB, homeDir)
+	if wtPathB == "" {
+		t.Fatal("could not extract repo B worktree path")
+	}
+
+	outsideDir := t.TempDir()
+	pruneOut, pruneErr, code := runTreehouseFromDir(t, repoA, outsideDir, homeDir, nil, "prune", "--all")
+	if code != 0 {
+		t.Fatalf("prune --all dry run failed from outside a repo (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "would prune 2 stale worktrees across 2 pools") {
+		t.Fatalf("expected global dry-run summary, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	for _, wtPath := range []string{wtPathA, wtPathB} {
+		prettyWtPath := "~" + wtPath[len(homeDir):]
+		if !strings.Contains(pruneOut, prettyWtPath) {
+			t.Fatalf("expected dry run to list %s, got:\n%s", prettyWtPath, pruneOut)
+		}
+		if _, err := os.Stat(wtPath); err != nil {
+			t.Fatalf("dry run removed worktree %s: %v", wtPath, err)
+		}
+	}
+
+	aliasOut, aliasErr, code := runTreehouseFromDir(t, repoA, outsideDir, homeDir, nil, "prune", "--global")
+	if code != 0 {
+		t.Fatalf("prune --global dry run failed from outside a repo (code %d): %s", code, aliasErr)
+	}
+	if !strings.Contains(aliasOut, "would prune 2 stale worktrees across 2 pools") {
+		t.Fatalf("expected --global alias to match --all, got stdout:\n%s\nstderr:\n%s", aliasOut, aliasErr)
+	}
+
+	pruneOut, pruneErr, code = runTreehouseFromDir(t, repoA, outsideDir, homeDir, nil, "prune", "--all", "--yes")
+	if code != 0 {
+		t.Fatalf("prune --all --yes failed from outside a repo (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "Pruned 2 stale worktrees across 2 pools") || !strings.Contains(pruneOut, "freed") {
+		t.Fatalf("expected global prune --yes summary, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	for _, wtPath := range []string{wtPathA, wtPathB} {
+		if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+			t.Fatalf("expected worktree to be removed after prune --all --yes, stat err: %v", err)
+		}
+	}
+}
+
+func TestPruneWithoutAllScopesToCurrentRepo(t *testing.T) {
+	repoA, homeDir := setupTestRepo(t)
+	repoB := setupTestRepoWithHome(t, homeDir, "otherrepo")
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErrA, code := runTreehouse(t, repoA, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo A get failed (code %d): %s", code, getErrA)
+	}
+	wtPathA := extractWorktreePath(getErrA, homeDir)
+	if wtPathA == "" {
+		t.Fatal("could not extract repo A worktree path")
+	}
+
+	_, getErrB, code := runTreehouse(t, repoB, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo B get failed (code %d): %s", code, getErrB)
+	}
+	wtPathB := extractWorktreePath(getErrB, homeDir)
+	if wtPathB == "" {
+		t.Fatal("could not extract repo B worktree path")
+	}
+
+	pruneOut, pruneErr, code := runTreehouse(t, repoA, homeDir, nil, "prune", "--yes")
+	if code != 0 {
+		t.Fatalf("repo-scoped prune --yes failed (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "Pruned 1 stale worktree") {
+		t.Fatalf("expected repo-scoped prune summary, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	prettyWtPathB := "~" + wtPathB[len(homeDir):]
+	if strings.Contains(pruneOut, prettyWtPathB) {
+		t.Fatalf("repo-scoped prune listed other repo worktree %s:\n%s", prettyWtPathB, pruneOut)
+	}
+	if _, err := os.Stat(wtPathA); !os.IsNotExist(err) {
+		t.Fatalf("expected current repo worktree to be removed, stat err: %v", err)
+	}
+	if _, err := os.Stat(wtPathB); err != nil {
+		t.Fatalf("expected other repo worktree to remain: %v", err)
 	}
 }
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -694,6 +694,49 @@ func TestPruneAllDryRunAndYesAcrossPoolsFromAnywhere(t *testing.T) {
 	}
 }
 
+func TestPruneAllYesDoesNotPartiallyDeleteBeforePlanningAllPools(t *testing.T) {
+	repoA, homeDir := setupTestRepo(t)
+	repoB := setupTestRepoWithHome(t, homeDir, "zzrepo")
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErrA, code := runTreehouse(t, repoA, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo A get failed (code %d): %s", code, getErrA)
+	}
+	wtPathA := extractWorktreePath(getErrA, homeDir)
+	if wtPathA == "" {
+		t.Fatal("could not extract repo A worktree path")
+	}
+
+	_, getErrB, code := runTreehouse(t, repoB, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo B get failed (code %d): %s", code, getErrB)
+	}
+	wtPathB := extractWorktreePath(getErrB, homeDir)
+	if wtPathB == "" {
+		t.Fatal("could not extract repo B worktree path")
+	}
+
+	poolDirB := filepath.Dir(filepath.Dir(wtPathB))
+	if err := os.WriteFile(filepath.Join(poolDirB, "treehouse-state.json"), []byte("{"), 0o644); err != nil {
+		t.Fatalf("corrupt state failed: %v", err)
+	}
+
+	outsideDir := t.TempDir()
+	_, pruneErr, code := runTreehouseFromDir(t, repoA, outsideDir, homeDir, nil, "prune", "--all", "--yes")
+	if code == 0 {
+		t.Fatal("expected prune --all --yes to fail")
+	}
+	if !strings.Contains(pruneErr, "unexpected end of JSON input") {
+		t.Fatalf("expected corrupt state error, got stderr:\n%s", pruneErr)
+	}
+	for _, wtPath := range []string{wtPathA, wtPathB} {
+		if _, err := os.Stat(wtPath); err != nil {
+			t.Fatalf("expected worktree to remain at %s: %v", wtPath, err)
+		}
+	}
+}
+
 func TestPruneWithoutAllScopesToCurrentRepo(t *testing.T) {
 	repoA, homeDir := setupTestRepo(t)
 	repoB := setupTestRepoWithHome(t, homeDir, "otherrepo")

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -30,7 +30,10 @@ running process is using it, it has no uncommitted changes, and its HEAD is
 already merged into the default branch.
 
 Prune is a dry run by default. Pass --yes to delete the listed worktrees.
-Pass --all to sweep every pool under the treehouse root from any directory.`,
+Pass --all or --global to sweep every managed pool under the user-level
+treehouse root from any directory. Global prune derives each worktree's owning
+repository from git metadata and requires the configured root to be unset or
+absolute.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if pruneAll || pruneGlobal {
@@ -80,7 +83,7 @@ Pass --all to sweep every pool under the treehouse root from any directory.`,
 
 func init() {
 	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Delete stale worktrees instead of doing a dry run")
-	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Prune stale worktrees across every pool under the treehouse root")
+	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Prune stale worktrees across every managed pool under the user-level treehouse root")
 	pruneCmd.Flags().BoolVar(&pruneGlobal, "global", false, "Alias for --all")
 	rootCmd.AddCommand(pruneCmd)
 }

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -14,7 +14,11 @@ import (
 	"github.com/kunchenguid/treehouse/internal/ui"
 )
 
-var pruneYes bool
+var (
+	pruneYes    bool
+	pruneAll    bool
+	pruneGlobal bool
+)
 
 var pruneCmd = &cobra.Command{
 	Use:   "prune",
@@ -25,9 +29,30 @@ A worktree is stale only when treehouse manages it, no owner reservation or
 running process is using it, it has no uncommitted changes, and its HEAD is
 already merged into the default branch.
 
-Prune is a dry run by default. Pass --yes to delete the listed worktrees.`,
+Prune is a dry run by default. Pass --yes to delete the listed worktrees.
+Pass --all to sweep every pool under the treehouse root from any directory.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if pruneAll || pruneGlobal {
+			cfg, err := config.LoadGlobal()
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			poolRoot, err := config.ResolvePoolRoot("", cfg.Root)
+			if err != nil {
+				return err
+			}
+
+			result, err := pool.PruneAll(poolRoot, !pruneYes, cfg.Hooks.PreDestroy)
+			if err != nil {
+				return err
+			}
+
+			printPruneAllResult(os.Stdout, result, !pruneYes)
+			return nil
+		}
+
 		repoRoot, err := git.FindRepoRoot()
 		if err != nil {
 			return fmt.Errorf("not in a git repository: %w", err)
@@ -55,6 +80,8 @@ Prune is a dry run by default. Pass --yes to delete the listed worktrees.`,
 
 func init() {
 	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Delete stale worktrees instead of doing a dry run")
+	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Prune stale worktrees across every pool under the treehouse root")
+	pruneCmd.Flags().BoolVar(&pruneGlobal, "global", false, "Alias for --all")
 	rootCmd.AddCommand(pruneCmd)
 }
 
@@ -90,6 +117,45 @@ func printPruneResult(w io.Writer, result pool.PruneResult, dryRun bool) {
 	)
 	printPruneWorktrees(w, result.Pruned)
 	printPruneSkipped(w, result.Skipped)
+}
+
+func printPruneAllResult(w io.Writer, result pool.PruneAllResult, dryRun bool) {
+	poolCount := len(result.Pools)
+	if dryRun {
+		if len(result.Result.Candidates) == 0 {
+			fmt.Fprintf(w, "🌳 No stale worktrees to prune across %d %s.\n", poolCount, plural("pool", poolCount))
+			printPruneSkipped(w, result.Result.Skipped)
+			return
+		}
+
+		fmt.Fprintf(w, "🌳 Dry run: would prune %d stale %s across %d %s and reclaim %s.\n",
+			len(result.Result.Candidates),
+			plural("worktree", len(result.Result.Candidates)),
+			poolCount,
+			plural("pool", poolCount),
+			formatBytes(result.Result.ReclaimableBytes),
+		)
+		printPruneWorktrees(w, result.Result.Candidates)
+		printPruneSkipped(w, result.Result.Skipped)
+		fmt.Fprintln(w, "🌳 Re-run with --all --yes to delete these worktrees.")
+		return
+	}
+
+	if len(result.Result.Pruned) == 0 {
+		fmt.Fprintf(w, "🌳 No stale worktrees pruned across %d %s.\n", poolCount, plural("pool", poolCount))
+		printPruneSkipped(w, result.Result.Skipped)
+		return
+	}
+
+	fmt.Fprintf(w, "🌳 Pruned %d stale %s across %d %s and freed %s.\n",
+		len(result.Result.Pruned),
+		plural("worktree", len(result.Result.Pruned)),
+		poolCount,
+		plural("pool", poolCount),
+		formatBytes(result.Result.FreedBytes),
+	)
+	printPruneWorktrees(w, result.Result.Pruned)
+	printPruneSkipped(w, result.Result.Skipped)
 }
 
 func printPruneWorktrees(w io.Writer, worktrees []pool.PruneWorktree) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,9 @@ func Load(repoRoot string) (Config, error) {
 	return cfg, nil
 }
 
+// LoadGlobal returns the default configuration merged with user-level config.
+// It intentionally ignores repo-level config because callers may run without a
+// repository context.
 func LoadGlobal() (Config, error) {
 	cfg := DefaultConfig()
 	userCfg, hasUserConfig, err := loadUser()
@@ -100,6 +103,9 @@ func ResolvePoolDir(repoRoot string, root string) (string, error) {
 	return filepath.Join(poolRoot, poolName), nil
 }
 
+// ResolvePoolRoot resolves the directory that contains per-repository pools.
+// Relative roots require repoRoot because they are resolved from the repository
+// root.
 func ResolvePoolRoot(repoRoot string, root string) (string, error) {
 	if root == "" {
 		home, err := os.UserHomeDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -38,22 +39,46 @@ func Load(repoRoot string) (Config, error) {
 		cfg.Hooks = Hooks{}
 	}
 
-	if home, err := os.UserHomeDir(); err == nil {
-		userPath := filepath.Join(home, ".config", "treehouse", "config.toml")
-		if _, err := os.Stat(userPath); err == nil {
-			userCfg := DefaultConfig()
-			if _, err := toml.DecodeFile(userPath, &userCfg); err != nil {
-				return cfg, err
-			}
-			if !hasRepoConfig {
-				cfg = userCfg
-			} else {
-				cfg.Hooks = userCfg.Hooks
-			}
+	userCfg, hasUserConfig, err := loadUser()
+	if err != nil {
+		return cfg, err
+	}
+	if hasUserConfig {
+		if !hasRepoConfig {
+			cfg = userCfg
+		} else {
+			cfg.Hooks = userCfg.Hooks
 		}
 	}
 
 	return cfg, nil
+}
+
+func LoadGlobal() (Config, error) {
+	cfg := DefaultConfig()
+	userCfg, hasUserConfig, err := loadUser()
+	if err != nil {
+		return cfg, err
+	}
+	if hasUserConfig {
+		cfg = userCfg
+	}
+	return cfg, nil
+}
+
+func loadUser() (Config, bool, error) {
+	cfg := DefaultConfig()
+	if home, err := os.UserHomeDir(); err == nil {
+		userPath := filepath.Join(home, ".config", "treehouse", "config.toml")
+		if _, err := os.Stat(userPath); err == nil {
+			if _, err := toml.DecodeFile(userPath, &cfg); err != nil {
+				return cfg, false, err
+			}
+			return cfg, true, nil
+		}
+	}
+
+	return cfg, false, nil
 }
 
 func ResolvePoolDir(repoRoot string, root string) (string, error) {
@@ -68,17 +93,28 @@ func ResolvePoolDir(repoRoot string, root string) (string, error) {
 	shortHash := git.ShortHash(hashInput)
 	poolName := repoName + "-" + shortHash
 
+	poolRoot, err := ResolvePoolRoot(repoRoot, root)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(poolRoot, poolName), nil
+}
+
+func ResolvePoolRoot(repoRoot string, root string) (string, error) {
 	if root == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", err
 		}
-		return filepath.Join(home, ".treehouse", poolName), nil
+		return filepath.Join(home, ".treehouse"), nil
 	}
 
 	expanded := os.ExpandEnv(root)
 	if !filepath.IsAbs(expanded) {
+		if repoRoot == "" {
+			return "", fmt.Errorf("relative treehouse root %q requires a repository", root)
+		}
 		expanded = filepath.Join(repoRoot, expanded)
 	}
-	return filepath.Join(expanded, ".treehouse", poolName), nil
+	return filepath.Join(expanded, ".treehouse"), nil
 }

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -92,3 +92,26 @@ func TestResolvePoolDir_EnvVarExpansion(t *testing.T) {
 		t.Errorf("expected pool dir to start with %s, got %s", expected, poolDir)
 	}
 }
+
+func TestResolvePoolRoot_EmptyRoot(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	poolRoot, err := ResolvePoolRoot("", "")
+	if err != nil {
+		t.Fatalf("ResolvePoolRoot failed: %v", err)
+	}
+
+	expected := filepath.Join(home, ".treehouse")
+	if poolRoot != expected {
+		t.Fatalf("expected pool root %s, got %s", expected, poolRoot)
+	}
+}
+
+func TestResolvePoolRoot_RelativeRootRequiresRepo(t *testing.T) {
+	if _, err := ResolvePoolRoot("", ".worktrees"); err == nil {
+		t.Fatal("expected relative root without repo to fail")
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -16,6 +16,14 @@ func FindRepoRootFrom(dir string) (string, error) {
 	return runGit(dir, "rev-parse", "--show-toplevel")
 }
 
+func FindMainRepoRootFrom(dir string) (string, error) {
+	repoRoot, err := FindRepoRootFrom(dir)
+	if err != nil {
+		return "", err
+	}
+	return mainRepoRoot(repoRoot), nil
+}
+
 func GetDefaultBranch(repoRoot string) (string, error) {
 	mainRoot := mainRepoRoot(repoRoot)
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -16,6 +16,9 @@ func FindRepoRootFrom(dir string) (string, error) {
 	return runGit(dir, "rev-parse", "--show-toplevel")
 }
 
+// FindMainRepoRootFrom returns the main repository root for dir.
+// For linked worktrees, it resolves the worktree root back to the owning
+// repository.
 func FindMainRepoRootFrom(dir string) (string, error) {
 	repoRoot, err := FindRepoRootFrom(dir)
 	if err != nil {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -45,6 +45,34 @@ func TestGetDefaultBranchFromDetachedLinkedWorktreeUsesMainRepoHead(t *testing.T
 	}
 }
 
+func TestFindMainRepoRootFromLinkedWorktree(t *testing.T) {
+	base := t.TempDir()
+	base, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoDir := filepath.Join(base, "repo")
+	wtPath := filepath.Join(base, "worktree")
+
+	mustGit(t, "", "init", "--initial-branch=main", repoDir)
+	mustGit(t, repoDir, "config", "user.email", "test@test.com")
+	mustGit(t, repoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repoDir, "add", ".")
+	mustGit(t, repoDir, "commit", "-m", "initial")
+	mustGit(t, repoDir, "worktree", "add", "--detach", wtPath, "main")
+
+	mainRoot, err := FindMainRepoRootFrom(wtPath)
+	if err != nil {
+		t.Fatalf("FindMainRepoRootFrom failed: %v", err)
+	}
+	if mainRoot != repoDir {
+		t.Fatalf("expected main repo root %s, got %s", repoDir, mainRoot)
+	}
+}
+
 func TestRemoveCleanWorktreeRejectsDirtyWorktree(t *testing.T) {
 	base := t.TempDir()
 	repoDir := filepath.Join(base, "repo")

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -592,6 +592,115 @@ func TestPruneRemovesAvailableWorktree(t *testing.T) {
 	}
 }
 
+func TestPrunePoolDerivesRepoContextFromManagedWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Fatalf("restore cwd failed: %v", err)
+		}
+	})
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("Chdir failed: %v", err)
+	}
+
+	result, err := PrunePool(poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("PrunePool failed: %v", err)
+	}
+	if len(result.Pruned) != 1 || result.Pruned[0].Path != wtPath {
+		t.Fatalf("expected pruned worktree %s, got %#v", wtPath, result.Pruned)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected worktree to be removed, stat err: %v", err)
+	}
+}
+
+func TestPruneAllSkipsUnsafeWorktreesAcrossPools(t *testing.T) {
+	poolRoot := t.TempDir()
+
+	safeRepo, _ := setupRepo(t)
+	safePool := filepath.Join(poolRoot, "safe")
+	safePath, err := Acquire(safeRepo, safePool, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire safe failed: %v", err)
+	}
+	if err := Release(safePool, safePath); err != nil {
+		t.Fatalf("Release safe failed: %v", err)
+	}
+
+	dirtyRepo, _ := setupRepo(t)
+	dirtyPool := filepath.Join(poolRoot, "dirty")
+	dirtyPath, err := Acquire(dirtyRepo, dirtyPool, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire dirty failed: %v", err)
+	}
+	if err := Release(dirtyPool, dirtyPath); err != nil {
+		t.Fatalf("Release dirty failed: %v", err)
+	}
+	runGit(t, dirtyPath, "config", "status.showUntrackedFiles", "no")
+	if err := os.WriteFile(filepath.Join(dirtyPath, "untracked.txt"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile dirty failed: %v", err)
+	}
+
+	inUseRepo, _ := setupRepo(t)
+	inUsePool := filepath.Join(poolRoot, "in-use")
+	inUsePath, err := Acquire(inUseRepo, inUsePool, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire in-use failed: %v", err)
+	}
+
+	unmergedRepo, _ := setupRepo(t)
+	unmergedPool := filepath.Join(poolRoot, "unmerged")
+	unmergedPath, err := Acquire(unmergedRepo, unmergedPool, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire unmerged failed: %v", err)
+	}
+	if err := Release(unmergedPool, unmergedPath); err != nil {
+		t.Fatalf("Release unmerged failed: %v", err)
+	}
+	runGit(t, unmergedPath, "checkout", "-b", "unmerged-work")
+	if err := os.WriteFile(filepath.Join(unmergedPath, "README.md"), []byte("unmerged\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile unmerged failed: %v", err)
+	}
+	runGit(t, unmergedPath, "commit", "-am", "unmerged work")
+
+	result, err := PruneAll(poolRoot, false, nil)
+	if err != nil {
+		t.Fatalf("PruneAll failed: %v", err)
+	}
+	if len(result.Result.Pruned) != 1 || result.Result.Pruned[0].Path != safePath {
+		t.Fatalf("expected only safe worktree to be pruned, got %#v", result.Result.Pruned)
+	}
+	if !hasSkippedReason(result.Result.Skipped, dirtyPath, "uncommitted changes") {
+		t.Fatalf("expected dirty worktree skip, got %#v", result.Result.Skipped)
+	}
+	if !hasSkippedReason(result.Result.Skipped, unmergedPath, "not merged") {
+		t.Fatalf("expected unmerged worktree skip, got %#v", result.Result.Skipped)
+	}
+
+	if _, err := os.Stat(safePath); !os.IsNotExist(err) {
+		t.Fatalf("expected safe worktree to be removed, stat err: %v", err)
+	}
+	for _, path := range []string{dirtyPath, inUsePath, unmergedPath} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected unsafe worktree to remain at %s: %v", path, err)
+		}
+	}
+}
+
 func TestPruneInUseWorktreeDoesNotRequireOrigin(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/kunchenguid/treehouse/internal/git"
 	"github.com/kunchenguid/treehouse/internal/hooks"
@@ -35,25 +36,97 @@ type PruneResult struct {
 	FreedBytes       int64
 }
 
+type PrunePoolResult struct {
+	PoolDir string
+	Result  PruneResult
+}
+
+type PruneAllResult struct {
+	PoolRoot string
+	Pools    []PrunePoolResult
+	Result   PruneResult
+}
+
 // Prune finds stale idle managed worktrees and optionally deletes them.
 // A stale worktree is clean, unused, unreserved, and merged into the default
 // branch ref selected by git.DefaultBranchMergeRef.
 // In dryRun mode Prune reports candidates and reclaimable bytes without deleting.
 func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
+	return prunePool(poolDir, dryRun, preDestroy, singleRepoPruneContextResolver(repoRoot), false)
+}
+
+func PrunePool(poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
+	return prunePool(poolDir, dryRun, preDestroy, worktreePruneContextResolver(), true)
+}
+
+func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult, error) {
+	poolDirs, err := prunePoolDirs(poolRoot)
+	if err != nil {
+		return PruneAllResult{}, err
+	}
+
+	result := PruneAllResult{
+		PoolRoot: poolRoot,
+		Pools:    make([]PrunePoolResult, 0, len(poolDirs)),
+	}
+	for _, poolDir := range poolDirs {
+		poolResult, err := PrunePool(poolDir, dryRun, preDestroy)
+		if err != nil {
+			return PruneAllResult{}, err
+		}
+		result.Pools = append(result.Pools, PrunePoolResult{
+			PoolDir: poolDir,
+			Result:  poolResult,
+		})
+		result.Result.Candidates = append(result.Result.Candidates, poolResult.Candidates...)
+		result.Result.Pruned = append(result.Result.Pruned, poolResult.Pruned...)
+		result.Result.Skipped = append(result.Result.Skipped, poolResult.Skipped...)
+		result.Result.ReclaimableBytes += poolResult.ReclaimableBytes
+		result.Result.FreedBytes += poolResult.FreedBytes
+	}
+	return result, nil
+}
+
+func prunePool(poolDir string, dryRun bool, preDestroy []string, resolveContext pruneContextResolver, skipContextErrors bool) (PruneResult, error) {
 	entries, err := pruneSnapshot(poolDir)
 	if err != nil {
 		return PruneResult{}, err
 	}
 
-	plan, defaultRef, err := planPrune(repoRoot, entries)
+	plan, err := planPrune(entries, resolveContext, skipContextErrors)
 	if err != nil {
 		return PruneResult{}, err
 	}
-	if dryRun || len(plan.Candidates) == 0 {
-		return plan, nil
+	if dryRun || len(plan.Result.Candidates) == 0 {
+		return plan.Result, nil
 	}
 
-	return executePrune(repoRoot, poolDir, defaultRef, plan, preDestroy)
+	return executePrune(poolDir, plan, preDestroy)
+}
+
+func prunePoolDirs(poolRoot string) ([]string, error) {
+	entries, err := os.ReadDir(poolRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var poolDirs []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		poolDir := filepath.Join(poolRoot, entry.Name())
+		if _, err := os.Stat(stateFilePath(poolDir)); err == nil {
+			poolDirs = append(poolDirs, poolDir)
+		} else if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	sort.Strings(poolDirs)
+	return poolDirs, nil
 }
 
 func pruneSnapshot(poolDir string) ([]WorktreeEntry, error) {
@@ -75,37 +148,53 @@ func pruneSnapshot(poolDir string) ([]WorktreeEntry, error) {
 	return entries, err
 }
 
-func planPrune(repoRoot string, entries []WorktreeEntry) (PruneResult, string, error) {
-	var result PruneResult
-	var defaultRef string
-	resolveDefaultRef := func() (string, error) {
-		if defaultRef != "" {
-			return defaultRef, nil
-		}
-		ref, err := resolvePruneDefaultRef(repoRoot)
-		if err != nil {
-			return "", err
-		}
-		defaultRef = ref
-		return defaultRef, nil
-	}
+type pruneContext struct {
+	RepoRoot   string
+	DefaultRef string
+}
 
+type pruneContextResolver func(WorktreeEntry) (pruneContext, error)
+
+type plannedPruneWorktree struct {
+	Worktree PruneWorktree
+	Context  pruneContext
+}
+
+type prunePlan struct {
+	Result   PruneResult
+	Planned  map[string]plannedPruneWorktree
+	Reserved map[string]pruneContext
+}
+
+func planPrune(entries []WorktreeEntry, resolveContext pruneContextResolver, skipContextErrors bool) (prunePlan, error) {
+	plan := prunePlan{
+		Planned: make(map[string]plannedPruneWorktree),
+	}
 	for _, wt := range entries {
-		worktree, skipped, stale, err := analyzePruneCandidate(resolveDefaultRef, wt)
+		worktree, skipped, stale, context, err := analyzePruneCandidate(resolveContext, wt)
 		if err != nil {
-			return PruneResult{}, "", err
+			if skipContextErrors {
+				skipped.Reason = fmt.Sprintf("cannot resolve default branch: %v", err)
+				plan.Result.Skipped = append(plan.Result.Skipped, skipped)
+				continue
+			}
+			return prunePlan{}, err
 		}
 		if !stale {
 			continue
 		}
 		if skipped.Reason != "" {
-			result.Skipped = append(result.Skipped, skipped)
+			plan.Result.Skipped = append(plan.Result.Skipped, skipped)
 			continue
 		}
-		result.Candidates = append(result.Candidates, worktree)
-		result.ReclaimableBytes += worktree.Bytes
+		plan.Result.Candidates = append(plan.Result.Candidates, worktree)
+		plan.Result.ReclaimableBytes += worktree.Bytes
+		plan.Planned[worktree.Path] = plannedPruneWorktree{
+			Worktree: worktree,
+			Context:  context,
+		}
 	}
-	return result, defaultRef, nil
+	return plan, nil
 }
 
 func resolvePruneDefaultRef(repoRoot string) (string, error) {
@@ -119,14 +208,50 @@ func resolvePruneDefaultRef(repoRoot string) (string, error) {
 	return defaultRef, nil
 }
 
-func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDestroy []string) (PruneResult, error) {
-	result := PruneResult{
-		Skipped: append([]PruneSkipped(nil), plan.Skipped...),
+func singleRepoPruneContextResolver(repoRoot string) pruneContextResolver {
+	var defaultRef string
+	return func(WorktreeEntry) (pruneContext, error) {
+		if defaultRef == "" {
+			ref, err := resolvePruneDefaultRef(repoRoot)
+			if err != nil {
+				return pruneContext{}, err
+			}
+			defaultRef = ref
+		}
+		return pruneContext{RepoRoot: repoRoot, DefaultRef: defaultRef}, nil
 	}
+}
 
-	planned := make(map[string]PruneWorktree, len(plan.Candidates))
-	for _, wt := range plan.Candidates {
-		planned[wt.Path] = wt
+func worktreePruneContextResolver() pruneContextResolver {
+	contexts := make(map[string]pruneContext)
+	return func(wt WorktreeEntry) (pruneContext, error) {
+		repoRoot, err := git.FindMainRepoRootFrom(wt.Path)
+		if err != nil {
+			return pruneContext{}, fmt.Errorf("resolve repository for %s: %w", wt.Path, err)
+		}
+		if context, ok := contexts[repoRoot]; ok {
+			return context, nil
+		}
+
+		defaultRef, err := resolvePruneDefaultRef(repoRoot)
+		if err != nil {
+			return pruneContext{}, err
+		}
+		context := pruneContext{RepoRoot: repoRoot, DefaultRef: defaultRef}
+		contexts[repoRoot] = context
+		return context, nil
+	}
+}
+
+func fixedPruneContextResolver(context pruneContext) pruneContextResolver {
+	return func(WorktreeEntry) (pruneContext, error) {
+		return context, nil
+	}
+}
+
+func executePrune(poolDir string, plan prunePlan, preDestroy []string) (PruneResult, error) {
+	result := PruneResult{
+		Skipped: append([]PruneSkipped(nil), plan.Result.Skipped...),
 	}
 
 	var reserved []WorktreeEntry
@@ -138,12 +263,12 @@ func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDes
 		state = healState(state)
 
 		for i := range state.Worktrees {
-			plannedWorktree, ok := planned[state.Worktrees[i].Path]
+			plannedWorktree, ok := plan.Planned[state.Worktrees[i].Path]
 			if !ok {
 				continue
 			}
 
-			worktree, skipped, stale, err := analyzePruneCandidate(fixedPruneDefaultRef(defaultRef), state.Worktrees[i])
+			worktree, skipped, stale, context, err := analyzePruneCandidate(fixedPruneContextResolver(plannedWorktree.Context), state.Worktrees[i])
 			if err != nil {
 				return err
 			}
@@ -154,12 +279,16 @@ func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDes
 				result.Skipped = append(result.Skipped, skipped)
 				continue
 			}
-			worktree.Bytes = plannedWorktree.Bytes
+			worktree.Bytes = plannedWorktree.Worktree.Bytes
 			state.Worktrees[i].Destroying = true
 			if err := reserveOwner(&state.Worktrees[i]); err != nil {
 				return err
 			}
 			reserved = append(reserved, state.Worktrees[i])
+			if plan.Reserved == nil {
+				plan.Reserved = make(map[string]pruneContext)
+			}
+			plan.Reserved[state.Worktrees[i].Path] = context
 			result.Candidates = append(result.Candidates, worktree)
 			result.ReclaimableBytes += worktree.Bytes
 		}
@@ -192,7 +321,8 @@ func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDes
 				continue
 			}
 
-			worktree, skipped := finalPruneSafetyCheck(defaultRef, state.Worktrees[idx])
+			context := plan.Reserved[reservation.Path]
+			worktree, skipped := finalPruneSafetyCheck(context.DefaultRef, state.Worktrees[idx])
 			if skipped.Reason != "" {
 				clearReservation(&state.Worktrees[idx])
 				result.Skipped = append(result.Skipped, skipped)
@@ -200,12 +330,12 @@ func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDes
 			}
 
 			if worktree.Bytes == 0 {
-				if plannedWorktree, ok := planned[worktree.Path]; ok {
-					worktree.Bytes = plannedWorktree.Bytes
+				if plannedWorktree, ok := plan.Planned[worktree.Path]; ok {
+					worktree.Bytes = plannedWorktree.Worktree.Bytes
 				}
 			}
 
-			if err := git.RemoveCleanWorktree(repoRoot, worktree.Path); err != nil {
+			if err := git.RemoveCleanWorktree(context.RepoRoot, worktree.Path); err != nil {
 				clearReservation(&state.Worktrees[idx])
 				result.Skipped = append(result.Skipped, PruneSkipped{
 					Name:   worktree.Name,
@@ -244,30 +374,22 @@ func executePrune(repoRoot, poolDir, defaultRef string, plan PruneResult, preDes
 	return result, nil
 }
 
-type pruneRefResolver func() (string, error)
-
-func fixedPruneDefaultRef(defaultRef string) pruneRefResolver {
-	return func() (string, error) {
-		return defaultRef, nil
-	}
-}
-
-func analyzePruneCandidate(resolveDefaultRef pruneRefResolver, wt WorktreeEntry) (PruneWorktree, PruneSkipped, bool, error) {
+func analyzePruneCandidate(resolveContext pruneContextResolver, wt WorktreeEntry) (PruneWorktree, PruneSkipped, bool, pruneContext, error) {
 	worktree := PruneWorktree{Name: wt.Name, Path: wt.Path}
 	skipped := PruneSkipped{Name: wt.Name, Path: wt.Path}
 
 	if wt.Destroying || ownerAlive(wt) {
-		return worktree, skipped, false, nil
+		return worktree, skipped, false, pruneContext{}, nil
 	}
 	inUse, err := process.IsWorktreeInUse(wt.Path)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot check processes: %v", err)
-		return worktree, skipped, true, nil
+		return worktree, skipped, true, pruneContext{}, nil
 	}
 	if inUse {
-		return worktree, skipped, false, nil
+		return worktree, skipped, false, pruneContext{}, nil
 	}
-	return analyzeIdleWorktree(resolveDefaultRef, worktree, skipped)
+	return analyzeIdleWorktree(resolveContext, wt, worktree, skipped)
 }
 
 func finalPruneSafetyCheck(defaultRef string, wt WorktreeEntry) (PruneWorktree, PruneSkipped) {
@@ -283,46 +405,47 @@ func finalPruneSafetyCheck(defaultRef string, wt WorktreeEntry) (PruneWorktree, 
 		skipped.Reason = "in use"
 		return worktree, skipped
 	}
-	worktree, skipped, _, err = analyzeIdleWorktree(fixedPruneDefaultRef(defaultRef), worktree, skipped)
+	context := pruneContext{DefaultRef: defaultRef}
+	worktree, skipped, _, _, err = analyzeIdleWorktree(fixedPruneContextResolver(context), wt, worktree, skipped)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot prove HEAD is merged into default branch: %v", err)
 	}
 	return worktree, skipped
 }
 
-func analyzeIdleWorktree(resolveDefaultRef pruneRefResolver, worktree PruneWorktree, skipped PruneSkipped) (PruneWorktree, PruneSkipped, bool, error) {
+func analyzeIdleWorktree(resolveContext pruneContextResolver, wt WorktreeEntry, worktree PruneWorktree, skipped PruneSkipped) (PruneWorktree, PruneSkipped, bool, pruneContext, error) {
 	dirty, err := git.IsDirty(worktree.Path)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot check status: %v", err)
-		return worktree, skipped, true, nil
+		return worktree, skipped, true, pruneContext{}, nil
 	}
 	if dirty {
 		skipped.Reason = "uncommitted changes"
-		return worktree, skipped, true, nil
+		return worktree, skipped, true, pruneContext{}, nil
 	}
 
-	defaultRef, err := resolveDefaultRef()
+	context, err := resolveContext(wt)
 	if err != nil {
-		return worktree, skipped, true, err
+		return worktree, skipped, true, pruneContext{}, err
 	}
 
-	merged, err := git.IsHeadMergedIntoRef(worktree.Path, defaultRef)
+	merged, err := git.IsHeadMergedIntoRef(worktree.Path, context.DefaultRef)
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot prove HEAD is merged into default branch: %v", err)
-		return worktree, skipped, true, nil
+		return worktree, skipped, true, context, nil
 	}
 	if !merged {
-		skipped.Reason = fmt.Sprintf("HEAD is not merged into %s", defaultRef)
-		return worktree, skipped, true, nil
+		skipped.Reason = fmt.Sprintf("HEAD is not merged into %s", context.DefaultRef)
+		return worktree, skipped, true, context, nil
 	}
 
 	bytes, err := dirSize(filepath.Dir(worktree.Path))
 	if err != nil {
 		skipped.Reason = fmt.Sprintf("cannot measure size: %v", err)
-		return worktree, skipped, true, nil
+		return worktree, skipped, true, context, nil
 	}
 	worktree.Bytes = bytes
-	return worktree, skipped, true, nil
+	return worktree, skipped, true, context, nil
 }
 
 func clearReservation(wt *WorktreeEntry) {

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -47,6 +47,11 @@ type PruneAllResult struct {
 	Result   PruneResult
 }
 
+type plannedPrunePool struct {
+	PoolDir string
+	Plan    prunePlan
+}
+
 // Prune finds stale idle managed worktrees and optionally deletes them.
 // A stale worktree is clean, unused, unreserved, and merged into the default
 // branch ref selected by git.DefaultBranchMergeRef.
@@ -69,31 +74,55 @@ func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult
 		PoolRoot: poolRoot,
 		Pools:    make([]PrunePoolResult, 0, len(poolDirs)),
 	}
+	plans := make([]plannedPrunePool, 0, len(poolDirs))
+	resolveContext := worktreePruneContextResolver()
 	for _, poolDir := range poolDirs {
-		poolResult, err := PrunePool(poolDir, dryRun, preDestroy)
+		plan, err := planPrunePool(poolDir, resolveContext, true)
 		if err != nil {
 			return PruneAllResult{}, err
 		}
-		result.Pools = append(result.Pools, PrunePoolResult{
+		plans = append(plans, plannedPrunePool{
 			PoolDir: poolDir,
-			Result:  poolResult,
+			Plan:    plan,
 		})
-		result.Result.Candidates = append(result.Result.Candidates, poolResult.Candidates...)
-		result.Result.Pruned = append(result.Result.Pruned, poolResult.Pruned...)
-		result.Result.Skipped = append(result.Result.Skipped, poolResult.Skipped...)
-		result.Result.ReclaimableBytes += poolResult.ReclaimableBytes
-		result.Result.FreedBytes += poolResult.FreedBytes
+		addPrunePoolResult(&result, poolDir, plan.Result)
 	}
-	return result, nil
+	if dryRun || len(result.Result.Candidates) == 0 {
+		return result, nil
+	}
+
+	executed := PruneAllResult{
+		PoolRoot: poolRoot,
+		Pools:    make([]PrunePoolResult, 0, len(plans)),
+	}
+	for _, planned := range plans {
+		poolResult := planned.Plan.Result
+		if len(planned.Plan.Result.Candidates) > 0 {
+			var err error
+			poolResult, err = executePrune(planned.PoolDir, planned.Plan, preDestroy)
+			if err != nil {
+				return PruneAllResult{}, err
+			}
+		}
+		addPrunePoolResult(&executed, planned.PoolDir, poolResult)
+	}
+	return executed, nil
+}
+
+func addPrunePoolResult(all *PruneAllResult, poolDir string, poolResult PruneResult) {
+	all.Pools = append(all.Pools, PrunePoolResult{
+		PoolDir: poolDir,
+		Result:  poolResult,
+	})
+	all.Result.Candidates = append(all.Result.Candidates, poolResult.Candidates...)
+	all.Result.Pruned = append(all.Result.Pruned, poolResult.Pruned...)
+	all.Result.Skipped = append(all.Result.Skipped, poolResult.Skipped...)
+	all.Result.ReclaimableBytes += poolResult.ReclaimableBytes
+	all.Result.FreedBytes += poolResult.FreedBytes
 }
 
 func prunePool(poolDir string, dryRun bool, preDestroy []string, resolveContext pruneContextResolver, skipContextErrors bool) (PruneResult, error) {
-	entries, err := pruneSnapshot(poolDir)
-	if err != nil {
-		return PruneResult{}, err
-	}
-
-	plan, err := planPrune(entries, resolveContext, skipContextErrors)
+	plan, err := planPrunePool(poolDir, resolveContext, skipContextErrors)
 	if err != nil {
 		return PruneResult{}, err
 	}
@@ -102,6 +131,14 @@ func prunePool(poolDir string, dryRun bool, preDestroy []string, resolveContext 
 	}
 
 	return executePrune(poolDir, plan, preDestroy)
+}
+
+func planPrunePool(poolDir string, resolveContext pruneContextResolver, skipContextErrors bool) (prunePlan, error) {
+	entries, err := pruneSnapshot(poolDir)
+	if err != nil {
+		return prunePlan{}, err
+	}
+	return planPrune(entries, resolveContext, skipContextErrors)
 }
 
 func prunePoolDirs(poolRoot string) ([]string, error) {

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -36,11 +36,13 @@ type PruneResult struct {
 	FreedBytes       int64
 }
 
+// PrunePoolResult records the prune result for one managed pool directory.
 type PrunePoolResult struct {
 	PoolDir string
 	Result  PruneResult
 }
 
+// PruneAllResult records per-pool and aggregate prune results under a pool root.
 type PruneAllResult struct {
 	PoolRoot string
 	Pools    []PrunePoolResult
@@ -60,10 +62,17 @@ func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneRes
 	return prunePool(poolDir, dryRun, preDestroy, singleRepoPruneContextResolver(repoRoot), false)
 }
 
+// PrunePool prunes one pool by deriving each worktree's repository context from
+// git metadata.
+// Worktrees whose repository or default branch cannot be resolved are reported
+// as skipped.
 func PrunePool(poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
 	return prunePool(poolDir, dryRun, preDestroy, worktreePruneContextResolver(), true)
 }
 
+// PruneAll prunes every managed pool directly under poolRoot and aggregates the
+// results.
+// When dryRun is false, all pools are planned before any worktree is deleted.
 func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult, error) {
 	poolDirs, err := prunePoolDirs(poolRoot)
 	if err != nil {


### PR DESCRIPTION
## Intent

Add an opt-in global mode to treehouse prune so one invocation can sweep every managed repo pool under the treehouse root from any directory, while preserving the existing no-flag current-repo behavior. The global mode must not require being inside a git repo; it must discover pool directories, derive each worktree's owning repo/default branch from git metadata, keep all prune safety guarantees for dirty, in-use, reserved, unmerged, or non-managed worktrees, preserve dry-run by default and --yes deletion, aggregate output across pools, honor user-level config/hooks, remain Windows-compatible, update docs/help, and include tests proving multi-pool pruning, global safety skips, and default scoping.

## What Changed

- Added `treehouse prune --all` / `--global` to discover and prune managed pools under the Treehouse root from any directory while preserving repo-scoped pruning by default.
- Updated global prune planning so all pools are inspected before any destructive `--yes` deletion, with aggregated output across pools and user-level config/hooks for non-repo execution.
- Added coverage for multi-pool pruning, default scoping, config resolution, git metadata helpers, and safety skips for dirty, unmerged, unsafe, or non-managed worktrees.

## Risk Assessment

✅ Low: The change is well-bounded to prune/config/docs/tests, preserves existing single-repo behavior, and the new global path keeps the prune safety checks before deletion.

## Testing

Inspected the committed diff and status, ran focused prune tests plus the full Go suite, then captured a product-level CLI transcript showing help flags, no-flag non-repo failure, global dry-run and `--global` alias from a non-repo cwd, repo-scoped prune isolation, in-use status, global `--yes` deleting only the safe candidate, dirty/unmerged/in-use/non-managed preservation, and user-level `pre_destroy` hook execution; all checks passed and transient test files were removed.

- Evidence: [Global prune CLI evidence transcript](https://github.com/kunchenguid/treehouse/blob/1b3e11fa216914c645f1149e38b5a436c37f629b/.no-mistakes/evidence/fm/th-prune-global-g3/global-prune-cli-transcript.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/pool/prune.go:73` - `PruneAll` plans and executes each pool before reading the next one, so `treehouse prune --all --yes` can delete candidates from earlier pools and then return an error on a later pool, such as a corrupt state file, without printing the partial deletion summary. Make global prune do an all-pools planning pass before destructive execution, or return and print partial results alongside the error.

🔧 Fix: Plan global prune before deletes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short` plus `git diff --stat ba289d0b5b28d1576ef3fbd9cc52378442880efa..2b445d9223cd6b9c11321958710fc50c92ca7952` and `git diff --name-only ba289d0b5b28d1576ef3fbd9cc52378442880efa..2b445d9223cd6b9c11321958710fc50c92ca7952` to understand scope before testing.</code>
- `go test ./cmd -run 'TestPrune(AllDryRunAndYesAcrossPoolsFromAnywhere|AllYesDoesNotPartiallyDeleteBeforePlanningAllPools|WithoutAllScopesToCurrentRepo)$'`
- `go test ./internal/pool -run 'TestPrune(AllSkipsUnsafeWorktreesAcrossPools|PoolDerivesRepoContextFromManagedWorktree|SkipsDirtyWorktree|SkipsUnmergedCommit|FailsClosedWhenRemoteDefaultTrackingRefIsStale)$'`
- `go test ./internal/config ./internal/git`
- `go test ./...`
- <code>Manual CLI evidence scenario: built `treehouse`, created four real git repos under a fake HOME, ran `treehouse get`, `treehouse prune`, `treehouse prune --all`, `treehouse prune --global`, repo-scoped `treehouse prune --yes`, `treehouse status`, and `treehouse prune --all --yes` with `GIT_CEILING_DIRECTORIES=$PWD`; saved the transcript to `.no-mistakes/evidence/fm/th-prune-global-g3/global-prune-cli-transcript.md`.</code>
- <code>Cleanup and sanity check: `rm -rf .no-mistakes/tmp`, then `git status --short` confirmed only the intended evidence directory remains.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
