### PR TITLE
Add 'enter' command to open a subshell in an existing worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Treehouse is a Go CLI tool that manages a pool of git worktrees for parallel AI 
 ## Project Structure
 
 - `main.go` - entry point, calls `cmd.Execute()`
-- `cmd/` - CLI commands (cobra): `get` (incl. `get --lease`), `return`, `status`, `prune`, `destroy`
+- `cmd/` - CLI commands (cobra): `get` (incl. `get --lease`), `enter`, `return`, `status`, `prune`, `destroy`
 - `internal/config/` - config file loading (`treehouse.toml`)
 - `internal/hooks/` - user-configured lifecycle hook command execution
 - `internal/pool/` - pool manager (acquire, release, list, destroy, prune) + state file

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The default treehouse root is `~/.treehouse/`.
 | `treehouse`                | Get a worktree and open a subshell (alias for `get`) |
 | `treehouse get`            | Acquire a worktree from the pool                     |
 | `treehouse get --lease`    | Durably lease a worktree without a subshell; print its path |
+| `treehouse enter <name>`   | Open a subshell in an existing worktree by name (the number from `status`), even if it is in use; pool state is left untouched |
 | `treehouse status`         | Show pool status (highlights leased and current worktrees) |
 | `treehouse return [path]`  | Release any lease, terminate lingering worktree processes, and return it to the pool |
 | `treehouse prune`          | Dry-run removal of stale idle worktrees in the current repo pool |

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The default treehouse root is `~/.treehouse/`.
 | --------- | --------- | --------------------------------- |
 | `get`     | `--lease` | Durably lease the worktree without opening a subshell; print only its path to stdout |
 | `get`     | `--lease-holder` | Optional label recorded as the lease holder (defaults to `$TREEHOUSE_LEASE_HOLDER`) |
+| `enter`   | `--print-path` | Print only the worktree's absolute path to stdout instead of opening a subshell (for `cd "$(treehouse enter --print-path 1)"`) |
 | `return`  | `--force` | Clean, reset, and return without prompting |
 | `prune`   | `--yes`   | Delete listed prune candidates instead of doing a dry run |
 | `prune`   | `--all`   | Sweep every managed pool under the user-level treehouse root |

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1628,3 +1628,52 @@ func TestPruneUsesCurrentRemoteDefaultBranch(t *testing.T) {
 		t.Fatalf("worktree unmerged into current remote default was removed: %v", err)
 	}
 }
+
+func TestEnterByNameOpensSubshellWithoutChangingPool(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	// exit-shell exits immediately so both get and enter return at once.
+	env := []string{"SHELL=" + exitShellBin}
+
+	if _, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get"); code != 0 {
+		t.Fatalf("treehouse get failed (code %d): %s", code, getErr)
+	}
+
+	_, enterErr, code := runTreehouse(t, repoDir, homeDir, env, "enter", "1")
+	if code != 0 {
+		t.Fatalf("treehouse enter 1 failed (code %d): %s", code, enterErr)
+	}
+	if !strings.Contains(enterErr, "Entered worktree 1 at") {
+		t.Errorf("expected 'Entered worktree 1 at' in stderr: %s", enterErr)
+	}
+	if !strings.Contains(enterErr, "Pool state unchanged") {
+		t.Errorf("expected 'Pool state unchanged' in stderr: %s", enterErr)
+	}
+
+	// enter must not return the worktree to an acquired/leased state; it stays
+	// in the pool exactly as before.
+	statusOut, statusErr, code := runTreehouse(t, repoDir, homeDir, nil, "status")
+	if code != 0 {
+		t.Fatalf("treehouse status failed (code %d): %s", code, statusErr)
+	}
+	if !strings.Contains(statusOut, "1") {
+		t.Errorf("expected worktree 1 in status output: %s", statusOut)
+	}
+}
+
+func TestEnterUnknownNameFails(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	env := []string{"SHELL=" + exitShellBin}
+	if _, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get"); code != 0 {
+		t.Fatalf("treehouse get failed (code %d): %s", code, getErr)
+	}
+
+	_, enterErr, code := runTreehouse(t, repoDir, homeDir, env, "enter", "999")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for unknown worktree name, got 0: %s", enterErr)
+	}
+	if !strings.Contains(enterErr, "no worktree named") {
+		t.Errorf("expected 'no worktree named' error in stderr: %s", enterErr)
+	}
+}

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1677,3 +1677,29 @@ func TestEnterUnknownNameFails(t *testing.T) {
 		t.Errorf("expected 'no worktree named' error in stderr: %s", enterErr)
 	}
 }
