### PR TITLE
feat(pool): classify orphaned worktrees during prune

### DIFF
--- a/.no-mistakes/evidence/fm/th-orphan-prune-o6/prune-orphan-unreachable-transcript.txt
+++ b/.no-mistakes/evidence/fm/th-orphan-prune-o6/prune-orphan-unreachable-transcript.txt
@@ -1,0 +1,77 @@
+Treehouse prune orphan and unverifiable worktree CLI transcript
+Workspace: /Users/kunchen/.no-mistakes/worktrees/8c0b202f5740/01KVHZB97RVQYFQSYS0ZGD1YY7
+
+Scenario 1: true backing-repository-missing orphan
+
+$ cd case-orphan/myrepo && treehouse get
+🌳 Setting up worktree...
+🌳 Entered worktree at ~/.treehouse/myrepo-f9065e/1/myrepo. Type 'exit' to return.
+🌳 Worktree returned to pool.
+
+$ cd case-orphan/myrepo && treehouse get # first worktree is dirty, so a second managed worktree is created
+🌳 Setting up worktree...
+🌳 Entered worktree at ~/.treehouse/myrepo-f9065e/2/myrepo. Type 'exit' to return.
+🌳 Worktree returned to pool.
+
+Prepared clean stale worktree: /Users/kunchen/.no-mistakes/worktrees/8c0b202f5740/01KVHZB97RVQYFQSYS0ZGD1YY7/.no-mistakes/tmp/prune-orphan-e2e/case-orphan/myrepo/.home/.treehouse/myrepo-f9065e/1/myrepo
+Prepared true orphan: /Users/kunchen/.no-mistakes/worktrees/8c0b202f5740/01KVHZB97RVQYFQSYS0ZGD1YY7/.no-mistakes/tmp/prune-orphan-e2e/case-orphan/myrepo/.home/.treehouse/myrepo-f9065e/2/myrepo
+
+$ cd case-orphan/outside && treehouse prune --all
+🌳 Dry run: would prune 1 stale worktree across 1 pool and reclaim 391 B.
+1     391 B  ~/.treehouse/myrepo-f9065e/1/myrepo
+🌳 Skipped 1 unsafe idle worktree:
+  orphaned (backing repository missing):
+  2     content could not be verified  ~/.treehouse/myrepo-f9065e/2/myrepo
+🌳 Re-run with --all --yes to delete these worktrees.
+🌳 Re-run with --all --prune-orphans to include true orphans in the dry run; add --yes to delete them.
+
+$ cd case-orphan/outside && treehouse prune --all --yes
+🌳 Pruned 1 stale worktree across 1 pool and freed 391 B.
+1     391 B  ~/.treehouse/myrepo-f9065e/1/myrepo
+🌳 Skipped 1 unsafe idle worktree:
+  orphaned (backing repository missing):
+  2     content could not be verified  ~/.treehouse/myrepo-f9065e/2/myrepo
+🌳 Re-run with --all --prune-orphans --yes to delete true orphans whose backing repository is missing.
+
+verified: --yes pruned the stale worktree and left the orphan in place
+
+$ cd case-orphan/outside && treehouse prune --all --prune-orphans
+🌳 Dry run: would prune 1 stale/orphaned worktree across 1 pool and reclaim 392 B.
+2     392 B  ~/.treehouse/myrepo-f9065e/2/myrepo  content could not be verified
+🌳 Re-run with --all --prune-orphans --yes to delete these worktrees.
+
+$ cd case-orphan/outside && treehouse prune --all --prune-orphans --yes
+🌳 Pruned 1 stale/orphaned worktree across 1 pool and freed 392 B.
+2     392 B  ~/.treehouse/myrepo-f9065e/2/myrepo  content could not be verified
+
+verified: explicit --prune-orphans --yes removed the true orphan
+
+Scenario 2: origin unreachable is unverifiable, not deletable
+
+$ cd case-unreachable/myrepo && treehouse get
+🌳 Setting up worktree...
+🌳 Entered worktree at ~/.treehouse/myrepo-b7b084/1/myrepo. Type 'exit' to return.
+🌳 Worktree returned to pool.
+
+Prepared origin-unreachable worktree: /Users/kunchen/.no-mistakes/worktrees/8c0b202f5740/01KVHZB97RVQYFQSYS0ZGD1YY7/.no-mistakes/tmp/prune-orphan-e2e/case-unreachable/myrepo/.home/.treehouse/myrepo-b7b084/1/myrepo
+
+$ cd case-unreachable/outside && treehouse prune --all --prune-orphans --yes
+🌳 No stale worktrees pruned across 1 pool.
+🌳 Skipped 1 unsafe idle worktree:
+  origin unreachable (cannot verify):
+  1     cannot fetch origin  ~/.treehouse/myrepo-b7b084/1/myrepo
+
+verified: origin-unreachable worktree remains after --prune-orphans --yes
+
+$ cd case-unreachable/outside && treehouse prune --all --verbose
+🌳 No stale worktrees to prune across 1 pool.
+🌳 Skipped 1 unsafe idle worktree:
+  origin unreachable (cannot verify):
+  1     cannot fetch origin  ~/.treehouse/myrepo-b7b084/1/myrepo
+        detail: refresh origin before prune: git fetch origin: fatal: '/Users/kunchen/.no-mistakes/worktrees/8c0b202f5740/01KVHZB97RVQYFQSYS0ZGD1YY7/.no-mistakes/tmp/prune-orphan-e2e/case-unreachable/remote.git' does not appear to be a git repository
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists.
+
+verified: verbose output includes detailed diagnostics, while default output above stays grouped and actionable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,9 @@ make test
 - In-use detection uses process scanning plus short-lived persisted owner reservations for lifecycle operations
 - Dirty checks include untracked files even when repository config hides them from normal `git status` output
 - Prune deletes only idle managed worktrees that are clean and whose HEAD is merged into the default branch; dry run is the default
+- Prune reports unsafe idle worktrees in grouped, stable categories and keeps raw git diagnostics for verbose output instead of default output
+- Prune treats backing-repository-missing linked worktrees as orphans; they are only deletable with explicit `--prune-orphans --yes`, and each candidate warns that content could not be verified
+- Prune never treats an unreachable origin as a deletable orphan; those worktrees stay skipped because the repository may still be valid
 - Global prune enumerates managed pool directories under the user-level treehouse root and derives each worktree's owning repository from git metadata instead of relying on the current directory
 - Global prune loads user-level config and hooks only because it can run without a repository context
 - State file tracks pool membership and temporary owner/destroy reservations, not long-term usage status

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ The default treehouse root is `~/.treehouse/`.
 - **No daemon** — all operations are inline CLI commands. No background processes, no state to get corrupted.
 - **In-use detection** — treehouse scans running processes and short-lived owner reservations to determine which worktrees are in-use. Reservations are persisted only while `get`, `destroy`, and `prune` lifecycle work is running.
 - **Dirty detection** - treehouse treats tracked changes and untracked files as dirty, even when repository config hides untracked files from normal `git status` output.
-- **Safe pruning** - `treehouse prune` removes only idle managed worktrees whose HEAD is already merged into the default branch and whose working tree is clean.
+- **Safe pruning** - By default, `treehouse prune` removes only idle managed worktrees whose HEAD is already merged into the default branch and whose working tree is clean.
   `treehouse prune --all` applies the same safety checks across every managed pool under the user-level treehouse root.
-  Backing-repository-missing orphans are reported by default and require `--prune-orphans --yes` before deletion.
+  Backing-repository-missing orphans are reported by default; `--prune-orphans` includes them as unverified prune candidates, and `--yes` is required before deletion.
   It is a dry run unless you pass `--yes`.
 
 ## CLI Reference
@@ -157,24 +157,24 @@ The default treehouse root is `~/.treehouse/`.
 | Command   | Flag      | Description                       |
 | --------- | --------- | --------------------------------- |
 | `return`  | `--force` | Clean, reset, and return without prompting |
-| `prune`   | `--yes`   | Delete stale idle worktrees instead of doing a dry run |
+| `prune`   | `--yes`   | Delete listed prune candidates instead of doing a dry run |
 | `prune`   | `--all`   | Sweep every managed pool under the user-level treehouse root |
 | `prune`   | `--global` | Alias for `--all` |
 | `prune`   | `--prune-orphans` | Include backing-repository-missing orphans in prune candidates |
-| `prune`   | `--verbose` | Show detailed skip diagnostics |
+| `prune`   | `--verbose`, `-v` | Show detailed skip diagnostics |
 | `destroy` | `--force` | Force destroy even if in-use      |
 | `destroy` | `--all`   | Destroy all worktrees in the pool |
 
-### Pruning stale worktrees
+### Pruning stale worktrees and orphans
 
 `treehouse prune` is a dry run by default.
-It lists stale idle managed worktrees that would be deleted and shows the reclaimable disk space.
+By default, it lists stale idle managed worktrees that would be deleted and shows the reclaimable disk space.
 Pass `treehouse prune --yes` to delete those worktrees.
 
 By default, prune only inspects the current repository's pool and must be run inside a git repo.
 Pass `treehouse prune --all` or `treehouse prune --global` to inspect every managed pool under the user-level treehouse root from any directory.
 Global prune reads the user-level config and hooks, derives each worktree's owning repository from git metadata, then fetches and checks merge safety against that repository.
-Pass `treehouse prune --all --yes` to delete only the globally safe candidates.
+Without `--prune-orphans`, pass `treehouse prune --all --yes` to delete only the globally safe stale candidates.
 
 Prune ignores worktrees that are currently in use or reserved by another lifecycle operation.
 It skips idle worktrees that are unsafe to remove and prints the skip reason, such as uncommitted tracked or untracked changes, or a HEAD commit that is not merged into the default branch.
