### PR TITLE
fix(pool): prune stale worktree registrations before adding in get

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ make test
 - State file tracks pool membership, temporary owner/destroy reservations, and explicit durable leases.
   It still does not infer long-term usage from processes.
 - Git operations shell out to `git` (go-git has incomplete worktree support)
-- Self-healing: stale state entries are auto-removed
+- Self-healing: stale state entries are auto-removed, and `get` prunes stale git worktree registrations before adding a worktree
 
 ## Windows Compatibility
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The default treehouse root is `~/.treehouse/`.
   `treehouse prune --all` applies the same safety checks across every managed pool under the user-level treehouse root.
   Backing-repository-missing orphans are reported by default; `--prune-orphans` includes them as unverified prune candidates, and `--yes` is required before deletion.
   It is a dry run unless you pass `--yes`.
+- **Self-healing get** - `treehouse get` prunes stale git worktree bookkeeping (e.g. left behind by a crashed or forcibly removed worktree) before adding a new worktree, so a prunable registration never wedges the pool with a "missing but already registered worktree" error.
 
 ## CLI Reference
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -679,6 +679,61 @@ func TestGetReusesWorktree(t *testing.T) {
 	}
 }
 
+// TestGetRecoversFromStaleWorktreeRegistration verifies that "treehouse get"
+// self-heals when git still has bookkeeping for a worktree whose directory was
+// removed out-of-band (e.g. a crashed agent). Without prune-before-add, git
+// rejects the add with "missing but already registered worktree" and every
+// subsequent get is wedged. See issue #30.
+func TestGetRecoversFromStaleWorktreeRegistration(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	env := []string{"SHELL=" + exitShellBin}
+
+	// Materialize the pool directory so we can plant the stale entry at the
+	// exact slot path Acquire will target (slot 1 / <repo-basename>).
+	if _, _, code := runTreehouse(t, repoDir, homeDir, nil, "status"); code != 0 {
+		t.Fatalf("initial status failed (code %d)", code)
+	}
+	matches, err := filepath.Glob(filepath.Join(homeDir, ".treehouse", filepath.Base(repoDir)+"-*"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected exactly one pool dir under %s/.treehouse, got %v: %v", homeDir, matches, err)
+	}
+	poolDir := matches[0]
+	stalePath := filepath.Join(poolDir, "1", filepath.Base(repoDir))
+
+	// Simulate a crashed scout: register a worktree at the slot path, then
+	// delete its directory without telling git. This leaves a prunable entry.
+	if err := os.MkdirAll(filepath.Dir(stalePath), 0755); err != nil {
+		t.Fatalf("mkdir slot parent: %v", err)
+	}
+	gitCmd(t, repoDir, "worktree", "add", "--detach", stalePath, "main")
+	if err := os.RemoveAll(stalePath); err != nil {
+		t.Fatalf("remove stale worktree dir: %v", err)
+	}
+
+	// Sanity: git should now consider the entry prunable.
+	listOut := gitCmd(t, repoDir, "worktree", "list", "--porcelain")
+	if !strings.Contains(listOut, "prunable") {
+		t.Fatalf("expected prunable entry in worktree list, got:\n%s", listOut)
+	}
+
+	// get must recover and create the worktree despite the stale registration.
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("treehouse get failed on stale registration (code %d): %s", code, getErr)
+	}
+	if strings.Contains(getErr, "already registered") || strings.Contains(getErr, "failed to create worktree") {
+		t.Fatalf("get did not recover from stale registration: %s", getErr)
+	}
+	if !strings.Contains(getErr, "Entered worktree at") {
+		t.Fatalf("expected 'Entered worktree at' in stderr, got: %s", getErr)
+	}
+
+	// The worktree directory must actually exist on disk after get.
+	if _, err := os.Stat(filepath.Join(stalePath, "README.md")); err != nil {
+		t.Errorf("worktree was not recreated at %s: %v", stalePath, err)
+	}
+}
+
 func TestReturnFromInsideWorktreeDoesNotTerminateCaller(t *testing.T) {
 	repoDir, homeDir := setupTestRepo(t)
 	env := []string{"SHELL=" + exitShellBin}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -142,6 +142,15 @@ func AddWorktree(repoRoot, path, branch string) error {
 	return err
 }
 
+// PruneWorktrees removes git worktree bookkeeping for worktrees whose
+// directories no longer exist. It is safe by design: git only deletes
+// registrations for already-missing directories and never touches live
+// worktrees or their data.
+func PruneWorktrees(repoRoot string) error {
+	_, err := runGit(repoRoot, "worktree", "prune")
+	return err
+}
+
 func RemoveWorktree(repoRoot, path string) error {
 	_, err := runGit(repoRoot, "worktree", "remove", "--force", path)
 	return err

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -133,6 +133,14 @@ func acquire(repoRoot, poolDir string, poolSize int, postCreate []string, opts a
 			return err
 		}
 
+		// Clear any stale worktree bookkeeping left behind by a crashed or
+		// forcibly removed worktree. Without this, git rejects the add with
+		// "missing but already registered worktree". Prune is safe: it only
+		// removes registrations whose target directories are already gone.
+		if err := git.PruneWorktrees(repoRoot); err != nil {
+			return fmt.Errorf("failed to prune stale worktrees: %w", err)
+		}
+
 		if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
 			return fmt.Errorf("failed to create worktree: %w", err)
 		}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -137,8 +137,14 @@ func acquire(repoRoot, poolDir string, poolSize int, postCreate []string, opts a
 		// forcibly removed worktree. Without this, git rejects the add with
 		// "missing but already registered worktree". Prune is safe: it only
 		// removes registrations whose target directories are already gone.
+		//
+		// Best-effort: prune is a self-healing optimization, not a precondition
+		// for AddWorktree in the common (non-stale) case. A transient failure
+		// (e.g. a temporary .git/worktrees lock or permission issue) must not
+		// wedge a get that would otherwise succeed; let AddWorktree surface the
+		// real error if one exists.
 		if err := git.PruneWorktrees(repoRoot); err != nil {
-			return fmt.Errorf("failed to prune stale worktrees: %w", err)
+			fmt.Fprintf(os.Stderr, "🌳 Warning: failed to prune stale worktrees: %v\n", err)
 		}
 
 		if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {


### PR DESCRIPTION
## Intent

The developer tasked an autonomous agent with two jobs on the treehouse repo. First, fix a review finding on PR #31's branch fix/get-prunes-stale-worktree-registrations by making PruneWorktrees failures non-fatal (best-effort, logged/ignored), mirroring the existing EnsureGitignore warning-and-continue pattern, so a transient prune error no longer wedges a get that AddWorktree would otherwise handle. Second, add a minimal .github/workflows/ci.yml triggering on push and pull_request that checks out, sets up Go per go.mod, and runs go test ./... and go build ./.... Explicit constraints: do NOT push either branch (the no-mistakes pipeline was broken and being fixed in parallel, with firstmate pushing later), stay inside the worktree, fetch the existing finding-fix branch rather than creating a new one, and create fm/add-ci off main only for CI. After the agent discovered CI already existed on main and reported the conflict, the developer agreed to no-op Task 2 and report done with just the prune fix committed.

## What Changed

- `treehouse get` now runs `git worktree prune` before adding a worktree, so stale bookkeeping left by a crashed or forcibly-removed worktree no longer wedges the pool with a "missing but already registered worktree" error.
- The prune is best-effort: a transient failure logs a warning and continues, letting `AddWorktree` surface the real error if one exists rather than failing a `get` that would otherwise succeed.
- Adds the `git.PruneWorktrees` helper, an e2e test (`TestGetRecoversFromStaleWorktreeRegistration`), and documents the self-healing behavior in README and AGENTS.md.

## Risk Assessment

✅ Low: Well-bounded, safe-by-design change that mirrors an established best-effort warning pattern, applies only to the create-new path, preserves the lease-mode stdout contract, is covered by a regression test, and introduces no security, performance, or breaking-change concerns.

## Testing

Demonstrated the fix both ways: (1) treehouse get recovers from a prunable stale worktree registration and recreates the worktree on disk (exit 0), and (2) with a git shim that forces only `worktree prune` to fail, treehouse get still succeeds (exit 0) while printing the prune warning — directly proving a transient prune error no longer wedges get. The cmd/pool/git test packages all pass, including the dedicated TestGetRecoversFromStaleWorktreeRegistration.

<details>
<summary>Evidence: Happy-path: get recovers from stale worktree registration (CLI transcript)</summary>

<code>==&gt; 2. Simulate crashed scout: register worktree at slot, then rm its dir&#10;worktree .../1/repo&#10;prunable gitdir file points to non-existent location&#10;&#10;==&gt; 3. Run &#39;treehouse get&#39; (should recover despite stale registration)&#10;🌳 Setting up worktree...&#10;🌳 Entered worktree at ~/.treehouse/repo-4d04fe/1/repo. Type &#39;exit&#39; to return.&#10;🌳 Worktree returned to pool.&#10;get exit code: 0&#10;&#10;==&gt; 4. Verify the worktree was recreated on disk&#10;RECREATED_OK</code>

```text
==> 1. Materialize pool dir via status
🌳 No worktrees in pool.
pool dir: /tmp/repro_happy/home/.treehouse/repo-4d04fe

==> 2. Simulate crashed scout: register worktree at slot, then rm its dir
git worktree list --porcelain:
worktree /tmp/repro_happy/repo
worktree /tmp/repro_happy/home/.treehouse/repo-4d04fe/1/repo
prunable gitdir file points to non-existent location

==> 3. Run 'treehouse get' (should recover despite stale registration)
🌳 Setting up worktree...
🌳 Entered worktree at ~/.treehouse/repo-4d04fe/1/repo. Type 'exit' to return.
🌳 Worktree returned to pool.
get exit code: 0

==> 4. Verify the worktree was recreated on disk
-rw-rw-r-- 1 ubuntu ubuntu 7 Jul  1 15:13 /tmp/repro_happy/home/.treehouse/repo-4d04fe/1/repo/README.md
RECREATED_OK
```
</details>
<details>
<summary>Evidence: Best-effort: prune fails (shim) yet get still succeeds (CLI transcript)</summary>

<code>==&gt; Confirm shim intercepts &#39;worktree prune&#39; (invoked like treehouse: cd then bare git)&#10;git worktree prune: simulated transient failure (lock busy)&#10;prune exit: 1 (expected non-zero)&#10;&#10;==&gt; 2. &#39;treehouse get&#39; with the prune-failing shim first in PATH&#10;🌳 Setting up worktree...&#10;🌳 Warning: failed to prune stale worktrees: git worktree prune: simulated transient failure (lock busy)&#10;🌳 Entered worktree at ~/.treehouse/repo-a33b89/1/repo. Type &#39;exit&#39; to return.&#10;🌳 Worktree returned to pool.&#10;get exit code: 0 (expected 0 -&gt; transient prune error did NOT wedge get)</code>

```text
==> Confirm shim intercepts 'worktree prune' (invoked like treehouse: cd then bare git)
git worktree prune: simulated transient failure (lock busy)
prune exit: 1 (expected non-zero)

==> Confirm shim still delegates other commands: 'git worktree add' must work
add exit: 0

==> 1. Materialize pool dir
==> 2. 'treehouse get' with the prune-failing shim first in PATH
    (Expected: prune warning printed to stderr, but get still succeeds)
🌳 Setting up worktree...
🌳 Warning: failed to prune stale worktrees: git worktree prune: git worktree prune: simulated transient failure (lock busy)
🌳 Entered worktree at ~/.treehouse/repo-a33b89/1/repo. Type 'exit' to return.
🌳 Worktree returned to pool.
get exit code: 0 (expected 0 -> transient prune error did NOT wedge get)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./cmd/ -run TestGetRecoversFromStaleWorktreeRegistration -v`
- `go test ./cmd/ ./internal/pool/ ./internal/git/`
- `go build -o /tmp/no-mistakes-evidence/.../treehouse . (builds clean)`
- <code>Manual happy-path: init repo, register worktree at Acquire&#39;s slot path then rm its dir, run `treehouse get` -&gt; recovers, recreates worktree on disk, exit 0</code>
- <code>Manual best-effort: PATH shim that fails `git worktree prune` (exit 1) but delegates `git worktree add` -&gt; `treehouse get` prints prune warning AND still enters worktree, exit 0</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
