### PR TITLE
feat(get): Add branch checkout mode

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -13,6 +13,7 @@ import (
 var (
 	treehouseBin      string
 	exitShellBin      string
+	dirtyShellBin     string
 	dirtyMainShellBin string
 )
 
@@ -59,6 +60,36 @@ func TestMain(m *testing.M) {
 	buildShell.Stderr = os.Stderr
 	if err := buildShell.Run(); err != nil {
 		panic("failed to build exit-shell: " + err.Error())
+	}
+
+	dirtyShellBin = filepath.Join(buildDir, "dirty-shell")
+	if runtime.GOOS == "windows" {
+		dirtyShellBin += ".exe"
+	}
+	dirtySrcDir := filepath.Join(buildDir, "dirty-shell-src")
+	if err := os.MkdirAll(dirtySrcDir, 0o755); err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirtySrcDir, "go.mod"), []byte("module dirty-shell\n\ngo 1.21\n"), 0o644); err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirtySrcDir, "main.go"), []byte(`package main
+
+import "os"
+
+func main() {
+	if err := os.WriteFile("branch-dirty.txt", []byte("dirty\n"), 0o644); err != nil {
+		os.Exit(1)
+	}
+}
+`), 0o644); err != nil {
+		panic(err)
+	}
+	buildDirtyShell := exec.Command("go", "build", "-o", dirtyShellBin, ".")
+	buildDirtyShell.Dir = dirtySrcDir
+	buildDirtyShell.Stderr = os.Stderr
+	if err := buildDirtyShell.Run(); err != nil {
+		panic("failed to build dirty-shell: " + err.Error())
 	}
 
 	dirtyMainShellBin = filepath.Join(buildDir, "dirty-main-shell")