@@ -223,7 +223,7 @@ pre_destroy = ["./scripts/teardown.sh"]
 ```
 
 - `post_create` runs after a worktree is provisioned or reset and right before `treehouse get` hands it to you.
-- `pre_destroy` runs before a worktree is removed by `treehouse destroy`, `treehouse destroy --all`, or `treehouse prune --yes`.
+- `pre_destroy` runs before a worktree is removed by `treehouse destroy`, `treehouse destroy --all`, or prune deletion commands such as `treehouse prune --yes` and `treehouse prune --prune-orphans --yes`.
 
 Commands in each list run sequentially in the worktree directory, via the OS shell (`/bin/sh -c` on Linux/macOS, `%COMSPEC% /c` on Windows).
 If a command exits non-zero, treehouse logs the command, exit code, and stderr, then continues with the remaining commands.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The default treehouse root is `~/.treehouse/`.
 - **Dirty detection** - treehouse treats tracked changes and untracked files as dirty, even when repository config hides untracked files from normal `git status` output.
 - **Safe pruning** - `treehouse prune` removes only idle managed worktrees whose HEAD is already merged into the default branch and whose working tree is clean.
   `treehouse prune --all` applies the same safety checks across every managed pool under the user-level treehouse root.
+  Backing-repository-missing orphans are reported by default and require `--prune-orphans --yes` before deletion.
   It is a dry run unless you pass `--yes`.
 
 ## CLI Reference
@@ -159,6 +160,8 @@ The default treehouse root is `~/.treehouse/`.
 | `prune`   | `--yes`   | Delete stale idle worktrees instead of doing a dry run |
 | `prune`   | `--all`   | Sweep every managed pool under the user-level treehouse root |
 | `prune`   | `--global` | Alias for `--all` |
+| `prune`   | `--prune-orphans` | Include backing-repository-missing orphans in prune candidates |
+| `prune`   | `--verbose` | Show detailed skip diagnostics |
 | `destroy` | `--force` | Force destroy even if in-use      |
 | `destroy` | `--all`   | Destroy all worktrees in the pool |
 
@@ -175,8 +178,15 @@ Pass `treehouse prune --all --yes` to delete only the globally safe candidates.
 
 Prune ignores worktrees that are currently in use or reserved by another lifecycle operation.
 It skips idle worktrees that are unsafe to remove and prints the skip reason, such as uncommitted tracked or untracked changes, or a HEAD commit that is not merged into the default branch.
+Skip output is grouped by reason so large global sweeps stay scannable.
 When `origin` exists, prune fetches it and proves each HEAD against the current remote default branch tracking ref.
 Without `origin`, prune uses the local default branch ref.
+If `origin` cannot be reached, prune reports `origin unreachable (cannot verify)` and leaves the worktree untouched, even when `--prune-orphans` is set.
+If a linked worktree points at a missing backing repository, prune reports `orphaned (backing repository missing)`.
+Plain `treehouse prune` and `treehouse prune --all` never delete those orphans.
+Pass `--prune-orphans` to include true backing-repository-missing orphans in the dry run, then add `--yes` to delete them.
+Treehouse cannot verify orphan contents after the backing git metadata is gone, so each orphan candidate is marked `content could not be verified`.
+Use `--verbose` to show the underlying git diagnostic details for skipped worktrees.
 
 ## Configuration
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -285,6 +285,13 @@ func extractWorktreePath(stderr, homeDir string) string {
 	return path
 }
 
+func containsRawGitFailure(output string) bool {
+	return strings.Contains(output, "fatal:") ||
+		strings.Contains(output, "not a git repository") ||
+		strings.Contains(output, "Could not read from remote repository") ||
+		strings.Contains(output, "does not appear to be a git repository")
+}
+
 // --- Tests ---
 
 func TestInit(t *testing.T) {
@@ -691,6 +698,101 @@ func TestPruneAllDryRunAndYesAcrossPoolsFromAnywhere(t *testing.T) {
 		if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
 			t.Fatalf("expected worktree to be removed after prune --all --yes, stat err: %v", err)
 		}
+	}
+}
+
+func TestPruneAllReportsOrphanWithoutRawGitErrorsAndPrunesOnlyWithExplicitFlag(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+	if err := os.RemoveAll(repoDir); err != nil {
+		t.Fatalf("RemoveAll repo failed: %v", err)
+	}
+
+	outsideDir := t.TempDir()
+	pruneOut, pruneErr, code := runTreehouseFromDir(t, repoDir, outsideDir, homeDir, nil, "prune", "--all")
+	if code != 0 {
+		t.Fatalf("prune --all failed on orphan (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "orphaned (backing repository missing)") || !strings.Contains(pruneOut, "content could not be verified") {
+		t.Fatalf("expected clean orphan skip, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if containsRawGitFailure(pruneOut) || containsRawGitFailure(pruneErr) {
+		t.Fatalf("default orphan output leaked raw git failure, stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("plain prune removed orphan %s: %v", wtPath, err)
+	}
+
+	pruneOut, pruneErr, code = runTreehouseFromDir(t, repoDir, outsideDir, homeDir, nil, "prune", "--all", "--prune-orphans")
+	if code != 0 {
+		t.Fatalf("prune --all --prune-orphans failed on orphan dry run (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "would prune 1 stale/orphaned worktree") || !strings.Contains(pruneOut, "content could not be verified") {
+		t.Fatalf("expected orphan dry-run candidate, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("orphan dry run removed %s: %v", wtPath, err)
+	}
+
+	pruneOut, pruneErr, code = runTreehouseFromDir(t, repoDir, outsideDir, homeDir, nil, "prune", "--all", "--prune-orphans", "--yes")
+	if code != 0 {
+		t.Fatalf("prune --all --prune-orphans --yes failed (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "Pruned 1 stale/orphaned worktree") || !strings.Contains(pruneOut, "content could not be verified") {
+		t.Fatalf("expected orphan prune summary, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected orphan to be removed after explicit prune, stat err: %v", err)
+	}
+}
+
+func TestPruneAllDoesNotDeleteOriginUnreachableWithPruneOrphans(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+	remoteDir := filepath.Join(filepath.Dir(repoDir), "remote.git")
+	if err := os.RemoveAll(remoteDir); err != nil {
+		t.Fatalf("RemoveAll remote failed: %v", err)
+	}
+
+	outsideDir := t.TempDir()
+	pruneOut, pruneErr, code := runTreehouseFromDir(t, repoDir, outsideDir, homeDir, nil, "prune", "--all", "--prune-orphans", "--yes")
+	if code != 0 {
+		t.Fatalf("prune --all --prune-orphans --yes failed with unreachable origin (code %d): %s", code, pruneErr)
+	}
+	if !strings.Contains(pruneOut, "origin unreachable (cannot verify)") {
+		t.Fatalf("expected origin-unreachable skip, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if containsRawGitFailure(pruneOut) || containsRawGitFailure(pruneErr) {
+		t.Fatalf("default origin-unreachable output leaked raw git failure, stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("origin-unreachable worktree was removed: %v", err)
+	}
+
+	verboseOut, verboseErr, code := runTreehouseFromDir(t, repoDir, outsideDir, homeDir, nil, "prune", "--all", "--verbose")
+	if code != 0 {
+		t.Fatalf("prune --all --verbose failed with unreachable origin (code %d): %s", code, verboseErr)
+	}
+	if !strings.Contains(verboseOut, "detail: refresh origin before prune") {
+		t.Fatalf("expected verbose origin diagnostic detail, got stdout:\n%s\nstderr:\n%s", verboseOut, verboseErr)
 	}
 }
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -292,6 +292,66 @@ func containsRawGitFailure(output string) bool {
 		strings.Contains(output, "does not appear to be a git repository")
 }
 
+func setupMixedStaleAndOrphanedWorktrees(t *testing.T) (repoDir, homeDir, stalePath, orphanPath string) {
+	t.Helper()
+
+	repoDir, homeDir = setupTestRepo(t)
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("first get failed (code %d): %s", code, getErr)
+	}
+	stalePath = extractWorktreePath(getErr, homeDir)
+	if stalePath == "" {
+		t.Fatal("could not extract first worktree path")
+	}
+
+	dirtyPath := filepath.Join(stalePath, "dirty.txt")
+	if err := os.WriteFile(dirtyPath, []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, getErr, code = runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("second get failed (code %d): %s", code, getErr)
+	}
+	orphanPath = extractWorktreePath(getErr, homeDir)
+	if orphanPath == "" {
+		t.Fatal("could not extract second worktree path")
+	}
+	if orphanPath == stalePath {
+		t.Fatalf("expected dirty first worktree to force a second worktree, got %s", orphanPath)
+	}
+
+	if err := os.Remove(dirtyPath); err != nil {
+		t.Fatal(err)
+	}
+	removeWorktreeBackingGitDir(t, orphanPath)
+
+	return repoDir, homeDir, stalePath, orphanPath
+}
+
+func removeWorktreeBackingGitDir(t *testing.T, wtPath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(wtPath, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir: ")
+	if !ok {
+		t.Fatalf("expected linked worktree .git file, got %q", data)
+	}
+	gitDir = filepath.FromSlash(strings.TrimSpace(gitDir))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(wtPath, gitDir)
+	}
+	if err := os.RemoveAll(gitDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // --- Tests ---
 
 func TestInit(t *testing.T) {
@@ -698,6 +758,90 @@ func TestPruneAllDryRunAndYesAcrossPoolsFromAnywhere(t *testing.T) {
 		if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
 			t.Fatalf("expected worktree to be removed after prune --all --yes, stat err: %v", err)
 		}
+	}
+}
+
+func TestPruneMixedStaleAndSkippedOrphanPrintsOrphanHints(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		fromOutside  bool
+		removesStale bool
+		wants        []string
+	}{
+		{
+			name: "repo dry run",
+			args: []string{"prune"},
+			wants: []string{
+				"would prune 1 stale worktree",
+				"orphaned (backing repository missing)",
+				"Re-run with --yes to delete these worktrees.",
+				"Re-run with --prune-orphans to include true orphans in the dry run; add --yes to delete them.",
+			},
+		},
+		{
+			name:         "repo yes",
+			args:         []string{"prune", "--yes"},
+			removesStale: true,
+			wants: []string{
+				"Pruned 1 stale worktree",
+				"orphaned (backing repository missing)",
+				"Re-run with --prune-orphans --yes to delete true orphans whose backing repository is missing.",
+			},
+		},
+		{
+			name:        "global dry run",
+			args:        []string{"prune", "--all"},
+			fromOutside: true,
+			wants: []string{
+				"would prune 1 stale worktree across 1 pool",
+				"orphaned (backing repository missing)",
+				"Re-run with --all --yes to delete these worktrees.",
+				"Re-run with --all --prune-orphans to include true orphans in the dry run; add --yes to delete them.",
+			},
+		},
+		{
+			name:         "global yes",
+			args:         []string{"prune", "--all", "--yes"},
+			fromOutside:  true,
+			removesStale: true,
+			wants: []string{
+				"Pruned 1 stale worktree across 1 pool",
+				"orphaned (backing repository missing)",
+				"Re-run with --all --prune-orphans --yes to delete true orphans whose backing repository is missing.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir, homeDir, stalePath, orphanPath := setupMixedStaleAndOrphanedWorktrees(t)
+			workDir := repoDir
+			if tt.fromOutside {
+				workDir = t.TempDir()
+			}
+
+			pruneOut, pruneErr, code := runTreehouseFromDir(t, repoDir, workDir, homeDir, nil, tt.args...)
+			if code != 0 {
+				t.Fatalf("%s failed (code %d): %s", strings.Join(tt.args, " "), code, pruneErr)
+			}
+			for _, want := range tt.wants {
+				if !strings.Contains(pruneOut, want) {
+					t.Fatalf("expected %q in stdout:\n%s\nstderr:\n%s", want, pruneOut, pruneErr)
+				}
+			}
+
+			if tt.removesStale {
+				if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+					t.Fatalf("expected stale worktree to be removed, stat err: %v", err)
+				}
+			} else if _, err := os.Stat(stalePath); err != nil {
+				t.Fatalf("dry run removed worktree %s: %v", stalePath, err)
+			}
+			if _, err := os.Stat(orphanPath); err != nil {
+				t.Fatalf("%s removed orphan %s: %v", strings.Join(tt.args, " "), orphanPath, err)
+			}
+		})
 	}
 }
 

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -121,6 +121,7 @@ func printPruneResult(w io.Writer, result pool.PruneResult, dryRun bool, pruneOr
 		printPruneWorktrees(w, result.Candidates)
 		printPruneSkipped(w, result.Skipped, verbose)
 		fmt.Fprintf(w, "🌳 Re-run with %s to delete these worktrees.\n", pruneDeleteFlags(false, pruneOrphans))
+		printPruneOrphanHint(w, result.Skipped, false, pruneOrphans, false)
 		return
 	}
 
@@ -139,6 +140,7 @@ func printPruneResult(w io.Writer, result pool.PruneResult, dryRun bool, pruneOr
 	)
 	printPruneWorktrees(w, result.Pruned)
 	printPruneSkipped(w, result.Skipped, verbose)
+	printPruneOrphanHint(w, result.Skipped, false, pruneOrphans, true)
 }
 
 func printPruneAllResult(w io.Writer, result pool.PruneAllResult, dryRun bool, pruneOrphans bool, verbose bool) {
@@ -162,6 +164,7 @@ func printPruneAllResult(w io.Writer, result pool.PruneAllResult, dryRun bool, p
 		printPruneWorktrees(w, result.Result.Candidates)
 		printPruneSkipped(w, result.Result.Skipped, verbose)
 		fmt.Fprintf(w, "🌳 Re-run with %s to delete these worktrees.\n", pruneDeleteFlags(true, pruneOrphans))
+		printPruneOrphanHint(w, result.Result.Skipped, true, pruneOrphans, false)
 		return
 	}
 
@@ -182,6 +185,7 @@ func printPruneAllResult(w io.Writer, result pool.PruneAllResult, dryRun bool, p
 	)
 	printPruneWorktrees(w, result.Result.Pruned)
 	printPruneSkipped(w, result.Result.Skipped, verbose)
+	printPruneOrphanHint(w, result.Result.Skipped, true, pruneOrphans, true)
 }
 
 func printPruneWorktrees(w io.Writer, worktrees []pool.PruneWorktree) {

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -25,16 +25,17 @@ var (
 
 var pruneCmd = &cobra.Command{
 	Use:   "prune",
-	Short: "Remove stale idle worktrees from the pool",
-	Long: `Remove stale idle worktrees from the pool to reclaim disk space.
+	Short: "Remove stale worktrees and opted-in orphans from the pool",
+	Long: `Remove stale worktrees and opted-in orphans from the pool to reclaim disk space.
 
 A worktree is stale only when treehouse manages it, no owner reservation or
 running process is using it, it has no uncommitted changes, and its HEAD is
 already merged into the default branch.
 
-Prune is a dry run by default. Pass --yes to delete the listed worktrees.
-Backing-repository-missing orphans are reported by default but are only included
-for deletion when --prune-orphans is explicitly set.
+Prune is a dry run by default. Pass --yes to delete the listed candidates.
+Backing-repository-missing orphans are reported by default. Pass --prune-orphans
+to include them as unverified candidates, and combine it with --yes to delete
+them.
 Pass --all or --global to sweep every managed pool under the user-level
 treehouse root from any directory. Global prune derives each worktree's owning
 repository from git metadata and requires the configured root to be unset or
@@ -95,8 +96,8 @@ absolute.`,
 }
 
 func init() {
-	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Delete stale worktrees instead of doing a dry run")
-	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Prune stale worktrees across every managed pool under the user-level treehouse root")
+	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Delete listed prune candidates instead of doing a dry run")
+	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Sweep every managed pool under the user-level treehouse root")
 	pruneCmd.Flags().BoolVar(&pruneGlobal, "global", false, "Alias for --all")
 	pruneCmd.Flags().BoolVar(&pruneOrphans, "prune-orphans", false, "Include backing-repository-missing orphaned worktrees in prune candidates")
 	pruneCmd.Flags().BoolVarP(&pruneVerbose, "verbose", "v", false, "Show detailed skip diagnostics")

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -15,9 +16,11 @@ import (
 )
 
 var (
-	pruneYes    bool
-	pruneAll    bool
-	pruneGlobal bool
+	pruneYes     bool
+	pruneAll     bool
+	pruneGlobal  bool
+	pruneOrphans bool
+	pruneVerbose bool
 )
 
 var pruneCmd = &cobra.Command{
@@ -30,6 +33,8 @@ running process is using it, it has no uncommitted changes, and its HEAD is
 already merged into the default branch.
 
 Prune is a dry run by default. Pass --yes to delete the listed worktrees.
+Backing-repository-missing orphans are reported by default but are only included
+for deletion when --prune-orphans is explicitly set.
 Pass --all or --global to sweep every managed pool under the user-level
 treehouse root from any directory. Global prune derives each worktree's owning
 repository from git metadata and requires the configured root to be unset or
@@ -47,12 +52,16 @@ absolute.`,
 				return err
 			}
 
-			result, err := pool.PruneAll(poolRoot, !pruneYes, cfg.Hooks.PreDestroy)
+			result, err := pool.PruneAllWithOptions(poolRoot, pool.PruneOptions{
+				DryRun:       !pruneYes,
+				PruneOrphans: pruneOrphans,
+				PreDestroy:   cfg.Hooks.PreDestroy,
+			})
 			if err != nil {
 				return err
 			}
 
-			printPruneAllResult(os.Stdout, result, !pruneYes)
+			printPruneAllResult(os.Stdout, result, !pruneYes, pruneOrphans, pruneVerbose)
 			return nil
 		}
 
@@ -71,12 +80,16 @@ absolute.`,
 			return err
 		}
 
-		result, err := pool.Prune(repoRoot, poolDir, !pruneYes, cfg.Hooks.PreDestroy)
+		result, err := pool.PruneWithOptions(repoRoot, poolDir, pool.PruneOptions{
+			DryRun:       !pruneYes,
+			PruneOrphans: pruneOrphans,
+			PreDestroy:   cfg.Hooks.PreDestroy,
+		})
 		if err != nil {
 			return err
 		}
 
-		printPruneResult(os.Stdout, result, !pruneYes)
+		printPruneResult(os.Stdout, result, !pruneYes, pruneOrphans, pruneVerbose)
 		return nil
 	},
 }
