### PR TITLE
fix(pool): accept dot-prefixed subdirectories in cwdInWorktree

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kunchenguid/treehouse/internal/git"
@@ -355,7 +356,10 @@ func cwdInWorktree(cwd, worktreePath string) bool {
 	if err != nil {
 		return false
 	}
-	return rel == "." || !filepath.IsAbs(rel) && len(rel) >= 1 && rel[0] != '.'
+	// The cwd is inside the worktree when rel is "." (the worktree root itself)
+	// or any path that does not escape the root via "..". This deliberately
+	// accepts dot-prefixed subdirectories such as .venv/bin or .cache/tmp.
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func nextName(state State) string {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -2206,6 +2206,47 @@ func TestHoldCwdProbe(t *testing.T) {
 	select {}
 }
 
+func TestCwdInWorktree(t *testing.T) {
+	worktree := t.TempDir()
+	worktree, err := filepath.EvalSymlinks(worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the subdirectories the test cases cd into.
+	for _, sub := range []string{"src/foo", ".venv/bin", ".cache/tmp"} {
+		if err := os.MkdirAll(filepath.Join(worktree, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sibling := filepath.Join(filepath.Dir(worktree), "sibling")
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		cwd  string
+		want bool
+	}{
+		{"worktree root", worktree, true},
+		{"regular subdir", filepath.Join(worktree, "src", "foo"), true},
+		{"dot-prefixed subdir .venv/bin", filepath.Join(worktree, ".venv", "bin"), true},
+		{"dot-prefixed subdir .cache/tmp", filepath.Join(worktree, ".cache", "tmp"), true},
+		{"parent of worktree (rel starts with ..)", filepath.Dir(worktree), false},
+		{"sibling dir", sibling, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cwdInWorktree(tc.cwd, worktree); got != tc.want {
+				t.Fatalf("cwdInWorktree(%q, %q) = %v, want %v", tc.cwd, worktree, got, tc.want)
+			}
+		})
+	}
+}
+
 // quoteForShell wraps a path so it survives splitting by /bin/sh or cmd.exe.
 // Tests only use temp-dir paths which don't contain quotes, so simple quoting
 // is sufficient.


### PR DESCRIPTION
## Intent

The developer wanted to fix a treehouse bug where cwdInWorktree in internal/pool/pool.go (~line 427) rejected dot-prefixed subdirectories, causing `treehouse status` to fail to recognize the user as "here" when their cwd is inside paths like .venv, .cache, or .git-hooks. They required replacing the buggy `rel[0] != '.'` check with the correct "does not escape via .." predicate (already present at internal/process/detect.go:75), and adding the first table-driven test for cwdInWorktree in internal/pool/pool_test.go covering root, regular subdir, dot-prefixed subdir, outside-worktree, and sibling-dir cases, verified with `go test ./internal/pool/...`. Explicit constraints: branch off upstream/main (never local main), push to the e-jung fork, open a cross-repo PR titled "fix(pool): cwdInWorktree accepts dot-prefixed subdirectories" against kunchenguid/treehouse with AI disclosure = Human-reviewed, do NOT merge, and stay confined to the worktree. The developer framed this as a status-display-only bug with very low risk.

## What Changed

- Replaced the `rel[0] != '.'` guard in `cwdInWorktree` (`internal/pool/pool.go`) with a "does not escape via `..`" predicate, so dot-prefixed subdirectories like `.venv/bin` or `.cache/tmp` are correctly recognized as inside the worktree.
- Added the first table-driven `TestCwdInWorktree` covering worktree root, regular subdir, dot-prefixed subdirs, parent, and sibling paths.

## Risk Assessment

✅ Low: The fix is a minimal, correct one-liner that mirrors the already-proven predicate in detect.go:75 and is exercised by a well-chosen table-driven test; its only consumer is the StatusHere display flag (pool.go:269), so blast radius is purely cosmetic.

## Testing

The fix works end-to-end as an end user would experience it: running `treehouse status` from inside `.venv/bin` or `.cache/tmp` of a pooled worktree now correctly prints "you're here" instead of the buggy "in-use". The new table-driven unit test passes all six cases, the entire `go test ./...` suite is green, and Windows/macOS cross-builds succeed. A side-by-side run of the buggy base binary versus the fixed binary on the identical scenario directly demonstrates the status-display bug being resolved.

<details>
<summary>Evidence: status transcript - FIXED binary (target commit)</summary>

<code>treehouse status from cwd inside dot-prefixed subdirs (fixed binary):&#10;--- cwd = worktree/ --- -&gt; 1 you&#39;re here&#10;--- cwd = worktree/src/foo --- -&gt; 1 you&#39;re here&#10;--- cwd = worktree/.venv/bin --- -&gt; 1 you&#39;re here (was &#39;in-use&#39; before fix)&#10;--- cwd = worktree/.cache/tmp --- -&gt; 1 you&#39;re here (was &#39;in-use&#39; before fix)</code>

```text
treehouse status transcripts (cwd inside dot-prefixed subdirs)
binary: /tmp/no-mistakes-evidence/01KW9VEMQHM7A4ND2HG8XE0VGG/treehouse
worktree: /tmp/tmp.FY1fFXgfQs/home/.treehouse/myrepo-c3de26/1/myrepo
created worktree banner/get output:
🌳 Setting up worktree...
🌳 Entered worktree at ~/.treehouse/myrepo-c3de26/1/myrepo. Type 'exit' to return.
🌳 Worktree returned to pool.

--- cwd = worktree/ ---
1     you're here  ~/.treehouse/myrepo-c3de26/1/myrepo
                   bash (174856), treehouse (174857)

--- cwd = worktree/src/foo ---
1     you're here  ~/.treehouse/myrepo-c3de26/1/myrepo
                   bash (174866), treehouse (174867)

--- cwd = worktree/.venv/bin ---
1     you're here  ~/.treehouse/myrepo-c3de26/1/myrepo
                   bash (174876), treehouse (174877)

--- cwd = worktree/.cache/tmp ---
1     you're here  ~/.treehouse/myrepo-c3de26/1/myrepo
                   bash (174886), treehouse (174887)
```
</details>
<details>
<summary>Evidence: status transcript - BASE (buggy) binary</summary>

<code>treehouse status from cwd inside dot-prefixed subdirs (buggy base binary):&#10;--- cwd = worktree/ --- -&gt; 1 you&#39;re here&#10;--- cwd = worktree/src/foo --- -&gt; 1 you&#39;re here&#10;--- cwd = worktree/.venv/bin --- -&gt; 1 in-use (BUG: should be &#39;you&#39;re here&#39;)&#10;--- cwd = worktree/.cache/tmp --- -&gt; 1 in-use (BUG: should be &#39;you&#39;re here&#39;)</code>

```text
treehouse status transcripts (cwd inside dot-prefixed subdirs)
binary: /tmp/tmp.TWFYrysdNa/treehouse-base
worktree: /tmp/tmp.430113JFwm/home/.treehouse/myrepo-8900c0/1/myrepo
created worktree banner/get output:
🌳 Setting up worktree...
🌳 Entered worktree at ~/.treehouse/myrepo-8900c0/1/myrepo. Type 'exit' to return.
🌳 Worktree returned to pool.

--- cwd = worktree/ ---
1     you're here  ~/.treehouse/myrepo-8900c0/1/myrepo
                   bash (175056), treehouse-base (175057)

--- cwd = worktree/src/foo ---
1     you're here  ~/.treehouse/myrepo-8900c0/1/myrepo
                   bash (175072), treehouse-base (175073)

--- cwd = worktree/.venv/bin ---
1     in-use       ~/.treehouse/myrepo-8900c0/1/myrepo
                   bash (175082), treehouse-base (175083)

--- cwd = worktree/.cache/tmp ---
1     in-use       ~/.treehouse/myrepo-8900c0/1/myrepo
                   bash (175092), treehouse-base (175093)
```
</details>
<details>
<summary>Evidence: TestCwdInWorktree unit test result</summary>

```text
=== RUN TestCwdInWorktree
--- PASS: TestCwdInWorktree (0.00s)
--- PASS: worktree_root
--- PASS: regular_subdir
--- PASS: dot-prefixed_subdir_.venv/bin
--- PASS: dot-prefixed_subdir_.cache/tmp
--- PASS: parent_of_worktree_(rel_starts_with_..)
--- PASS: sibling_dir
PASS
ok github.com/kunchenguid/treehouse/internal/pool
```
</details>
<details>
<summary>Evidence: reproducible e2e demo script</summary>

```text
#!/usr/bin/env bash
# End-to-end demonstration that `treehouse status` correctly reports
# "you're here" when the user's cwd is inside a dot-prefixed subdirectory
# (e.g. .venv/bin, .cache/tmp) of a pooled worktree.
set -u

BIN="$1"          # path to the treehouse binary under test
EVDIR="$2"        # evidence output dir

DEMO="$(mktemp -d)"
DEMO="$(cd "$DEMO" && pwd)"

# Minimal "exit-shell" so `treehouse get` does not block waiting on a TTY.
EXITSHELL_SRC="$DEMO/exitshell-src"
mkdir -p "$EXITSHELL_SRC"
printf 'module exitshell\n\ngo 1.21\n' > "$EXITSHELL_SRC/go.mod"
printf 'package main\n\nfunc main() {}\n' > "$EXITSHELL_SRC/main.go"
EXITSHELL="$DEMO/exitshell"
( cd "$EXITSHELL_SRC" && go build -o "$EXITSHELL" . ) || { echo "exitshell build failed"; exit 1; }

# Isolated HOME so we don't touch real user pool state.
HOME_ISOLATED="$DEMO/home"
mkdir -p "$HOME_ISOLATED"

# --- Set up a real git repo with a bare remote (mirrors e2e_test.go setup) ---
BARE="$DEMO/remote.git"
REPO="$DEMO/myrepo"
git init --bare --initial-branch=main "$BARE" >/dev/null
git init --initial-branch=main "$REPO" >/dev/null
git -C "$REPO" config user.email test@test.com
git -C "$REPO" config user.name Test
git -C "$REPO" remote add origin "$BARE"
printf 'hello\n' > "$REPO/README.md"
git -C "$REPO" add .
git -C "$REPO" commit -m "initial commit" >/dev/null
git -C "$REPO" push -u origin main >/dev/null 2>&1

export HOME="$HOME_ISOLATED"
SHELL="$EXITSHELL"

run() {
  # run <workdir> <args...>
  local wd="$1"; shift
  ( cd "$wd" && HOME="$HOME_ISOLATED" SHELL="$EXITSHELL" "$BIN" "$@" )
}

echo "============================================================"
echo "Scenario: treehouse status from inside dot-prefixed subdirs"
echo "============================================================"

# Create a pooled worktree.
GET_OUT="$(run "$REPO" get 2>&1)" || true
# The worktree lives under $HOME_ISOLATED/.treehouse/myrepo-<hash>/<n>/myrepo.
WT="$(find "$HOME_ISOLATED/.treehouse" -maxdepth 4 -type d -name myrepo 2>/dev/null | head -n1)"
if [ -z "${WT:-}" ] || [ ! -d "$WT" ]; then
  echo "Could not locate created worktree. get output:"; printf '%s\n' "$GET_OUT"; exit 1
fi
echo "Created pooled worktree: $WT"

# Create the dot-prefixed subdirs an end user would have.
mkdir -p "$WT/.venv/bin" "$WT/.cache/tmp" "$WT/src/foo"

probe() {
  # probe <subdir-relative> <label>
  local sub="$1" label="$2"
  local target="$WT/$sub"
  echo ""
  echo "--- cwd = worktree/$sub  ($label) ---"
  ( cd "$target" && HOME="$HOME_ISOLATED" SHELL="$EXITSHELL" "$BIN" status ) 2>&1
}

probe ""            "worktree root"
probe "src/foo"     "regular subdir"
probe ".venv/bin"   "dot-prefixed subdir (the bug case)"
probe ".cache/tmp"  "dot-prefixed subdir (the bug case)"

# Persist the full transcript for the artifact.
{
  echo "treehouse status transcripts (cwd inside dot-prefixed subdirs)"
  echo "binary: $BIN"
  echo "worktree: $WT"
  echo "created worktree banner/get output:"
  printf '%s\n' "$GET_OUT"
  for s in "" "src/foo" ".venv/bin" ".cache/tmp"; do
    echo ""
    echo "--- cwd = worktree/$s ---"
    ( cd "$WT/$s" && HOME="$HOME_ISOLATED" SHELL="$EXITSHELL" "$BIN" status ) 2>&1
  done
} > "$EVDIR/status-e2e-transcript.txt"

echo ""
echo "Transcript saved to $EVDIR/status-e2e-transcript.txt"

# Cleanup the demo scratch (keep evidence dir intact).
rm -rf "$DEMO"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/pool/pool_test.go` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `internal/pool/pool.go:362` - The new predicate `rel == &#34;.&#34; || (rel != &#34;..&#34; &amp;&amp; !strings.HasPrefix(rel, &#34;..&#34;+string(filepath.Separator)))` is now byte-for-byte identical to the inline check in internal/process/detect.go:75. Since package `pool` already imports `process` (pool.go:14), the two could share an exported helper (e.g. process.IsPathInsideWorktree) to guarantee the two containment checks never diverge again. The divergence was the root cause of this bug, so consolidating would prevent recurrence. Optional, low-value follow-up given it&#39;s a one-liner.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/pool/... -run TestCwdInWorktree -v`
- `go test ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `GOOS=darwin GOARCH=arm64 go build ./...`
- <code>e2e: built fixed binary, ran `treehouse get` to create a pooled worktree, then `treehouse status` with cwd in worktree root, src/foo, .venv/bin, and .cache/tmp -&gt; all show &#39;you&#39;re here&#39; (status-e2e-FIXED.txt)</code>
- `e2e contrast: built the base-commit (buggy) binary and ran the identical scenario -> .venv/bin and .cache/tmp wrongly show 'in-use' (status-e2e-BASE-buggy.txt), proving the bug and the fix`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