@@ -179,10 +210,18 @@ func runTreehouse(t *testing.T, repoDir, homeDir string, extraEnv []string, args
 
 func runTreehouseFromDir(t *testing.T, repoDir, workDir, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
+	return runTreehouseFromDirWithInput(t, repoDir, workDir, homeDir, extraEnv, "", args...)
+}
+
+func runTreehouseFromDirWithInput(t *testing.T, repoDir, workDir, homeDir string, extraEnv []string, stdin string, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
 
 	cmd := exec.Command(treehouseBin, args...)
 	cmd.Dir = workDir
 	cmd.Env = buildEnv(homeDir, extraEnv...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
 
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -474,6 +513,58 @@ func TestGetLeasePrintsOnlyPathToStdout(t *testing.T) {
 	}
 }
 
+func TestGetLeaseBranchCreatesBranchAndPrintsOnlyPathToStdout(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	wantCommit := gitCmd(t, repoDir, "rev-parse", "origin/main")
+
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease", "-b", "agent-home")
+	if code != 0 {
+		t.Fatalf("treehouse get --lease -b failed (code %d): %s", code, stderr)
+	}
+
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly one stdout line, got %d:\n%q", len(lines), stdout)
+	}
+	wtPath := lines[0]
+	if !filepath.IsAbs(wtPath) {
+		t.Fatalf("expected an absolute path on stdout, got %q", wtPath)
+	}
+	if strings.Contains(stdout, "🌳") || strings.Contains(stdout, "Leased worktree") {
+		t.Fatalf("stdout must contain only the path, got:\n%q", stdout)
+	}
+
+	branch := gitCmd(t, wtPath, "symbolic-ref", "--short", "HEAD")
+	if branch != "agent-home" {
+		t.Fatalf("expected worktree to be on branch agent-home, got %q", branch)
+	}
+	gotCommit := gitCmd(t, wtPath, "rev-parse", "HEAD")
+	if gotCommit != wantCommit {
+		t.Fatalf("expected branch at %s, got %s", wantCommit, gotCommit)
+	}
+}
+
+func TestGetBranchRejectsExistingBranchBeforeAcquire(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	gitCmd(t, repoDir, "branch", "agent-home")
+
+	_, stderr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease", "-b", "agent-home")
+	if code == 0 {
+		t.Fatal("expected treehouse get --lease -b existing branch to fail")
+	}
+	if !strings.Contains(stderr, "branch \"agent-home\" already exists") {
+		t.Fatalf("expected existing branch error, got:\n%s", stderr)
+	}
+
+	statusOut, statusErr, code := runTreehouse(t, repoDir, homeDir, nil, "status")
+	if code != 0 {
+		t.Fatalf("status failed (code %d): %s", code, statusErr)
+	}
+	if strings.Contains(statusOut, "leased") || strings.Contains(statusOut, "in-use") || strings.Contains(statusOut, "available") {
+		t.Fatalf("expected no acquired worktrees after branch rejection, got:\n%s", statusOut)
+	}
+}
+
 func TestGetLeaseRecordsHolder(t *testing.T) {
 	repoDir, homeDir := setupTestRepo(t)
 
@@ -726,6 +817,31 @@ func TestGetDetachesWorktreeWhenLeavingDirty(t *testing.T) {
 	}
 	if out, err := gitCmdResult(t, repoDir, "checkout", "main"); err != nil {
 		t.Fatalf("expected main repo to checkout main after dirty worktree exit, got: %v\n%s", err, out)
+	}
+}
+
+func TestGetBranchLeavesDirtyWorktreeOnBranch(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	env := []string{"SHELL=" + dirtyShellBin}
+	_, getErr, code := runTreehouseFromDirWithInput(t, repoDir, repoDir, homeDir, env, "n\n", "get", "-b", "agent-work")
+	if code != 0 {
+		t.Fatalf("get -b failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+	if !strings.Contains(getErr, "Worktree left dirty") {
+		t.Fatalf("expected get to leave dirty worktree for this regression, got: %s", getErr)
+	}
+
+	branch := gitCmd(t, wtPath, "symbolic-ref", "--short", "HEAD")
+	if branch != "agent-work" {
+		t.Fatalf("expected dirty worktree to remain on branch agent-work, got %q", branch)
+	}
+	if status := gitCmd(t, wtPath, "status", "--porcelain"); !strings.Contains(status, "branch-dirty.txt") {
+		t.Fatalf("expected dirty shell output to remain, got status:\n%s", status)
 	}
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -20,6 +20,7 @@ import (
 var (
 	getLease       bool
 	getLeaseHolder string
+	getBranch      string
 )
 
 var getCmd = &cobra.Command{
@@ -38,6 +39,7 @@ running inside it, until you release it with 'treehouse return <path>'.`,
 func init() {
 	getCmd.Flags().BoolVar(&getLease, "lease", false, "Durably lease a worktree without opening a subshell; print only its path to stdout")
 	getCmd.Flags().StringVar(&getLeaseHolder, "lease-holder", "", "Optional label recorded as the lease holder (defaults to $TREEHOUSE_LEASE_HOLDER)")
+	getCmd.Flags().StringVarP(&getBranch, "branch", "b", "", "Create and check out a new branch in the acquired worktree")
 	rootCmd.AddCommand(getCmd)
 }
 
@@ -61,6 +63,10 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "warning: failed to update .gitignore: %v\n", err)
 	}
 
+	if err := git.ValidateNewBranch(repoRoot, getBranch); err != nil {
+		return err
+	}
+
 	if getLease {
 		return getLeaseRunE(repoRoot, poolDir, cfg)
 	}
@@ -68,6 +74,14 @@ func getRunE(cmd *cobra.Command, args []string) error {
 	wtPath, err := pool.Acquire(repoRoot, poolDir, cfg.MaxTrees, cfg.Hooks.PostCreate)
 	if err != nil {
 		return err
+	}
+	if getBranch != "" {
+		if err := git.CreateBranchInWorktree(wtPath, getBranch); err != nil {
+			if releaseErr := pool.Release(poolDir, wtPath); releaseErr != nil {
+				return fmt.Errorf("create branch %q: %w; additionally failed to return worktree: %v", getBranch, err, releaseErr)
+			}
+			return fmt.Errorf("create branch %q: %w", getBranch, err)
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "🌳 Entered worktree at %s. Type 'exit' to return.\n", ui.PrettyPath(wtPath))
@@ -77,9 +91,10 @@ func getRunE(cmd *cobra.Command, args []string) error {
 	}
 	_, err = shell.Spawn(wtPath, env)
 
-	// Subshell exited — handle return
-	if err := git.DetachWorktree(wtPath); err != nil {
-		fmt.Fprintf(os.Stderr, "🌳 Warning: failed to detach worktree HEAD: %v\n", err)
+	if getBranch == "" {
+		if err := git.DetachWorktree(wtPath); err != nil {
+			fmt.Fprintf(os.Stderr, "🌳 Warning: failed to detach worktree HEAD: %v\n", err)
+		}
 	}
 
 	dirty, _ := git.IsDirty(wtPath)
@@ -90,6 +105,12 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		if promptErr != nil || !ok {
 			fmt.Fprintln(os.Stderr, "🌳 Worktree left dirty. Use 'treehouse return --force' to clean it later.")
 			return nil
+		}
+	}
+
+	if getBranch != "" {
+		if err := git.DetachWorktree(wtPath); err != nil {
+			fmt.Fprintf(os.Stderr, "🌳 Warning: failed to detach worktree HEAD: %v\n", err)
 		}
 	}
 
@@ -117,6 +138,14 @@ func getLeaseRunE(repoRoot, poolDir string, cfg config.Config) error {
 	wtPath, err := pool.AcquireLease(repoRoot, poolDir, cfg.MaxTrees, cfg.Hooks.PostCreate, holder)
 	if err != nil {
 		return err
+	}
+	if getBranch != "" {
+		if err := git.CreateBranchInWorktree(wtPath, getBranch); err != nil {
+			if releaseErr := pool.Release(poolDir, wtPath); releaseErr != nil {
+				return fmt.Errorf("create branch %q: %w; additionally failed to release lease: %v", getBranch, err, releaseErr)
+			}
+			return fmt.Errorf("create branch %q: %w", getBranch, err)
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "🌳 Leased worktree at %s. Run 'treehouse return %s' to release it.\n",

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -153,6 +153,34 @@ func RemoveCleanWorktree(repoRoot, path string) error {
 	return err
 }
 
+// ValidateNewBranch checks that branch can be created as a new local branch.
+func ValidateNewBranch(repoRoot, branch string) error {
+	if branch == "" {
+		return nil
+	}
+	if _, err := runGit(repoRoot, "check-ref-format", "--branch", branch); err != nil {
+		return fmt.Errorf("invalid branch name %q: %w", branch, err)
+	}
+	if refExists(repoRoot, "refs/heads/"+branch) {
+		return fmt.Errorf("branch %q already exists", branch)
+	}
+	return nil
+}
+
+// CreateBranchInWorktree creates branch at the worktree's current HEAD and
+// checks it out in that worktree.
+func CreateBranchInWorktree(worktreePath, branch string) error {
+	repoRoot, err := FindMainRepoRootFrom(worktreePath)
+	if err != nil {
+		return err
+	}
+	if err := ValidateNewBranch(repoRoot, branch); err != nil {
+		return err
+	}
+	_, err = runGit(worktreePath, "checkout", "-b", branch)
+	return err
+}
+
 func Fetch(repoRoot string) error {
 	if !HasRemote(repoRoot, "origin") {
 		return nil

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -101,6 +101,66 @@ func TestRemoveCleanWorktreeRejectsDirtyWorktree(t *testing.T) {
 	}
 }
 
+func TestValidateNewBranchRejectsInvalidName(t *testing.T) {
+	repoDir := setupGitTestRepo(t)
+
+	if err := ValidateNewBranch(repoDir, "bad name"); err == nil {
+		t.Fatal("expected invalid branch name to be rejected")
+	}
+}
+
+func TestValidateNewBranchRejectsExistingBranch(t *testing.T) {
+	repoDir := setupGitTestRepo(t)
+	mustGit(t, repoDir, "branch", "agent-home")
+
+	err := ValidateNewBranch(repoDir, "agent-home")
+	if err == nil {
+		t.Fatal("expected existing branch to be rejected")
+	}
+	if !strings.Contains(err.Error(), "branch \"agent-home\" already exists") {
+		t.Fatalf("expected existing branch error, got %v", err)
+	}
+}
+
+func TestCreateBranchInWorktreeCreatesBranchAtCurrentHead(t *testing.T) {
+	base := t.TempDir()
+	repoDir := setupGitTestRepoInDir(t, filepath.Join(base, "repo"))
+	wtPath := filepath.Join(base, "worktree")
+	mustGit(t, repoDir, "worktree", "add", "--detach", wtPath, "main")
+	want := mustGitOutput(t, wtPath, "rev-parse", "HEAD")
+
+	if err := CreateBranchInWorktree(wtPath, "agent-home"); err != nil {
+		t.Fatalf("CreateBranchInWorktree failed: %v", err)
+	}
+
+	branch := mustGitOutput(t, wtPath, "symbolic-ref", "--short", "HEAD")
+	if branch != "agent-home" {
+		t.Fatalf("expected branch agent-home, got %q", branch)
+	}
+	got := mustGitOutput(t, wtPath, "rev-parse", "HEAD")
+	if got != want {
+		t.Fatalf("expected branch at %s, got %s", want, got)
+	}
+}
+
+func setupGitTestRepo(t *testing.T) string {
+	t.Helper()
+	return setupGitTestRepoInDir(t, filepath.Join(t.TempDir(), "repo"))
+}
+
+func setupGitTestRepoInDir(t *testing.T, repoDir string) string {
+	t.Helper()
+	mustGit(t, "", "init", "--initial-branch=main", repoDir)
+	mustGit(t, repoDir, "config", "user.email", "test@test.com")
+	mustGit(t, repoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repoDir, "add", ".")
+	mustGit(t, repoDir, "commit", "-m", "initial")
+	return repoDir
+}
+
 func mustGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -111,4 +171,17 @@ func mustGit(t *testing.T, dir string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
 	}
+}
+
+func mustGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
Allow `treehouse get -b <branch>` and `treehouse get --lease -b <branch>`
to create a new local branch after acquisition.
The worktree still enters through the existing detached acquisition path,
then checks out the requested branch at the acquired `HEAD`.

Preserve existing dirty-exit behavior for plain `treehouse get`.
Branch mode keeps a dirty declined-cleanup worktree on the branch,
while clean returns still detach and restore the pool state.