@@ -85,80 +98,90 @@ func init() {
 	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Delete stale worktrees instead of doing a dry run")
 	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Prune stale worktrees across every managed pool under the user-level treehouse root")
 	pruneCmd.Flags().BoolVar(&pruneGlobal, "global", false, "Alias for --all")
+	pruneCmd.Flags().BoolVar(&pruneOrphans, "prune-orphans", false, "Include backing-repository-missing orphaned worktrees in prune candidates")
+	pruneCmd.Flags().BoolVarP(&pruneVerbose, "verbose", "v", false, "Show detailed skip diagnostics")
 	rootCmd.AddCommand(pruneCmd)
 }
 
-func printPruneResult(w io.Writer, result pool.PruneResult, dryRun bool) {
+func printPruneResult(w io.Writer, result pool.PruneResult, dryRun bool, pruneOrphans bool, verbose bool) {
 	if dryRun {
 		if len(result.Candidates) == 0 {
 			fmt.Fprintln(w, "🌳 No stale worktrees to prune.")
-			printPruneSkipped(w, result.Skipped)
+			printPruneSkipped(w, result.Skipped, verbose)
+			printPruneOrphanHint(w, result.Skipped, false, pruneOrphans, false)
 			return
 		}
 
-		fmt.Fprintf(w, "🌳 Dry run: would prune %d stale %s and reclaim %s.\n",
+		fmt.Fprintf(w, "🌳 Dry run: would prune %d %s %s and reclaim %s.\n",
 			len(result.Candidates),
+			pruneCandidateKind(result.Candidates),
 			plural("worktree", len(result.Candidates)),
 			formatBytes(result.ReclaimableBytes),
 		)
 		printPruneWorktrees(w, result.Candidates)
-		printPruneSkipped(w, result.Skipped)
-		fmt.Fprintln(w, "🌳 Re-run with --yes to delete these worktrees.")
+		printPruneSkipped(w, result.Skipped, verbose)
+		fmt.Fprintf(w, "🌳 Re-run with %s to delete these worktrees.\n", pruneDeleteFlags(false, pruneOrphans))
 		return
 	}
 
 	if len(result.Pruned) == 0 {
 		fmt.Fprintln(w, "🌳 No stale worktrees pruned.")
-		printPruneSkipped(w, result.Skipped)
+		printPruneSkipped(w, result.Skipped, verbose)
+		printPruneOrphanHint(w, result.Skipped, false, pruneOrphans, true)
 		return
 	}
 
-	fmt.Fprintf(w, "🌳 Pruned %d stale %s and freed %s.\n",
+	fmt.Fprintf(w, "🌳 Pruned %d %s %s and freed %s.\n",
 		len(result.Pruned),
+		pruneCandidateKind(result.Pruned),
 		plural("worktree", len(result.Pruned)),
 		formatBytes(result.FreedBytes),
 	)
 	printPruneWorktrees(w, result.Pruned)
-	printPruneSkipped(w, result.Skipped)
+	printPruneSkipped(w, result.Skipped, verbose)
 }
 
-func printPruneAllResult(w io.Writer, result pool.PruneAllResult, dryRun bool) {
+func printPruneAllResult(w io.Writer, result pool.PruneAllResult, dryRun bool, pruneOrphans bool, verbose bool) {
 	poolCount := len(result.Pools)
 	if dryRun {
 		if len(result.Result.Candidates) == 0 {
 			fmt.Fprintf(w, "🌳 No stale worktrees to prune across %d %s.\n", poolCount, plural("pool", poolCount))
-			printPruneSkipped(w, result.Result.Skipped)
+			printPruneSkipped(w, result.Result.Skipped, verbose)
+			printPruneOrphanHint(w, result.Result.Skipped, true, pruneOrphans, false)
 			return
 		}
 
-		fmt.Fprintf(w, "🌳 Dry run: would prune %d stale %s across %d %s and reclaim %s.\n",
+		fmt.Fprintf(w, "🌳 Dry run: would prune %d %s %s across %d %s and reclaim %s.\n",
 			len(result.Result.Candidates),
+			pruneCandidateKind(result.Result.Candidates),
 			plural("worktree", len(result.Result.Candidates)),
 			poolCount,
 			plural("pool", poolCount),
 			formatBytes(result.Result.ReclaimableBytes),
 		)
 		printPruneWorktrees(w, result.Result.Candidates)
-		printPruneSkipped(w, result.Result.Skipped)
-		fmt.Fprintln(w, "🌳 Re-run with --all --yes to delete these worktrees.")
+		printPruneSkipped(w, result.Result.Skipped, verbose)
+		fmt.Fprintf(w, "🌳 Re-run with %s to delete these worktrees.\n", pruneDeleteFlags(true, pruneOrphans))
 		return
 	}
 
 	if len(result.Result.Pruned) == 0 {
 		fmt.Fprintf(w, "🌳 No stale worktrees pruned across %d %s.\n", poolCount, plural("pool", poolCount))
-		printPruneSkipped(w, result.Result.Skipped)
+		printPruneSkipped(w, result.Result.Skipped, verbose)
+		printPruneOrphanHint(w, result.Result.Skipped, true, pruneOrphans, true)
 		return
 	}
 
-	fmt.Fprintf(w, "🌳 Pruned %d stale %s across %d %s and freed %s.\n",
+	fmt.Fprintf(w, "🌳 Pruned %d %s %s across %d %s and freed %s.\n",
 		len(result.Result.Pruned),
+		pruneCandidateKind(result.Result.Pruned),
 		plural("worktree", len(result.Result.Pruned)),
 		poolCount,
 		plural("pool", poolCount),
 		formatBytes(result.Result.FreedBytes),
 	)
 	printPruneWorktrees(w, result.Result.Pruned)
-	printPruneSkipped(w, result.Result.Skipped)
+	printPruneSkipped(w, result.Result.Skipped, verbose)
 }
 
 func printPruneWorktrees(w io.Writer, worktrees []pool.PruneWorktree) {
@@ -172,25 +195,136 @@ func printPruneWorktrees(w io.Writer, worktrees []pool.PruneWorktree) {
 	}
 
 	for i, wt := range worktrees {
-		fmt.Fprintf(w, "%-4s  %*s  %s\n", wt.Name, sizeWidth, sizes[i], ui.PrettyPath(wt.Path))
+		fmt.Fprintf(w, "%-4s  %*s  %s", wt.Name, sizeWidth, sizes[i], ui.PrettyPath(wt.Path))
+		if wt.Warning != "" {
+			fmt.Fprintf(w, "  %s", wt.Warning)
+		}
+		fmt.Fprintln(w)
 	}
 }
 
-func printPruneSkipped(w io.Writer, skipped []pool.PruneSkipped) {
+func printPruneSkipped(w io.Writer, skipped []pool.PruneSkipped, verbose bool) {
 	if len(skipped) == 0 {
 		return
 	}
 
 	fmt.Fprintf(w, "🌳 Skipped %d unsafe idle %s:\n", len(skipped), plural("worktree", len(skipped)))
-	reasonWidth := 0
-	for _, wt := range skipped {
-		if len(wt.Reason) > reasonWidth {
-			reasonWidth = len(wt.Reason)
+	for _, category := range orderedPruneSkipCategories(skipped) {
+		group := pruneSkipGroup(skipped, category)
+		fmt.Fprintf(w, "  %s:\n", category)
+		reasonWidth := 0
+		for _, wt := range group {
+			if pruneSkipShowsReason(wt) && len(wt.Reason) > reasonWidth {
+				reasonWidth = len(wt.Reason)
+			}
+		}
+		for _, wt := range group {
+			if pruneSkipShowsReason(wt) {
+				fmt.Fprintf(w, "  %-4s  %-*s  %s\n", wt.Name, reasonWidth, wt.Reason, ui.PrettyPath(wt.Path))
+			} else {
+				fmt.Fprintf(w, "  %-4s  %s\n", wt.Name, ui.PrettyPath(wt.Path))
+			}
+			if verbose && wt.Detail != "" {
+				fmt.Fprintf(w, "        detail: %s\n", wt.Detail)
+			}
 		}
 	}
-	for _, wt := range skipped {
-		fmt.Fprintf(w, "%-4s  %-*s  %s\n", wt.Name, reasonWidth, wt.Reason, ui.PrettyPath(wt.Path))
+}
+
+func pruneSkipShowsReason(wt pool.PruneSkipped) bool {
+	return wt.Reason != "" && wt.Reason != pruneSkipCategory(wt)
+}
+
+func pruneSkipCategory(wt pool.PruneSkipped) string {
+	if wt.Category != "" {
+		return wt.Category
 	}
+	if wt.Reason != "" {
+		return wt.Reason
+	}
+	return "cannot verify worktree"
+}
+
+func orderedPruneSkipCategories(skipped []pool.PruneSkipped) []string {
+	groups := make(map[string]struct{})
+	for _, wt := range skipped {
+		groups[pruneSkipCategory(wt)] = struct{}{}
+	}
+
+	preferred := []string{
+		pool.PruneSkipUncommitted,
+		pool.PruneSkipUnmerged,
+		pool.PruneSkipOrphanedBackingRepo,
+		pool.PruneSkipOriginUnreachable,
+	}
+	var ordered []string
+	for _, category := range preferred {
+		if _, ok := groups[category]; ok {
+			ordered = append(ordered, category)
+			delete(groups, category)
+		}
+	}
+	var remaining []string
+	for category := range groups {
+		remaining = append(remaining, category)
+	}
+	sort.Strings(remaining)
+	return append(ordered, remaining...)
+}
+
+func pruneSkipGroup(skipped []pool.PruneSkipped, category string) []pool.PruneSkipped {
+	var group []pool.PruneSkipped
+	for _, wt := range skipped {
+		if pruneSkipCategory(wt) == category {
+			group = append(group, wt)
+		}
+	}
+	return group
+}
+
+func pruneCandidateKind(worktrees []pool.PruneWorktree) string {
+	for _, wt := range worktrees {
+		if wt.Orphaned {
+			return "stale/orphaned"
+		}
+	}
+	return "stale"
+}
+
+func pruneDeleteFlags(all bool, pruneOrphans bool) string {
+	var flags []string
+	if all {
+		flags = append(flags, "--all")
+	}
+	if pruneOrphans {
+		flags = append(flags, "--prune-orphans")
+	}
+	flags = append(flags, "--yes")
+	return strings.Join(flags, " ")
+}
+
+func printPruneOrphanHint(w io.Writer, skipped []pool.PruneSkipped, all bool, pruneOrphans bool, yes bool) {
+	if pruneOrphans || !hasSkippedCategory(skipped, pool.PruneSkipOrphanedBackingRepo) {
+		return
+	}
+	if yes {
+		fmt.Fprintf(w, "🌳 Re-run with %s to delete true orphans whose backing repository is missing.\n", pruneDeleteFlags(all, true))
+		return
+	}
+	flags := "--prune-orphans"
+	if all {
+		flags = "--all --prune-orphans"
+	}
+	fmt.Fprintf(w, "🌳 Re-run with %s to include true orphans in the dry run; add --yes to delete them.\n", flags)
+}
+
+func hasSkippedCategory(skipped []pool.PruneSkipped, category string) bool {
+	for _, wt := range skipped {
+		if pruneSkipCategory(wt) == category {
+			return true
+		}
+	}
+	return false
 }
 
 func plural(word string, count int) string {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -628,6 +628,122 @@ func TestPrunePoolDerivesRepoContextFromManagedWorktree(t *testing.T) {
 	}
 }
 
+func TestPruneAllReportsBackingMissingOrphanWithoutDeletingByDefault(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+	if err := os.RemoveAll(repoDir); err != nil {
+		t.Fatalf("RemoveAll repo failed: %v", err)
+	}
+
+	result, err := PruneAllWithOptions(filepath.Dir(poolDir), PruneOptions{DryRun: false})
+	if err != nil {
+		t.Fatalf("PruneAll failed: %v", err)
+	}
+	if len(result.Result.Pruned) != 0 {
+		t.Fatalf("plain prune must not delete orphans, got %#v", result.Result.Pruned)
+	}
+	if !hasSkippedCategory(result.Result.Skipped, wtPath, PruneSkipOrphanedBackingRepo) {
+		t.Fatalf("expected orphan skip, got %#v", result.Result.Skipped)
+	}
+	if !hasSkippedReason(result.Result.Skipped, wtPath, pruneOrphanUnverifiedWarning) {
+		t.Fatalf("expected unverified-content warning, got %#v", result.Result.Skipped)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("plain prune removed orphan %s: %v", wtPath, err)
+	}
+}
+
+func TestPruneAllPrunesBackingMissingOrphanOnlyWithExplicitFlag(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+	if err := os.RemoveAll(repoDir); err != nil {
+		t.Fatalf("RemoveAll repo failed: %v", err)
+	}
+
+	result, err := PruneAllWithOptions(filepath.Dir(poolDir), PruneOptions{
+		DryRun:       true,
+		PruneOrphans: true,
+	})
+	if err != nil {
+		t.Fatalf("PruneAll dry run failed: %v", err)
+	}
+	if len(result.Result.Candidates) != 1 || result.Result.Candidates[0].Path != wtPath {
+		t.Fatalf("expected orphan dry-run candidate %s, got %#v", wtPath, result.Result.Candidates)
+	}
+	if !result.Result.Candidates[0].Orphaned || result.Result.Candidates[0].Warning != pruneOrphanUnverifiedWarning {
+		t.Fatalf("expected orphan warning on candidate, got %#v", result.Result.Candidates[0])
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("dry run removed orphan %s: %v", wtPath, err)
+	}
+
+	result, err = PruneAllWithOptions(filepath.Dir(poolDir), PruneOptions{PruneOrphans: true})
+	if err != nil {
+		t.Fatalf("PruneAll --prune-orphans failed: %v", err)
+	}
+	if len(result.Result.Pruned) != 1 || result.Result.Pruned[0].Path != wtPath {
+		t.Fatalf("expected pruned orphan %s, got %#v", wtPath, result.Result.Pruned)
+	}
+	if !result.Result.Pruned[0].Orphaned || result.Result.Pruned[0].Warning != pruneOrphanUnverifiedWarning {
+		t.Fatalf("expected orphan warning on pruned worktree, got %#v", result.Result.Pruned[0])
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected orphan worktree to be removed, stat err: %v", err)
+	}
+
+	state, err := ReadState(poolDir)
+	if err != nil {
+		t.Fatalf("ReadState failed: %v", err)
+	}
+	if len(state.Worktrees) != 0 {
+		t.Fatalf("expected pruned orphan to be removed from state, got %#v", state.Worktrees)
+	}
+}
+
+func TestPruneAllNeverDeletesOriginUnreachableWithPruneOrphans(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+	remoteDir := filepath.Join(filepath.Dir(repoDir), "remote.git")
+	if err := os.RemoveAll(remoteDir); err != nil {
+		t.Fatalf("RemoveAll remote failed: %v", err)
+	}
+
+	result, err := PruneAllWithOptions(filepath.Dir(poolDir), PruneOptions{PruneOrphans: true})
+	if err != nil {
+		t.Fatalf("PruneAll failed: %v", err)
+	}
+	if len(result.Result.Pruned) != 0 {
+		t.Fatalf("origin-unreachable worktree must not be pruned, got %#v", result.Result.Pruned)
+	}
+	if !hasSkippedCategory(result.Result.Skipped, wtPath, PruneSkipOriginUnreachable) {
+		t.Fatalf("expected origin-unreachable skip, got %#v", result.Result.Skipped)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("origin-unreachable worktree was removed: %v", err)
+	}
+}
+
 func TestPruneAllSkipsUnsafeWorktreesAcrossPools(t *testing.T) {
 	poolRoot := t.TempDir()
 
@@ -940,7 +1056,7 @@ func TestPruneIgnoresStaleOriginHeadWhenOriginIsAbsent(t *testing.T) {
 	}
 }
 
-func TestPruneFailsClosedWhenRemoteDefaultTrackingRefIsStale(t *testing.T) {
+func TestPruneSkipsWhenRemoteDefaultTrackingRefIsStale(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 
 	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
@@ -970,10 +1086,18 @@ func TestPruneFailsClosedWhenRemoteDefaultTrackingRefIsStale(t *testing.T) {
 	runGit(t, rewriteDir, "commit", "-m", "replacement")
 	runGit(t, rewriteDir, "push", "--force", "origin", "replacement:main")
 
-	if _, err := Prune(repoDir, poolDir, false, nil); err == nil {
-		t.Fatal("expected Prune to reject stale remote default tracking ref")
-	} else if !strings.Contains(err.Error(), "stale") {
-		t.Fatalf("expected stale remote default error, got %v", err)
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 0 {
+		t.Fatalf("stale remote default worktree must not be pruned, got %#v", result.Pruned)
+	}
+	if !hasSkippedCategory(result.Skipped, wtPath, pruneSkipCannotVerify) {
+		t.Fatalf("expected cannot-verify skip, got %#v", result.Skipped)
+	}
+	if !hasSkippedDetail(result.Skipped, wtPath, "stale") {
+		t.Fatalf("expected stale diagnostic detail, got %#v", result.Skipped)
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("expected stale remote default worktree to remain: %v", err)
@@ -1031,6 +1155,24 @@ func TestRelease_RejectsDestroyingWorktree(t *testing.T) {
 func hasSkippedReason(skipped []PruneSkipped, path, reason string) bool {
 	for _, wt := range skipped {
 		if wt.Path == path && strings.Contains(wt.Reason, reason) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSkippedCategory(skipped []PruneSkipped, path, category string) bool {
+	for _, wt := range skipped {
+		if wt.Path == path && wt.Category == category {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSkippedDetail(skipped []PruneSkipped, path, detail string) bool {
+	for _, wt := range skipped {
+		if wt.Path == path && strings.Contains(wt.Detail, detail) {
 			return true
 		}
 	}

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -14,22 +14,29 @@ import (
 	"github.com/kunchenguid/treehouse/internal/process"
 )
 
-// PruneWorktree describes a stale worktree that prune can remove or did remove.
+// PruneWorktree describes a stale or explicitly selected orphaned worktree that
+// prune can remove or did remove.
 type PruneWorktree struct {
-	Name     string
-	Path     string
-	Bytes    int64
+	Name  string
+	Path  string
+	Bytes int64
+	// Orphaned marks a backing-repository-missing worktree that was explicitly
+	// included by PruneOptions.PruneOrphans.
 	Orphaned bool
-	Warning  string
+	// Warning describes safety information that should be shown with the entry.
+	Warning string
 }
 
 // PruneSkipped describes a worktree that prune left in place for safety.
 type PruneSkipped struct {
-	Name     string
-	Path     string
+	Name string
+	Path string
+	// Category is the stable group label for prune skip reporting.
 	Category string
-	Reason   string
-	Detail   string
+	// Reason is the short user-facing explanation for this specific worktree.
+	Reason string
+	// Detail carries raw diagnostics intended for verbose output.
+	Detail string
 }
 
 // PruneResult describes dry-run candidates, removed worktrees, skipped worktrees,
@@ -55,16 +62,25 @@ type PruneAllResult struct {
 	Result   PruneResult
 }
 
+// PruneOptions controls dry-run, orphan, and hook behavior for prune operations.
 type PruneOptions struct {
-	DryRun       bool
+	// DryRun reports candidates and byte counts without deleting worktrees.
+	DryRun bool
+	// PruneOrphans includes backing-repository-missing linked worktrees as
+	// unverified prune candidates.
 	PruneOrphans bool
-	PreDestroy   []string
+	// PreDestroy is the hook command list to run before deleting each candidate.
+	PreDestroy []string
 }
 
 const (
-	PruneSkipUncommitted           = "uncommitted changes"
-	PruneSkipUnmerged              = "unmerged"
-	PruneSkipOrphanedBackingRepo   = "orphaned (backing repository missing)"
+	// PruneSkipUncommitted means a worktree has tracked or untracked changes.
+	PruneSkipUncommitted = "uncommitted changes"
+	// PruneSkipUnmerged means HEAD is not merged into the selected default ref.
+	PruneSkipUnmerged = "unmerged"
+	// PruneSkipOrphanedBackingRepo means the linked worktree's gitdir is gone.
+	PruneSkipOrphanedBackingRepo = "orphaned (backing repository missing)"
+	// PruneSkipOriginUnreachable means origin could not be reached for verification.
 	PruneSkipOriginUnreachable     = "origin unreachable (cannot verify)"
 	pruneSkipCannotVerify          = "cannot verify worktree"
 	pruneSkipCannotCheckProcesses  = "cannot check processes"
@@ -85,6 +101,8 @@ type plannedPrunePool struct {
 // A stale worktree is clean, unused, unreserved, and merged into the default
 // branch ref selected by git.DefaultBranchMergeRef.
 // In dryRun mode Prune reports candidates and reclaimable bytes without deleting.
+// Backing-repository-missing orphans are reported as skipped; use
+// PruneWithOptions with PruneOptions.PruneOrphans to include them as candidates.
 func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
 	return PruneWithOptions(repoRoot, poolDir, PruneOptions{
 		DryRun:     dryRun,
@@ -92,6 +110,8 @@ func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneRes
 	})
 }
 
+// PruneWithOptions finds prune candidates in one repository pool and applies
+// options for dry-run behavior, orphan handling, and pre-destroy hooks.
 func PruneWithOptions(repoRoot, poolDir string, options PruneOptions) (PruneResult, error) {
 	return prunePool(poolDir, options, singleRepoPruneContextResolver(repoRoot))
 }
@@ -100,6 +120,9 @@ func PruneWithOptions(repoRoot, poolDir string, options PruneOptions) (PruneResu
 // git metadata.
 // Worktrees whose repository or default branch cannot be resolved are reported
 // as skipped.
+// Backing-repository-missing orphans are reported as skipped; use
+// PrunePoolWithOptions with PruneOptions.PruneOrphans to include them as
+// candidates.
 func PrunePool(poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
 	return PrunePoolWithOptions(poolDir, PruneOptions{
 		DryRun:     dryRun,
@@ -107,6 +130,8 @@ func PrunePool(poolDir string, dryRun bool, preDestroy []string) (PruneResult, e
 	})
 }
 
+// PrunePoolWithOptions prunes one pool by deriving each worktree's repository
+// context from git metadata and applying the supplied options.
 func PrunePoolWithOptions(poolDir string, options PruneOptions) (PruneResult, error) {
 	return prunePool(poolDir, options, worktreePruneContextResolver())
 }
@@ -114,6 +139,9 @@ func PrunePoolWithOptions(poolDir string, options PruneOptions) (PruneResult, er
 // PruneAll prunes every managed pool directly under poolRoot and aggregates the
 // results.
 // When dryRun is false, all pools are planned before any worktree is deleted.
+// Backing-repository-missing orphans are reported as skipped; use
+// PruneAllWithOptions with PruneOptions.PruneOrphans to include them as
+// candidates.
 func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult, error) {
 	return PruneAllWithOptions(poolRoot, PruneOptions{
 		DryRun:     dryRun,
@@ -121,6 +149,8 @@ func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult
 	})
 }
 
+// PruneAllWithOptions prunes every managed pool directly under poolRoot and
+// applies options for dry-run behavior, orphan handling, and pre-destroy hooks.
 func PruneAllWithOptions(poolRoot string, options PruneOptions) (PruneAllResult, error) {
 	poolDirs, err := prunePoolDirs(poolRoot)
 	if err != nil {

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -1,11 +1,13 @@
 package pool
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/kunchenguid/treehouse/internal/git"
 	"github.com/kunchenguid/treehouse/internal/hooks"
@@ -14,16 +16,20 @@ import (
 
 // PruneWorktree describes a stale worktree that prune can remove or did remove.
 type PruneWorktree struct {
-	Name  string
-	Path  string
-	Bytes int64
+	Name     string
+	Path     string
+	Bytes    int64
+	Orphaned bool
+	Warning  string
 }
 
 // PruneSkipped describes a worktree that prune left in place for safety.
 type PruneSkipped struct {
-	Name   string
-	Path   string
-	Reason string
+	Name     string
+	Path     string
+	Category string
+	Reason   string
+	Detail   string
 }
 
 // PruneResult describes dry-run candidates, removed worktrees, skipped worktrees,
@@ -49,6 +55,27 @@ type PruneAllResult struct {
 	Result   PruneResult
 }
 
+type PruneOptions struct {
+	DryRun       bool
+	PruneOrphans bool
+	PreDestroy   []string
+}
+
+const (
+	PruneSkipUncommitted           = "uncommitted changes"
+	PruneSkipUnmerged              = "unmerged"
+	PruneSkipOrphanedBackingRepo   = "orphaned (backing repository missing)"
+	PruneSkipOriginUnreachable     = "origin unreachable (cannot verify)"
+	pruneSkipCannotVerify          = "cannot verify worktree"
+	pruneSkipCannotCheckProcesses  = "cannot check processes"
+	pruneSkipCannotMeasureSize     = "cannot measure size"
+	pruneSkipCleanupFailed         = "cleanup failed"
+	pruneSkipRemoveFailed          = "remove failed"
+	pruneSkipInUse                 = "in use"
+	pruneOrphanUnverifiedWarning   = "content could not be verified"
+	pruneOrphanRecoveredRepository = "backing repository is available again"
+)
+
 type plannedPrunePool struct {
 	PoolDir string
 	Plan    prunePlan
@@ -59,7 +86,14 @@ type plannedPrunePool struct {
 // branch ref selected by git.DefaultBranchMergeRef.
 // In dryRun mode Prune reports candidates and reclaimable bytes without deleting.
 func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
-	return prunePool(poolDir, dryRun, preDestroy, singleRepoPruneContextResolver(repoRoot), false)
+	return PruneWithOptions(repoRoot, poolDir, PruneOptions{
+		DryRun:     dryRun,
+		PreDestroy: preDestroy,
+	})
+}
+
+func PruneWithOptions(repoRoot, poolDir string, options PruneOptions) (PruneResult, error) {
+	return prunePool(poolDir, options, singleRepoPruneContextResolver(repoRoot))
 }
 
 // PrunePool prunes one pool by deriving each worktree's repository context from
@@ -67,13 +101,27 @@ func Prune(repoRoot, poolDir string, dryRun bool, preDestroy []string) (PruneRes
 // Worktrees whose repository or default branch cannot be resolved are reported
 // as skipped.
 func PrunePool(poolDir string, dryRun bool, preDestroy []string) (PruneResult, error) {
-	return prunePool(poolDir, dryRun, preDestroy, worktreePruneContextResolver(), true)
+	return PrunePoolWithOptions(poolDir, PruneOptions{
+		DryRun:     dryRun,
+		PreDestroy: preDestroy,
+	})
+}
+
+func PrunePoolWithOptions(poolDir string, options PruneOptions) (PruneResult, error) {
+	return prunePool(poolDir, options, worktreePruneContextResolver())
 }
 
 // PruneAll prunes every managed pool directly under poolRoot and aggregates the
 // results.
 // When dryRun is false, all pools are planned before any worktree is deleted.
 func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult, error) {
+	return PruneAllWithOptions(poolRoot, PruneOptions{
+		DryRun:     dryRun,
+		PreDestroy: preDestroy,
+	})
+}
+
+func PruneAllWithOptions(poolRoot string, options PruneOptions) (PruneAllResult, error) {
 	poolDirs, err := prunePoolDirs(poolRoot)
 	if err != nil {
 		return PruneAllResult{}, err
@@ -86,7 +134,7 @@ func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult
 	plans := make([]plannedPrunePool, 0, len(poolDirs))
 	resolveContext := worktreePruneContextResolver()
 	for _, poolDir := range poolDirs {
-		plan, err := planPrunePool(poolDir, resolveContext, true)
+		plan, err := planPrunePool(poolDir, resolveContext, options)
 		if err != nil {
 			return PruneAllResult{}, err
 		}
@@ -96,7 +144,7 @@ func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult
 		})
 		addPrunePoolResult(&result, poolDir, plan.Result)
 	}
-	if dryRun || len(result.Result.Candidates) == 0 {
+	if options.DryRun || len(result.Result.Candidates) == 0 {
 		return result, nil
 	}
 
@@ -108,7 +156,7 @@ func PruneAll(poolRoot string, dryRun bool, preDestroy []string) (PruneAllResult
 		poolResult := planned.Plan.Result
 		if len(planned.Plan.Result.Candidates) > 0 {
 			var err error
-			poolResult, err = executePrune(planned.PoolDir, planned.Plan, preDestroy)
+			poolResult, err = executePrune(planned.PoolDir, planned.Plan, options)
 			if err != nil {
 				return PruneAllResult{}, err
 			}
@@ -130,24 +178,24 @@ func addPrunePoolResult(all *PruneAllResult, poolDir string, poolResult PruneRes
 	all.Result.FreedBytes += poolResult.FreedBytes
 }
 
-func prunePool(poolDir string, dryRun bool, preDestroy []string, resolveContext pruneContextResolver, skipContextErrors bool) (PruneResult, error) {
-	plan, err := planPrunePool(poolDir, resolveContext, skipContextErrors)
+func prunePool(poolDir string, options PruneOptions, resolveContext pruneContextResolver) (PruneResult, error) {
+	plan, err := planPrunePool(poolDir, resolveContext, options)
 	if err != nil {
 		return PruneResult{}, err
 	}
-	if dryRun || len(plan.Result.Candidates) == 0 {
+	if options.DryRun || len(plan.Result.Candidates) == 0 {
 		return plan.Result, nil
 	}
 
-	return executePrune(poolDir, plan, preDestroy)
+	return executePrune(poolDir, plan, options)
 }
 
-func planPrunePool(poolDir string, resolveContext pruneContextResolver, skipContextErrors bool) (prunePlan, error) {
+func planPrunePool(poolDir string, resolveContext pruneContextResolver, options PruneOptions) (prunePlan, error) {
 	entries, err := pruneSnapshot(poolDir)
 	if err != nil {
 		return prunePlan{}, err
 	}
-	return planPrune(entries, resolveContext, skipContextErrors)
+	return planPrune(entries, resolveContext, options)
 }
 
 func prunePoolDirs(poolRoot string) ([]string, error) {
@@ -209,21 +257,16 @@ type plannedPruneWorktree struct {
 type prunePlan struct {
 	Result   PruneResult
 	Planned  map[string]plannedPruneWorktree
-	Reserved map[string]pruneContext
+	Reserved map[string]plannedPruneWorktree
 }
 
-func planPrune(entries []WorktreeEntry, resolveContext pruneContextResolver, skipContextErrors bool) (prunePlan, error) {
+func planPrune(entries []WorktreeEntry, resolveContext pruneContextResolver, options PruneOptions) (prunePlan, error) {
 	plan := prunePlan{
 		Planned: make(map[string]plannedPruneWorktree),
 	}
 	for _, wt := range entries {
-		worktree, skipped, stale, context, err := analyzePruneCandidate(resolveContext, wt)
+		worktree, skipped, stale, context, err := analyzePruneCandidate(resolveContext, wt, options)
 		if err != nil {
-			if skipContextErrors {
-				skipped.Reason = fmt.Sprintf("cannot resolve default branch: %v", err)
-				plan.Result.Skipped = append(plan.Result.Skipped, skipped)
-				continue
-			}
 			return prunePlan{}, err
 		}
 		if !stale {
@@ -245,24 +288,47 @@ func planPrune(entries []WorktreeEntry, resolveContext pruneContextResolver, ski
 
 func resolvePruneDefaultRef(repoRoot string) (string, error) {
 	if err := git.Fetch(repoRoot); err != nil {
-		return "", fmt.Errorf("refresh origin before prune: %w", err)
+		return "", pruneVerificationError{
+			Category: PruneSkipOriginUnreachable,
+			Reason:   "cannot fetch origin",
+			Detail:   fmt.Sprintf("refresh origin before prune: %v", err),
+		}
 	}
 	defaultRef, err := git.DefaultBranchMergeRef(repoRoot)
 	if err != nil {
-		return "", fmt.Errorf("resolve default branch before prune: %w", err)
+		category := pruneSkipCannotVerify
+		reason := "cannot resolve default branch"
+		if git.HasRemote(repoRoot, "origin") && isOriginAccessError(err) {
+			category = PruneSkipOriginUnreachable
+			reason = "cannot resolve origin default branch"
+		} else if git.HasRemote(repoRoot, "origin") {
+			reason = "cannot verify origin default branch"
+		}
+		return "", pruneVerificationError{
+			Category: category,
+			Reason:   reason,
+			Detail:   fmt.Sprintf("resolve default branch before prune: %v", err),
+		}
 	}
 	return defaultRef, nil
 }
 
 func singleRepoPruneContextResolver(repoRoot string) pruneContextResolver {
 	var defaultRef string
+	var defaultErr error
+	resolved := false
 	return func(WorktreeEntry) (pruneContext, error) {
-		if defaultRef == "" {
+		if !resolved {
 			ref, err := resolvePruneDefaultRef(repoRoot)
 			if err != nil {
-				return pruneContext{}, err
+				defaultErr = err
+			} else {
+				defaultRef = ref
 			}
-			defaultRef = ref
+			resolved = true
+		}
+		if defaultErr != nil {
+			return pruneContext{}, defaultErr
 		}
 		return pruneContext{RepoRoot: repoRoot, DefaultRef: defaultRef}, nil
 	}
@@ -270,6 +336,7 @@ func singleRepoPruneContextResolver(repoRoot string) pruneContextResolver {
 
 func worktreePruneContextResolver() pruneContextResolver {
 	contexts := make(map[string]pruneContext)
+	contextErrors := make(map[string]error)
 	return func(wt WorktreeEntry) (pruneContext, error) {
 		repoRoot, err := git.FindMainRepoRootFrom(wt.Path)
 		if err != nil {
@@ -278,9 +345,13 @@ func worktreePruneContextResolver() pruneContextResolver {
 		if context, ok := contexts[repoRoot]; ok {
 			return context, nil
 		}
+		if err, ok := contextErrors[repoRoot]; ok {
+			return pruneContext{}, err
+		}
 
 		defaultRef, err := resolvePruneDefaultRef(repoRoot)
 		if err != nil {
+			contextErrors[repoRoot] = err
 			return pruneContext{}, err
 		}
 		context := pruneContext{RepoRoot: repoRoot, DefaultRef: defaultRef}
@@ -295,7 +366,7 @@ func fixedPruneContextResolver(context pruneContext) pruneContextResolver {
 	}
 }
 
-func executePrune(poolDir string, plan prunePlan, preDestroy []string) (PruneResult, error) {
+func executePrune(poolDir string, plan prunePlan, options PruneOptions) (PruneResult, error) {
 	result := PruneResult{
 		Skipped: append([]PruneSkipped(nil), plan.Result.Skipped...),
 	}
@@ -314,7 +385,7 @@ func executePrune(poolDir string, plan prunePlan, preDestroy []string) (PruneRes
 				continue
 			}
 
-			worktree, skipped, stale, context, err := analyzePruneCandidate(fixedPruneContextResolver(plannedWorktree.Context), state.Worktrees[i])
+			worktree, skipped, stale, context, err := analyzePruneCandidate(fixedPruneContextResolver(plannedWorktree.Context), state.Worktrees[i], options)
 			if err != nil {
 				return err
 			}
@@ -332,9 +403,12 @@ func executePrune(poolDir string, plan prunePlan, preDestroy []string) (PruneRes
 			}
 			reserved = append(reserved, state.Worktrees[i])
 			if plan.Reserved == nil {
-				plan.Reserved = make(map[string]pruneContext)
+				plan.Reserved = make(map[string]plannedPruneWorktree)
 			}
-			plan.Reserved[state.Worktrees[i].Path] = context
+			plan.Reserved[state.Worktrees[i].Path] = plannedPruneWorktree{
+				Worktree: worktree,
+				Context:  context,
+			}
 			result.Candidates = append(result.Candidates, worktree)
 			result.ReclaimableBytes += worktree.Bytes
 		}
@@ -345,7 +419,7 @@ func executePrune(poolDir string, plan prunePlan, preDestroy []string) (PruneRes
 	}
 
 	for _, wt := range reserved {
-		hooks.Run(preDestroy, wt.Path, os.Stdout, os.Stderr)
+		hooks.Run(options.PreDestroy, wt.Path, os.Stdout, os.Stderr)
 	}
 
 	if err := WithStateLock(poolDir, func() error {
@@ -367,8 +441,15 @@ func executePrune(poolDir string, plan prunePlan, preDestroy []string) (PruneRes
 				continue
 			}
 
-			context := plan.Reserved[reservation.Path]
-			worktree, skipped := finalPruneSafetyCheck(context.DefaultRef, state.Worktrees[idx])
+			plannedWorktree := plan.Reserved[reservation.Path]
+			context := plannedWorktree.Context
+			var worktree PruneWorktree
+			var skipped PruneSkipped
+			if plannedWorktree.Worktree.Orphaned {
+				worktree, skipped = finalOrphanPruneSafetyCheck(state.Worktrees[idx])
+			} else {
+				worktree, skipped = finalPruneSafetyCheck(context.DefaultRef, state.Worktrees[idx])
+			}
 			if skipped.Reason != "" {
 				clearReservation(&state.Worktrees[idx])
 				result.Skipped = append(result.Skipped, skipped)
@@ -381,23 +462,35 @@ func executePrune(poolDir string, plan prunePlan, preDestroy []string) (PruneRes
 				}
 			}
 
-			if err := git.RemoveCleanWorktree(context.RepoRoot, worktree.Path); err != nil {
-				clearReservation(&state.Worktrees[idx])
-				result.Skipped = append(result.Skipped, PruneSkipped{
-					Name:   worktree.Name,
-					Path:   worktree.Path,
-					Reason: fmt.Sprintf("remove failed: %v", err),
-				})
-				continue
-			}
-			if err := os.RemoveAll(filepath.Dir(worktree.Path)); err != nil {
-				clearReservation(&state.Worktrees[idx])
-				result.Skipped = append(result.Skipped, PruneSkipped{
-					Name:   worktree.Name,
-					Path:   worktree.Path,
-					Reason: fmt.Sprintf("cleanup failed: %v", err),
-				})
-				continue
+			if worktree.Orphaned {
+				container, err := removableWorktreeContainer(worktree.Path)
+				if err != nil {
+					clearReservation(&state.Worktrees[idx])
+					result.Skipped = append(result.Skipped, newPruneSkipped(worktree.Name, worktree.Path, pruneSkipCleanupFailed, "refusing unsafe cleanup path", err.Error()))
+					continue
+				}
+				if err := os.RemoveAll(container); err != nil {
+					clearReservation(&state.Worktrees[idx])
+					result.Skipped = append(result.Skipped, newPruneSkipped(worktree.Name, worktree.Path, pruneSkipCleanupFailed, "could not remove worktree directory", err.Error()))
+					continue
+				}
+			} else {
+				if err := git.RemoveCleanWorktree(context.RepoRoot, worktree.Path); err != nil {
+					clearReservation(&state.Worktrees[idx])
+					result.Skipped = append(result.Skipped, newPruneSkipped(worktree.Name, worktree.Path, pruneSkipRemoveFailed, "git refused to remove worktree", err.Error()))
+					continue
+				}
+				container, err := removableWorktreeContainer(worktree.Path)
+				if err != nil {
+					clearReservation(&state.Worktrees[idx])
+					result.Skipped = append(result.Skipped, newPruneSkipped(worktree.Name, worktree.Path, pruneSkipCleanupFailed, "refusing unsafe cleanup path", err.Error()))
+					continue
+				}
+				if err := os.RemoveAll(container); err != nil {
+					clearReservation(&state.Worktrees[idx])
+					result.Skipped = append(result.Skipped, newPruneSkipped(worktree.Name, worktree.Path, pruneSkipCleanupFailed, "could not remove worktree directory", err.Error()))
+					continue
+				}
 			}
 
 			removed[worktree.Path] = struct{}{}
@@ -420,7 +513,7 @@ func executePrune(poolDir string, plan prunePlan, preDestroy []string) (PruneRes
 	return result, nil
 }
 
-func analyzePruneCandidate(resolveContext pruneContextResolver, wt WorktreeEntry) (PruneWorktree, PruneSkipped, bool, pruneContext, error) {
+func analyzePruneCandidate(resolveContext pruneContextResolver, wt WorktreeEntry, options PruneOptions) (PruneWorktree, PruneSkipped, bool, pruneContext, error) {
 	worktree := PruneWorktree{Name: wt.Name, Path: wt.Path}
 	skipped := PruneSkipped{Name: wt.Name, Path: wt.Path}
 
@@ -429,13 +522,13 @@ func analyzePruneCandidate(resolveContext pruneContextResolver, wt WorktreeEntry
 	}
 	inUse, err := process.IsWorktreeInUse(wt.Path)
 	if err != nil {
-		skipped.Reason = fmt.Sprintf("cannot check processes: %v", err)
+		skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotCheckProcesses, "cannot check processes", err.Error())
 		return worktree, skipped, true, pruneContext{}, nil
 	}
 	if inUse {
 		return worktree, skipped, false, pruneContext{}, nil
 	}
-	return analyzeIdleWorktree(resolveContext, wt, worktree, skipped)
+	return analyzeIdleWorktree(resolveContext, wt, worktree, skipped, options)
 }
 
 func finalPruneSafetyCheck(defaultRef string, wt WorktreeEntry) (PruneWorktree, PruneSkipped) {
@@ -444,54 +537,217 @@ func finalPruneSafetyCheck(defaultRef string, wt WorktreeEntry) (PruneWorktree, 
 
 	inUse, err := process.IsWorktreeInUse(wt.Path)
 	if err != nil {
-		skipped.Reason = fmt.Sprintf("cannot check processes: %v", err)
+		skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotCheckProcesses, "cannot check processes", err.Error())
 		return worktree, skipped
 	}
 	if inUse {
-		skipped.Reason = "in use"
+		skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipInUse, pruneSkipInUse, "")
 		return worktree, skipped
 	}
 	context := pruneContext{DefaultRef: defaultRef}
-	worktree, skipped, _, _, err = analyzeIdleWorktree(fixedPruneContextResolver(context), wt, worktree, skipped)
+	worktree, skipped, _, _, err = analyzeIdleWorktree(fixedPruneContextResolver(context), wt, worktree, skipped, PruneOptions{})
 	if err != nil {
-		skipped.Reason = fmt.Sprintf("cannot prove HEAD is merged into default branch: %v", err)
+		skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotVerify, "cannot prove HEAD is merged into default branch", err.Error())
 	}
 	return worktree, skipped
 }
 
-func analyzeIdleWorktree(resolveContext pruneContextResolver, wt WorktreeEntry, worktree PruneWorktree, skipped PruneSkipped) (PruneWorktree, PruneSkipped, bool, pruneContext, error) {
+func finalOrphanPruneSafetyCheck(wt WorktreeEntry) (PruneWorktree, PruneSkipped) {
+	worktree := PruneWorktree{
+		Name:     wt.Name,
+		Path:     wt.Path,
+		Orphaned: true,
+		Warning:  pruneOrphanUnverifiedWarning,
+	}
+	skipped := PruneSkipped{Name: wt.Name, Path: wt.Path}
+
+	inUse, err := process.IsWorktreeInUse(wt.Path)
+	if err != nil {
+		return worktree, newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotCheckProcesses, "cannot check processes", err.Error())
+	}
+	if inUse {
+		return worktree, newPruneSkipped(wt.Name, wt.Path, pruneSkipInUse, pruneSkipInUse, "")
+	}
+
+	orphaned, detail := backingRepositoryMissing(wt.Path)
+	if !orphaned {
+		return worktree, newPruneSkipped(wt.Name, wt.Path, PruneSkipOrphanedBackingRepo, pruneOrphanRecoveredRepository, detail)
+	}
+
+	container, err := removableWorktreeContainer(worktree.Path)
+	if err != nil {
+		return worktree, newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotMeasureSize, "refusing unsafe cleanup path", err.Error())
+	}
+	bytes, err := dirSize(container)
+	if err != nil {
+		return worktree, newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotMeasureSize, "cannot measure size", err.Error())
+	}
+	worktree.Bytes = bytes
+	return worktree, skipped
+}
+
+func analyzeIdleWorktree(resolveContext pruneContextResolver, wt WorktreeEntry, worktree PruneWorktree, skipped PruneSkipped, options PruneOptions) (PruneWorktree, PruneSkipped, bool, pruneContext, error) {
+	if orphaned, detail := backingRepositoryMissing(worktree.Path); orphaned {
+		if !options.PruneOrphans {
+			skipped = newPruneSkipped(wt.Name, wt.Path, PruneSkipOrphanedBackingRepo, pruneOrphanUnverifiedWarning, detail)
+			return worktree, skipped, true, pruneContext{}, nil
+		}
+
+		container, err := removableWorktreeContainer(worktree.Path)
+		if err != nil {
+			skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotMeasureSize, "refusing unsafe cleanup path", err.Error())
+			return worktree, skipped, true, pruneContext{}, nil
+		}
+		bytes, err := dirSize(container)
+		if err != nil {
+			skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotMeasureSize, "cannot measure size", err.Error())
+			return worktree, skipped, true, pruneContext{}, nil
+		}
+		worktree.Bytes = bytes
+		worktree.Orphaned = true
+		worktree.Warning = pruneOrphanUnverifiedWarning
+		return worktree, skipped, true, pruneContext{}, nil
+	}
+
 	dirty, err := git.IsDirty(worktree.Path)
 	if err != nil {
-		skipped.Reason = fmt.Sprintf("cannot check status: %v", err)
+		if orphaned, detail := backingRepositoryMissing(worktree.Path); orphaned {
+			skipped = newPruneSkipped(wt.Name, wt.Path, PruneSkipOrphanedBackingRepo, pruneOrphanUnverifiedWarning, detail)
+		} else {
+			skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotVerify, "cannot check status", err.Error())
+		}
 		return worktree, skipped, true, pruneContext{}, nil
 	}
 	if dirty {
-		skipped.Reason = "uncommitted changes"
+		skipped = newPruneSkipped(wt.Name, wt.Path, PruneSkipUncommitted, PruneSkipUncommitted, "")
 		return worktree, skipped, true, pruneContext{}, nil
 	}
 
 	context, err := resolveContext(wt)
 	if err != nil {
-		return worktree, skipped, true, pruneContext{}, err
+		skipped = skippedFromVerificationError(wt.Name, wt.Path, err)
+		return worktree, skipped, true, pruneContext{}, nil
 	}
 
 	merged, err := git.IsHeadMergedIntoRef(worktree.Path, context.DefaultRef)
 	if err != nil {
-		skipped.Reason = fmt.Sprintf("cannot prove HEAD is merged into default branch: %v", err)
+		if orphaned, detail := backingRepositoryMissing(worktree.Path); orphaned {
+			skipped = newPruneSkipped(wt.Name, wt.Path, PruneSkipOrphanedBackingRepo, pruneOrphanUnverifiedWarning, detail)
+		} else {
+			skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotVerify, "cannot prove HEAD is merged into default branch", err.Error())
+		}
 		return worktree, skipped, true, context, nil
 	}
 	if !merged {
-		skipped.Reason = fmt.Sprintf("HEAD is not merged into %s", context.DefaultRef)
+		skipped = newPruneSkipped(wt.Name, wt.Path, PruneSkipUnmerged, fmt.Sprintf("HEAD not merged into %s", context.DefaultRef), "")
 		return worktree, skipped, true, context, nil
 	}
 
-	bytes, err := dirSize(filepath.Dir(worktree.Path))
+	container, err := removableWorktreeContainer(worktree.Path)
 	if err != nil {
-		skipped.Reason = fmt.Sprintf("cannot measure size: %v", err)
+		skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotMeasureSize, "refusing unsafe cleanup path", err.Error())
+		return worktree, skipped, true, context, nil
+	}
+	bytes, err := dirSize(container)
+	if err != nil {
+		skipped = newPruneSkipped(wt.Name, wt.Path, pruneSkipCannotMeasureSize, "cannot measure size", err.Error())
 		return worktree, skipped, true, context, nil
 	}
 	worktree.Bytes = bytes
 	return worktree, skipped, true, context, nil
+}
+
+type pruneVerificationError struct {
+	Category string
+	Reason   string
+	Detail   string
+}
+
+func (e pruneVerificationError) Error() string {
+	return e.Detail
+}
+
+func skippedFromVerificationError(name, path string, err error) PruneSkipped {
+	var pruneErr pruneVerificationError
+	if errors.As(err, &pruneErr) {
+		return newPruneSkipped(name, path, pruneErr.Category, pruneErr.Reason, pruneErr.Detail)
+	}
+	return newPruneSkipped(name, path, pruneSkipCannotVerify, "cannot verify worktree", err.Error())
+}
+
+func isOriginAccessError(err error) bool {
+	detail := err.Error()
+	return strings.Contains(detail, "git ls-remote") ||
+		strings.Contains(detail, "Could not read from remote repository") ||
+		strings.Contains(detail, "does not appear to be a git repository") ||
+		strings.Contains(detail, "repository") && strings.Contains(detail, "not found")
+}
+
+func newPruneSkipped(name, path, category, reason, detail string) PruneSkipped {
+	if category == "" {
+		category = pruneSkipCannotVerify
+	}
+	if reason == "" {
+		reason = category
+	}
+	return PruneSkipped{
+		Name:     name,
+		Path:     path,
+		Category: category,
+		Reason:   reason,
+		Detail:   detail,
+	}
+}
+
+func backingRepositoryMissing(worktreePath string) (bool, string) {
+	gitDir, ok, detail := linkedWorktreeGitDir(worktreePath)
+	if !ok {
+		return false, detail
+	}
+	if _, err := os.Stat(gitDir); err == nil {
+		return false, ""
+	} else if os.IsNotExist(err) {
+		return true, fmt.Sprintf("gitdir %s does not exist", gitDir)
+	} else {
+		return false, fmt.Sprintf("cannot inspect gitdir %s: %v", gitDir, err)
+	}
+}
+
+func linkedWorktreeGitDir(worktreePath string) (string, bool, string) {
+	gitFile := filepath.Join(worktreePath, ".git")
+	info, err := os.Stat(gitFile)
+	if err != nil {
+		return "", false, err.Error()
+	}
+	if info.IsDir() {
+		return "", false, ""
+	}
+
+	data, err := os.ReadFile(gitFile)
+	if err != nil {
+		return "", false, err.Error()
+	}
+	line, _, _ := strings.Cut(string(data), "\n")
+	gitDir, ok := strings.CutPrefix(strings.TrimSpace(line), "gitdir:")
+	if !ok {
+		return "", false, fmt.Sprintf("%s does not contain a gitdir pointer", gitFile)
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if gitDir == "" {
+		return "", false, fmt.Sprintf("%s has an empty gitdir pointer", gitFile)
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreePath, gitDir)
+	}
+	return filepath.Clean(gitDir), true, ""
+}
+
+func removableWorktreeContainer(worktreePath string) (string, error) {
+	container := filepath.Clean(filepath.Dir(worktreePath))
+	if container == "." || filepath.Dir(container) == container {
+		return "", fmt.Errorf("refusing to remove %s", container)
+	}
+	return container, nil
 }
 
 func clearReservation(wt *WorktreeEntry) {


### PR DESCRIPTION
## Intent

Improve treehouse prune and prune --all handling of orphaned and unverifiable worktrees so users get a clean, actionable grouped report instead of raw multi-line git failures. Preserve existing safe pruning behavior for dirty and unmerged worktrees. Classify backing-repository-missing linked worktrees as true orphans, classify unreachable origin failures as unverifiable rather than deletable, and keep raw git diagnostics available only through verbose output. Add explicit --prune-orphans opt-in so true backing-missing orphans are included in dry-run candidates and require --yes before deletion; never delete origin-unreachable worktrees even when --prune-orphans --yes is used. Warn per orphan that content could not be verified, update README/help/project memory, keep CHANGELOG untouched because it is generated, and validate with unit tests, E2E CLI transcript-style tests, go test, go vet/lint, Windows build, and no-mistakes.

## What Changed
- Classifies backing-repository-missing worktrees as orphan candidates while treating unreachable origins as unverifiable, skipped worktrees that are never deleted.
- Adds explicit `--prune-orphans` handling and grouped prune output with actionable hints, keeping raw git diagnostics behind verbose output.
- Updates README guidance and adds prune coverage for orphan, mixed-candidate, origin-unreachable, and Windows build-safe paths.

## Risk Assessment

⚠️ Medium: The change is safety-sensitive because it adds an explicit orphan deletion path, but the implementation is scoped, opt-in, and keeps final safety checks in place.

## Testing

Focused prune tests, the full Go test suite, the Windows cross-build, and a manual CLI transcript all passed; the transcript shows default grouped orphan reporting, stale-only deletion with `--yes`, explicit orphan deletion with `--prune-orphans --yes`, and origin-unreachable worktrees remaining skipped. Linters and static analysis were not run because the task explicitly prohibited them.

- Evidence: [CLI prune orphan/unreachable evidence transcript](https://github.com/kunchenguid/treehouse/blob/95945e9b5cd3a1652fda2b02696668b9334fd410/.no-mistakes/evidence/fm/th-orphan-prune-o6/prune-orphan-unreachable-transcript.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `cmd/prune.go:123` - When regular stale candidates and skipped backing-repository-missing orphans appear in the same run, the output prints the skipped orphan group but only suggests rerunning with `--yes`. That follow-up will delete the regular candidates while leaving the reported orphans behind, with no hint that `--prune-orphans` is required. Print the orphan hint whenever skipped orphans are present and `--prune-orphans` is false, including the candidate/pruned branches for both repo-scoped and `--all` output.

🔧 Fix: Add mixed prune orphan hints
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/pool -run 'TestPruneAllReportsBackingMissingOrphanWithoutDeletingByDefault|TestPruneAllPrunesBackingMissingOrphanOnlyWithExplicitFlag|TestPruneAllNeverDeletesOriginUnreachableWithPruneOrphans|TestPruneSkipsWhenRemoteDefaultTrackingRefIsStale'`
- `go test ./cmd -run 'TestPruneMixedStaleAndSkippedOrphanPrintsOrphanHints|TestPruneAllReportsOrphanWithoutRawGitErrorsAndPrunesOnlyWithExplicitFlag|TestPruneAllDoesNotDeleteOriginUnreachableWithPruneOrphans'`
- `go test ./...`
- `GOOS=windows go build ./...`
- <code>Manual E2E transcript: built a temporary treehouse binary, created disposable in-repo git repositories, then ran `treehouse prune --all`, `treehouse prune --all --yes`, `treehouse prune --all --prune-orphans`, `treehouse prune --all --prune-orphans --yes`, and `treehouse prune --all --verbose` against backing-missing orphan and origin-unreachable worktrees.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