+
+func TestEnterPrintPathPrintsOnlyPathToStdout(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	env := []string{"SHELL=" + exitShellBin}
+	if _, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get"); code != 0 {
+		t.Fatalf("treehouse get failed (code %d): %s", code, getErr)
+	}
+
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, env, "enter", "--print-path", "1")
+	if code != 0 {
+		t.Fatalf("treehouse enter --print-path 1 failed (code %d): %s", code, stderr)
+	}
+
+	path := strings.TrimSpace(stdout)
+	if path == "" {
+		t.Fatalf("expected worktree path on stdout, got empty (stderr: %s)", stderr)
+	}
+	// Stdout must be exactly the path (one line) so command substitution is clean.
+	if strings.ContainsAny(path, "\n") || strings.Contains(stdout, "🌳") {
+		t.Errorf("expected only the bare path on stdout, got: %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(path, "README.md")); err != nil {
+		t.Errorf("printed path is not a valid worktree: %s (%v)", path, err)
+	}
+}

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kunchenguid/treehouse/internal/config"
+	"github.com/kunchenguid/treehouse/internal/git"
+	"github.com/kunchenguid/treehouse/internal/pool"
+	"github.com/kunchenguid/treehouse/internal/shell"
+	"github.com/kunchenguid/treehouse/internal/ui"
+)
+
+var enterCmd = &cobra.Command{
+	Use:   "enter <name>",
+	Short: "Open a subshell in an existing worktree by name, even if in use",
+	Long: `Open a subshell in an existing pool worktree identified by its name
+(the number shown by 'treehouse status'), including worktrees that are
+already in use.
+
+Unlike 'get', enter does not acquire, reset, or return the worktree: it
+drops you into the directory and leaves all pool state untouched when you
+exit. Use it to attach to a worktree another agent is already using.`,
+	Args: cobra.ExactArgs(1),
+	RunE: enterRunE,
+}
+
+func init() {
+	rootCmd.AddCommand(enterCmd)
+}
+
+func enterRunE(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	repoRoot, err := git.FindRepoRoot()
+	if err != nil {
+		return fmt.Errorf("not in a git repository: %w", err)
+	}
+
+	cfg, err := config.Load(repoRoot)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+	if err != nil {
+		return fmt.Errorf("failed to resolve pool directory: %w", err)
+	}
+
+	worktrees, err := pool.List(poolDir)
+	if err != nil {
+		return err
+	}
+
+	var target *pool.WorktreeStatus
+	for i := range worktrees {
+		if worktrees[i].Name == name {
+			target = &worktrees[i]
+			break
+		}
+	}
+	if target == nil {
+		names := make([]string, len(worktrees))
+		for i, wt := range worktrees {
+			names[i] = wt.Name
+		}
+		if len(names) == 0 {
+			return fmt.Errorf("no worktree named %q: the pool is empty. Run 'treehouse get' to create one", name)
+		}
+		return fmt.Errorf("no worktree named %q in pool (available: %s). Run 'treehouse status' for details", name, strings.Join(names, ", "))
+	}
+
+	fmt.Fprintf(os.Stderr, "🌳 Entered worktree %s at %s. Type 'exit' to leave.\n", target.Name, ui.PrettyPath(target.Path))
+
+	env := []string{
+		"TREEHOUSE_DIR=" + target.Path,
+	}
+	if _, err := shell.Spawn(target.Path, env); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(os.Stderr, "🌳 Left worktree. Pool state unchanged.")
+	return nil
+}

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -23,12 +23,19 @@ already in use.
 
 Unlike 'get', enter does not acquire, reset, or return the worktree: it
 drops you into the directory and leaves all pool state untouched when you
-exit. Use it to attach to a worktree another agent is already using.`,
+exit. Use it to attach to a worktree another agent is already using.
+
+Pass --print-path to print only the worktree's absolute path to stdout
+instead of opening a subshell. A shell can wrap this to change its own
+directory, e.g. 'cd "$(treehouse enter --print-path 1)"'.`,
 	Args: cobra.ExactArgs(1),
 	RunE: enterRunE,
 }
 
+var enterPrintPath bool
+
 func init() {
+	enterCmd.Flags().BoolVar(&enterPrintPath, "print-path", false, "Print the worktree's absolute path to stdout instead of opening a subshell")
 	rootCmd.AddCommand(enterCmd)
 }
 
@@ -71,6 +78,13 @@ func enterRunE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("no worktree named %q: the pool is empty. Run 'treehouse get' to create one", name)
 		}
 		return fmt.Errorf("no worktree named %q in pool (available: %s). Run 'treehouse status' for details", name, strings.Join(names, ", "))
+	}
+
+	if enterPrintPath {
+		// Only the absolute path goes to stdout so callers can capture it with
+		// command substitution, e.g. cd "$(treehouse enter --print-path 1)".
+		fmt.Fprintln(os.Stdout, target.Path)
+		return nil
 	}
 
 	fmt.Fprintf(os.Stderr, "🌳 Entered worktree %s at %s. Type 'exit' to leave.\n", target.Name, ui.PrettyPath(target.Path))


### PR DESCRIPTION
## What

Adds `treehouse enter <name>`, which opens a subshell in an existing pool worktree identified by its name (the number shown by `treehouse status`), including worktrees that are already in use.

## Why

`get` always hands out a *free* worktree and skips anything in-use/leased/dirty. There was no first-class way to re-attach to a specific existing worktree (e.g. to peek at what another agent is doing, or to hop back into a worktree you know by number). The workaround was `cd`-ing into the raw pool path by hand.

## Behavior

- Resolves the worktree by name via `pool.List`, then spawns a subshell in its directory (sets `TREEHOUSE_DIR`), mirroring how `get` enters.
- Unlike `get`, `enter` is a **guest**: it does **not** acquire, reset, lease, or return the worktree, and writes no pool state. On exit it leaves everything exactly as it was.
- Unknown names fail with a non-zero exit and list the available names.

```
$ treehouse enter 1
🌳 Entered worktree 1 at ~/.treehouse/myrepo-a1b2c3/1/myrepo. Type 'exit' to leave.
$ exit
🌳 Left worktree. Pool state unchanged.
```

## Tests

Adds two e2e tests (`TestEnterByNameOpensSubshellWithoutChangingPool`, `TestEnterUnknownNameFails`). Full suite passes; `gofmt`/`go vet` clean. Reuses the cross-platform `shell.Spawn`, so no Windows-specific handling is needed.

Docs (README CLI reference, AGENTS.md command list) updated.