### PR TITLE
Add go command for existing worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The default treehouse root is `~/.treehouse/`.
 | `treehouse`                | Get a worktree and open a subshell (alias for `get`) |
 | `treehouse get`            | Acquire a worktree from the pool                     |
 | `treehouse get --lease`    | Durably lease a worktree without a subshell; print its path |
+| `treehouse go [target]`    | Open a shell in an existing managed worktree from any directory |
 | `treehouse status`         | Show pool status (highlights leased and current worktrees) |
 | `treehouse return [path]`  | Release any lease, terminate lingering worktree processes, and return it to the pool |
 | `treehouse prune`          | Dry-run removal of stale idle worktrees in the current repo pool |
@@ -172,6 +173,23 @@ The default treehouse root is `~/.treehouse/`.
 | `destroy` | `--include-unlanded` | Also remove dirty, unmerged, or unverified worktrees (irreversible data loss) |
 | `destroy` | `--include-in-use` | Also remove worktrees with a running process or owner reservation (processes are terminated cleanly first) |
 | `destroy` | `--include-leased` | Also remove a leased worktree; only when the exact path is named, never via `--all` |
+
+### Navigating to an existing worktree
+
+Use `treehouse go` from any directory to list every existing managed worktree under the user-level treehouse root, choose one, and open a shell there.
+
+```sh
+treehouse go
+```
+
+Use a target to skip the prompt. The target resolves by exact path, worktree directory name, Treehouse state name, or a unique path substring.
+
+```sh
+treehouse go tree-3
+treehouse go my-feature-session
+```
+
+The command only opens a shell in an existing worktree. It does not acquire a new worktree or return the selected worktree to the pool when the shell exits.
 
 ### Leasing a worktree (no subshell)
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -479,9 +479,30 @@ func TestGoTargetFromAnywhereOpensExistingWorktree(t *testing.T) {
 	_ = wtPathA
 }
 
+func TestTruncateTableCell(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		width int
+		want  string
+	}{
+		{name: "short", value: "jira", width: 20, want: "jira"},
+		{name: "exact", value: "12345678901234567890", width: 20, want: "12345678901234567890"},
+		{name: "long", value: "very-long-project-name", width: 20, want: "very-long-project..."},
+		{name: "small width", value: "abcdef", width: 3, want: "abcdef"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateTableCell(tt.value, tt.width); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestGoInteractiveListsGlobalWorktreesAndOpensSelection(t *testing.T) {
 	repoA, homeDir := setupTestRepo(t)
-	repoB := setupTestRepoWithHome(t, homeDir, "otherrepo")
+	repoB := setupTestRepoWithHome(t, homeDir, "otherrepo-with-a-very-long-name")
 	env := []string{"SHELL=" + exitShellBin}
 
 	_, getErrA, code := runTreehouse(t, repoA, homeDir, env, "get")
@@ -515,10 +536,13 @@ func TestGoInteractiveListsGlobalWorktreesAndOpensSelection(t *testing.T) {
 	if !strings.Contains(goOut, "#   Status       Project               Location") || !strings.Contains(goOut, "--  -----------  --------------------  --------") {
 		t.Fatalf("expected interactive list to render as a table, got stdout:\n%s", goOut)
 	}
-	if !strings.Contains(goOut, "myrepo") || !strings.Contains(goOut, "otherrepo") {
+	if !strings.Contains(goOut, "myrepo") || !strings.Contains(goOut, "otherrepo-with-a-...") {
 		t.Fatalf("expected interactive list to include project names before locations, got stdout:\n%s", goOut)
 	}
-	otherRowIndex := strings.Index(goOut, "[available]  otherrepo")
+	if strings.Contains(goOut, "otherrepo-with-a-very-long-name  ") {
+		t.Fatalf("expected long project name to be truncated, got stdout:\n%s", goOut)
+	}
+	otherRowIndex := strings.Index(goOut, "[available]  otherrepo-with-a-...")
 	otherLocationIndex := strings.Index(goOut, filepath.Base(wtPathB))
 	if otherRowIndex < 0 || otherLocationIndex < 0 || otherRowIndex > otherLocationIndex {
 		t.Fatalf("expected table row with status, project otherrepo, then location %s, got stdout:\n%s", filepath.Base(wtPathB), goOut)

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -179,10 +179,18 @@ func runTreehouse(t *testing.T, repoDir, homeDir string, extraEnv []string, args
 
 func runTreehouseFromDir(t *testing.T, repoDir, workDir, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
+	return runTreehouseFromDirWithInput(t, repoDir, workDir, homeDir, extraEnv, "", args...)
+}
+
+func runTreehouseFromDirWithInput(t *testing.T, repoDir, workDir, homeDir string, extraEnv []string, stdin string, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
 
 	cmd := exec.Command(treehouseBin, args...)
 	cmd.Dir = workDir
 	cmd.Env = buildEnv(homeDir, extraEnv...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
 
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -431,6 +439,106 @@ func TestGetAndStatus(t *testing.T) {
 	}
 	if !strings.Contains(statusOut, "available") {
 		t.Errorf("expected 'available' in status output: %s", statusOut)
+	}
+}
+
+func TestGoTargetFromAnywhereOpensExistingWorktree(t *testing.T) {
+	repoA, homeDir := setupTestRepo(t)
+	repoB := setupTestRepoWithHome(t, homeDir, "otherrepo")
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErrA, code := runTreehouse(t, repoA, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo A get failed (code %d): %s", code, getErrA)
+	}
+	wtPathA := extractWorktreePath(getErrA, homeDir)
+	if wtPathA == "" {
+		t.Fatal("could not extract repo A worktree path")
+	}
+
+	_, getErrB, code := runTreehouse(t, repoB, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo B get failed (code %d): %s", code, getErrB)
+	}
+	wtPathB := extractWorktreePath(getErrB, homeDir)
+	if wtPathB == "" {
+		t.Fatal("could not extract repo B worktree path")
+	}
+
+	outsideDir := t.TempDir()
+	goOut, goErr, code := runTreehouseFromDir(t, repoA, outsideDir, homeDir, env, "go", filepath.Base(wtPathB))
+	if code != 0 {
+		t.Fatalf("treehouse go target failed from outside a repo (code %d): stdout:\n%s\nstderr:\n%s", code, goOut, goErr)
+	}
+	if !strings.Contains(goErr, "Entered worktree at") || !strings.Contains(goErr, filepath.Base(wtPathB)) {
+		t.Fatalf("expected go to enter repo B worktree, stdout:\n%s\nstderr:\n%s", goOut, goErr)
+	}
+	if strings.Contains(goErr, "Worktree returned to pool") {
+		t.Fatalf("treehouse go should not return an existing worktree to the pool, got stderr:\n%s", goErr)
+	}
+	_ = wtPathA
+}
+
+func TestGoInteractiveListsGlobalWorktreesAndOpensSelection(t *testing.T) {
+	repoA, homeDir := setupTestRepo(t)
+	repoB := setupTestRepoWithHome(t, homeDir, "otherrepo")
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, getErrA, code := runTreehouse(t, repoA, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo A get failed (code %d): %s", code, getErrA)
+	}
+	wtPathA := extractWorktreePath(getErrA, homeDir)
+	if wtPathA == "" {
+		t.Fatal("could not extract repo A worktree path")
+	}
+
+	_, getErrB, code := runTreehouse(t, repoB, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("repo B get failed (code %d): %s", code, getErrB)
+	}
+	wtPathB := extractWorktreePath(getErrB, homeDir)
+	if wtPathB == "" {
+		t.Fatal("could not extract repo B worktree path")
+	}
+
+	outsideDir := t.TempDir()
+	goOut, goErr, code := runTreehouseFromDirWithInput(t, repoA, outsideDir, homeDir, env, "1\n", "go")
+	if code != 0 {
+		t.Fatalf("treehouse go interactive failed from outside a repo (code %d): stdout:\n%s\nstderr:\n%s", code, goOut, goErr)
+	}
+	for _, wtPath := range []string{wtPathA, wtPathB} {
+		if !strings.Contains(goOut, filepath.Base(wtPath)) {
+			t.Fatalf("expected interactive list to include %s, got stdout:\n%s", filepath.Base(wtPath), goOut)
+		}
+	}
+	selectedBase := filepath.Base(wtPathA)
+	if strings.Index(goOut, filepath.Base(wtPathB)) < strings.Index(goOut, filepath.Base(wtPathA)) {
+		selectedBase = filepath.Base(wtPathB)
+	}
+	if !strings.Contains(goErr, selectedBase) {
+		t.Fatalf("expected selected worktree %s in stderr, got:\n%s", selectedBase, goErr)
+	}
+}
+
+func TestGoErrorsWhenNoWorktreesOrNoTargetMatch(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	outsideDir := t.TempDir()
+	env := []string{"SHELL=" + exitShellBin}
+
+	_, goErr, code := runTreehouseFromDir(t, repoDir, outsideDir, homeDir, env, "go")
+	if code == 0 || !strings.Contains(goErr, "no Treehouse worktrees found") {
+		t.Fatalf("expected empty go error, code %d stderr:\n%s", code, goErr)
+	}
+
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+
+	_, goErr, code = runTreehouseFromDir(t, repoDir, outsideDir, homeDir, env, "go", "missing-target")
+	if code == 0 || !strings.Contains(goErr, "no worktree matches") {
+		t.Fatalf("expected no-match go error, code %d stderr:\n%s", code, goErr)
 	}
 }
 

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -515,10 +515,11 @@ func TestGoInteractiveListsGlobalWorktreesAndOpensSelection(t *testing.T) {
 	if !strings.Contains(goOut, "myrepo") || !strings.Contains(goOut, "otherrepo") {
 		t.Fatalf("expected interactive list to include project names before locations, got stdout:\n%s", goOut)
 	}
+	otherStatusIndex := strings.Index(goOut, "[available]")
 	otherProjectIndex := strings.Index(goOut, "otherrepo")
 	otherLocationIndex := strings.Index(goOut, filepath.Base(wtPathB))
-	if otherProjectIndex < 0 || otherLocationIndex < 0 || otherProjectIndex > otherLocationIndex {
-		t.Fatalf("expected project name otherrepo before location %s, got stdout:\n%s", filepath.Base(wtPathB), goOut)
+	if otherStatusIndex < 0 || otherProjectIndex < 0 || otherLocationIndex < 0 || otherStatusIndex > otherProjectIndex || otherProjectIndex > otherLocationIndex {
+		t.Fatalf("expected status, project otherrepo, then location %s, got stdout:\n%s", filepath.Base(wtPathB), goOut)
 	}
 	selectedBase := filepath.Base(wtPathA)
 	if strings.Index(goOut, filepath.Base(wtPathB)) < strings.Index(goOut, filepath.Base(wtPathA)) {

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -512,14 +512,16 @@ func TestGoInteractiveListsGlobalWorktreesAndOpensSelection(t *testing.T) {
 			t.Fatalf("expected interactive list to include %s, got stdout:\n%s", filepath.Base(wtPath), goOut)
 		}
 	}
+	if !strings.Contains(goOut, "#   Status       Project               Location") || !strings.Contains(goOut, "--  -----------  --------------------  --------") {
+		t.Fatalf("expected interactive list to render as a table, got stdout:\n%s", goOut)
+	}
 	if !strings.Contains(goOut, "myrepo") || !strings.Contains(goOut, "otherrepo") {
 		t.Fatalf("expected interactive list to include project names before locations, got stdout:\n%s", goOut)
 	}
-	otherStatusIndex := strings.Index(goOut, "[available]")
-	otherProjectIndex := strings.Index(goOut, "otherrepo")
+	otherRowIndex := strings.Index(goOut, "[available]  otherrepo")
 	otherLocationIndex := strings.Index(goOut, filepath.Base(wtPathB))
-	if otherStatusIndex < 0 || otherProjectIndex < 0 || otherLocationIndex < 0 || otherStatusIndex > otherProjectIndex || otherProjectIndex > otherLocationIndex {
-		t.Fatalf("expected status, project otherrepo, then location %s, got stdout:\n%s", filepath.Base(wtPathB), goOut)
+	if otherRowIndex < 0 || otherLocationIndex < 0 || otherRowIndex > otherLocationIndex {
+		t.Fatalf("expected table row with status, project otherrepo, then location %s, got stdout:\n%s", filepath.Base(wtPathB), goOut)
 	}
 	selectedBase := filepath.Base(wtPathA)
 	if strings.Index(goOut, filepath.Base(wtPathB)) < strings.Index(goOut, filepath.Base(wtPathA)) {

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -512,6 +512,14 @@ func TestGoInteractiveListsGlobalWorktreesAndOpensSelection(t *testing.T) {
 			t.Fatalf("expected interactive list to include %s, got stdout:\n%s", filepath.Base(wtPath), goOut)
 		}
 	}
+	if !strings.Contains(goOut, "myrepo") || !strings.Contains(goOut, "otherrepo") {
+		t.Fatalf("expected interactive list to include project names before locations, got stdout:\n%s", goOut)
+	}
+	otherProjectIndex := strings.Index(goOut, "otherrepo")
+	otherLocationIndex := strings.Index(goOut, filepath.Base(wtPathB))
+	if otherProjectIndex < 0 || otherLocationIndex < 0 || otherProjectIndex > otherLocationIndex {
+		t.Fatalf("expected project name otherrepo before location %s, got stdout:\n%s", filepath.Base(wtPathB), goOut)
+	}
 	selectedBase := filepath.Base(wtPathA)
 	if strings.Index(goOut, filepath.Base(wtPathB)) < strings.Index(goOut, filepath.Base(wtPathA)) {
 		selectedBase = filepath.Base(wtPathB)

--- a/cmd/go.go
+++ b/cmd/go.go
@@ -75,10 +75,11 @@ func goRunE(cmd *cobra.Command, args []string) error {
 func promptNavigationWorktree(w io.Writer, r io.Reader, worktrees []pool.NavigationWorktree) (pool.NavigationWorktree, error) {
 	fmt.Fprintln(w, "🌳 Treehouse worktrees:")
 	for i, wt := range worktrees {
-		line := fmt.Sprintf("%d) %-20s  %s", i+1, wt.Project, ui.PrettyPath(wt.Path))
-		if wt.Status != "" {
-			line += fmt.Sprintf("  [%s]", wt.Status)
+		status := wt.Status
+		if status == "" {
+			status = "unknown"
 		}
+		line := fmt.Sprintf("%d) [%s] %-20s  %s", i+1, status, wt.Project, ui.PrettyPath(wt.Path))
 		if wt.Status == pool.StatusLeased && wt.LeaseHolder != "" {
 			line += fmt.Sprintf("  (held by %s)", wt.LeaseHolder)
 		}

--- a/cmd/go.go
+++ b/cmd/go.go
@@ -74,16 +74,18 @@ func goRunE(cmd *cobra.Command, args []string) error {
 
 func promptNavigationWorktree(w io.Writer, r io.Reader, worktrees []pool.NavigationWorktree) (pool.NavigationWorktree, error) {
 	fmt.Fprintln(w, "🌳 Treehouse worktrees:")
+	fmt.Fprintln(w, "#   Status       Project               Location")
+	fmt.Fprintln(w, "--  -----------  --------------------  --------")
 	for i, wt := range worktrees {
 		status := wt.Status
 		if status == "" {
 			status = "unknown"
 		}
-		line := fmt.Sprintf("%d) [%s] %-20s  %s", i+1, status, wt.Project, ui.PrettyPath(wt.Path))
+		location := ui.PrettyPath(wt.Path)
 		if wt.Status == pool.StatusLeased && wt.LeaseHolder != "" {
-			line += fmt.Sprintf("  (held by %s)", wt.LeaseHolder)
+			location += fmt.Sprintf("  (held by %s)", wt.LeaseHolder)
 		}
-		fmt.Fprintln(w, line)
+		fmt.Fprintf(w, "%-2d  [%-9s]  %-20s  %s\n", i+1, status, wt.Project, location)
 	}
 	fmt.Fprint(w, "Choose a worktree: ")
 

--- a/cmd/go.go
+++ b/cmd/go.go
@@ -72,6 +72,13 @@ func goRunE(cmd *cobra.Command, args []string) error {
 	return err
 }
 
+func truncateTableCell(value string, width int) string {
+	if width <= 3 || len(value) <= width {
+		return value
+	}
+	return value[:width-3] + "..."
+}
+
 func promptNavigationWorktree(w io.Writer, r io.Reader, worktrees []pool.NavigationWorktree) (pool.NavigationWorktree, error) {
 	fmt.Fprintln(w, "🌳 Treehouse worktrees:")
 	fmt.Fprintln(w, "#   Status       Project               Location")
@@ -85,7 +92,7 @@ func promptNavigationWorktree(w io.Writer, r io.Reader, worktrees []pool.Navigat
 		if wt.Status == pool.StatusLeased && wt.LeaseHolder != "" {
 			location += fmt.Sprintf("  (held by %s)", wt.LeaseHolder)
 		}
-		fmt.Fprintf(w, "%-2d  [%-9s]  %-20s  %s\n", i+1, status, wt.Project, location)
+		fmt.Fprintf(w, "%-2d  [%-9s]  %-20s  %s\n", i+1, status, truncateTableCell(wt.Project, 20), location)
 	}
 	fmt.Fprint(w, "Choose a worktree: ")
 

--- a/cmd/go.go
+++ b/cmd/go.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kunchenguid/treehouse/internal/config"
+	"github.com/kunchenguid/treehouse/internal/pool"
+	"github.com/kunchenguid/treehouse/internal/shell"
+	"github.com/kunchenguid/treehouse/internal/ui"
+)
+
+var goCmd = &cobra.Command{
+	Use:   "go [target]",
+	Short: "Open a shell in an existing Treehouse worktree",
+	Long: `Open a shell in an existing Treehouse-managed worktree.
+
+With no arguments, treehouse go lists every managed worktree under the
+user-level treehouse root and prompts you to choose one. With a target, it opens
+the unique worktree whose path, basename, name, or path substring matches.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: goRunE,
+}
+
+func init() {
+	rootCmd.AddCommand(goCmd)
+}
+
+func goRunE(cmd *cobra.Command, args []string) error {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	poolRoot, err := config.ResolvePoolRoot("", cfg.Root)
+	if err != nil {
+		return err
+	}
+
+	worktrees, err := pool.ListNavigationWorktrees(poolRoot)
+	if err != nil {
+		return err
+	}
+	if len(worktrees) == 0 {
+		return fmt.Errorf("no Treehouse worktrees found under %s", ui.PrettyPath(poolRoot))
+	}
+
+	var selected pool.NavigationWorktree
+	if len(args) > 0 {
+		selected, err = pool.ResolveNavigationTarget(worktrees, args[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		selected, err = promptNavigationWorktree(os.Stdout, os.Stdin, worktrees)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "🌳 Entered worktree at %s. Type 'exit' to return.\n", ui.PrettyPath(selected.Path))
+	env := []string{
+		"TREEHOUSE_DIR=" + selected.Path,
+	}
+	_, err = shell.Spawn(selected.Path, env)
+	return err
+}
+
+func promptNavigationWorktree(w io.Writer, r io.Reader, worktrees []pool.NavigationWorktree) (pool.NavigationWorktree, error) {
+	fmt.Fprintln(w, "🌳 Treehouse worktrees:")
+	for i, wt := range worktrees {
+		line := fmt.Sprintf("%d) %-4s  %-11s  %s", i+1, wt.Name, wt.Status, ui.PrettyPath(wt.Path))
+		if wt.Status == pool.StatusLeased && wt.LeaseHolder != "" {
+			line += fmt.Sprintf("  (held by %s)", wt.LeaseHolder)
+		}
+		fmt.Fprintln(w, line)
+	}
+	fmt.Fprint(w, "Choose a worktree: ")
+
+	reader := bufio.NewReader(r)
+	input, err := reader.ReadString('\n')
+	if err != nil && len(input) == 0 {
+		return pool.NavigationWorktree{}, err
+	}
+	trimmed := strings.TrimSpace(input)
+	choice, err := strconv.Atoi(trimmed)
+	if err != nil || choice < 1 || choice > len(worktrees) {
+		return pool.NavigationWorktree{}, fmt.Errorf("invalid worktree selection %q", trimmed)
+	}
+	return worktrees[choice-1], nil
+}

--- a/cmd/go.go
+++ b/cmd/go.go
@@ -75,7 +75,10 @@ func goRunE(cmd *cobra.Command, args []string) error {
 func promptNavigationWorktree(w io.Writer, r io.Reader, worktrees []pool.NavigationWorktree) (pool.NavigationWorktree, error) {
 	fmt.Fprintln(w, "🌳 Treehouse worktrees:")
 	for i, wt := range worktrees {
-		line := fmt.Sprintf("%d) %-4s  %-11s  %s", i+1, wt.Name, wt.Status, ui.PrettyPath(wt.Path))
+		line := fmt.Sprintf("%d) %-20s  %s", i+1, wt.Project, ui.PrettyPath(wt.Path))
+		if wt.Status != "" {
+			line += fmt.Sprintf("  [%s]", wt.Status)
+		}
 		if wt.Status == pool.StatusLeased && wt.LeaseHolder != "" {
 			line += fmt.Sprintf("  (held by %s)", wt.LeaseHolder)
 		}

--- a/internal/pool/navigation.go
+++ b/internal/pool/navigation.go
@@ -11,6 +11,7 @@ import (
 // treehouse go.
 type NavigationWorktree struct {
 	PoolDir     string
+	Project     string
 	Name        string
 	Path        string
 	Status      string
@@ -31,9 +32,11 @@ func ListNavigationWorktrees(poolRoot string) ([]NavigationWorktree, error) {
 		if err != nil {
 			return nil, err
 		}
+		project := navigationProjectName(poolDir)
 		for _, wt := range worktrees {
 			result = append(result, NavigationWorktree{
 				PoolDir:     poolDir,
+				Project:     project,
 				Name:        wt.Name,
 				Path:        wt.Path,
 				Status:      wt.Status,
@@ -102,6 +105,23 @@ func navigationMatches(worktrees []NavigationWorktree, match func(NavigationWork
 		}
 	}
 	return matches
+}
+
+func navigationProjectName(poolDir string) string {
+	name := filepath.Base(poolDir)
+	if len(name) > 7 && name[len(name)-7] == '-' && isLowerHex(name[len(name)-6:]) {
+		return name[:len(name)-7]
+	}
+	return name
+}
+
+func isLowerHex(s string) bool {
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func cleanPathEqual(path, target string) bool {

--- a/internal/pool/navigation.go
+++ b/internal/pool/navigation.go
@@ -1,0 +1,124 @@
+package pool
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// NavigationWorktree describes a managed worktree that can be opened by
+// treehouse go.
+type NavigationWorktree struct {
+	PoolDir     string
+	Name        string
+	Path        string
+	Status      string
+	LeaseHolder string
+}
+
+// ListNavigationWorktrees returns every non-destroying managed worktree under
+// the given user-level treehouse root.
+func ListNavigationWorktrees(poolRoot string) ([]NavigationWorktree, error) {
+	poolDirs, err := prunePoolDirs(poolRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []NavigationWorktree
+	for _, poolDir := range poolDirs {
+		worktrees, err := List(poolDir)
+		if err != nil {
+			return nil, err
+		}
+		for _, wt := range worktrees {
+			result = append(result, NavigationWorktree{
+				PoolDir:     poolDir,
+				Name:        wt.Name,
+				Path:        wt.Path,
+				Status:      wt.Status,
+				LeaseHolder: wt.LeaseHolder,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Path == result[j].Path {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Path < result[j].Path
+	})
+	return result, nil
+}
+
+// ResolveNavigationTarget resolves target by exact path, exact basename or
+// worktree name, then unique substring of the path, basename, or name.
+func ResolveNavigationTarget(worktrees []NavigationWorktree, target string) (NavigationWorktree, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return NavigationWorktree{}, fmt.Errorf("empty target")
+	}
+
+	if wt, ok := uniqueNavigationMatch(worktrees, func(wt NavigationWorktree) bool {
+		return cleanPathEqual(wt.Path, target)
+	}); ok {
+		return wt, nil
+	}
+
+	if wt, ok := uniqueNavigationMatch(worktrees, func(wt NavigationWorktree) bool {
+		return wt.Name == target || filepath.Base(wt.Path) == target
+	}); ok {
+		return wt, nil
+	}
+
+	needle := strings.ToLower(target)
+	matches := navigationMatches(worktrees, func(wt NavigationWorktree) bool {
+		return strings.Contains(strings.ToLower(wt.Path), needle) ||
+			strings.Contains(strings.ToLower(filepath.Base(wt.Path)), needle) ||
+			strings.Contains(strings.ToLower(wt.Name), needle)
+	})
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) == 0 {
+		return NavigationWorktree{}, fmt.Errorf("no worktree matches %q", target)
+	}
+	return NavigationWorktree{}, fmt.Errorf("target %q is ambiguous; matches: %s", target, formatNavigationMatches(matches))
+}
+
+func uniqueNavigationMatch(worktrees []NavigationWorktree, match func(NavigationWorktree) bool) (NavigationWorktree, bool) {
+	matches := navigationMatches(worktrees, match)
+	if len(matches) != 1 {
+		return NavigationWorktree{}, false
+	}
+	return matches[0], true
+}
+
+func navigationMatches(worktrees []NavigationWorktree, match func(NavigationWorktree) bool) []NavigationWorktree {
+	var matches []NavigationWorktree
+	for _, wt := range worktrees {
+		if match(wt) {
+			matches = append(matches, wt)
+		}
+	}
+	return matches
+}
+
+func cleanPathEqual(path, target string) bool {
+	if filepath.Clean(path) == filepath.Clean(target) {
+		return true
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(path) == filepath.Clean(absTarget)
+}
+
+func formatNavigationMatches(worktrees []NavigationWorktree) string {
+	parts := make([]string, len(worktrees))
+	for i, wt := range worktrees {
+		parts[i] = fmt.Sprintf("%s (%s)", wt.Name, wt.Path)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/pool/navigation_test.go
+++ b/internal/pool/navigation_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestListNavigationWorktreesAcrossPools(t *testing.T) {
 	poolRoot := t.TempDir()
-	poolA := filepath.Join(poolRoot, "repo-a")
-	poolB := filepath.Join(poolRoot, "repo-b")
+	poolA := filepath.Join(poolRoot, "repo-a-123abc")
+	poolB := filepath.Join(poolRoot, "repo-b-456def")
 	wtA := filepath.Join(poolA, "tree-1")
 	wtB := filepath.Join(poolB, "tree-2")
 	for _, dir := range []string{wtA, wtB} {
@@ -34,6 +34,9 @@ func TestListNavigationWorktreesAcrossPools(t *testing.T) {
 	}
 	if worktrees[0].Path != wtA || worktrees[1].Path != wtB {
 		t.Fatalf("expected worktrees sorted by path, got %#v", worktrees)
+	}
+	if worktrees[0].Project != "repo-a" || worktrees[1].Project != "repo-b" {
+		t.Fatalf("expected project labels from pool dirs, got %#v", worktrees)
 	}
 	if worktrees[1].Status != StatusLeased || worktrees[1].LeaseHolder != "agent" {
 		t.Fatalf("expected leased status with holder, got %#v", worktrees[1])

--- a/internal/pool/navigation_test.go
+++ b/internal/pool/navigation_test.go
@@ -1,0 +1,101 @@
+package pool
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListNavigationWorktreesAcrossPools(t *testing.T) {
+	poolRoot := t.TempDir()
+	poolA := filepath.Join(poolRoot, "repo-a")
+	poolB := filepath.Join(poolRoot, "repo-b")
+	wtA := filepath.Join(poolA, "tree-1")
+	wtB := filepath.Join(poolB, "tree-2")
+	for _, dir := range []string{wtA, wtB} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := WriteState(poolA, State{Worktrees: []WorktreeEntry{{Name: "t1", Path: wtA}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteState(poolB, State{Worktrees: []WorktreeEntry{{Name: "t2", Path: wtB, Leased: true, LeaseHolder: "agent"}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	worktrees, err := ListNavigationWorktrees(poolRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(worktrees) != 2 {
+		t.Fatalf("expected 2 worktrees, got %d: %#v", len(worktrees), worktrees)
+	}
+	if worktrees[0].Path != wtA || worktrees[1].Path != wtB {
+		t.Fatalf("expected worktrees sorted by path, got %#v", worktrees)
+	}
+	if worktrees[1].Status != StatusLeased || worktrees[1].LeaseHolder != "agent" {
+		t.Fatalf("expected leased status with holder, got %#v", worktrees[1])
+	}
+}
+
+func TestResolveNavigationTarget(t *testing.T) {
+	root := t.TempDir()
+	alpha := filepath.Join(root, "alpha-session")
+	beta := filepath.Join(root, "beta-session")
+	worktrees := []NavigationWorktree{
+		{Name: "t1", Path: alpha},
+		{Name: "t2", Path: beta},
+	}
+
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{name: "path", target: alpha, want: alpha},
+		{name: "basename", target: "beta-session", want: beta},
+		{name: "name", target: "t1", want: alpha},
+		{name: "substring", target: "beta", want: beta},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveNavigationTarget(worktrees, tt.target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Path != tt.want {
+				t.Fatalf("expected %s, got %#v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestResolveNavigationTargetErrors(t *testing.T) {
+	root := t.TempDir()
+	worktrees := []NavigationWorktree{
+		{Name: "t1", Path: filepath.Join(root, "repo-one")},
+		{Name: "t2", Path: filepath.Join(root, "repo-two")},
+	}
+
+	_, err := ResolveNavigationTarget(worktrees, "missing")
+	if err == nil || !strings.Contains(err.Error(), "no worktree matches") {
+		t.Fatalf("expected no-match error, got %v", err)
+	}
+
+	_, err = ResolveNavigationTarget(worktrees, "repo")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguous error, got %v", err)
+	}
+}
+
+func TestListNavigationWorktreesEmptyRoot(t *testing.T) {
+	worktrees, err := ListNavigationWorktrees(filepath.Join(t.TempDir(), "missing"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(worktrees) != 0 {
+		t.Fatalf("expected no worktrees, got %#v", worktrees)
+	}
+}


### PR DESCRIPTION
## Problem

Treehouse can create or lease worktrees, but there is no quick way to see existing sessions and jump back into one from an arbitrary directory. Users need a navigation command that works globally across managed pools, not just from the repository that owns a specific pool.

## Implementation summary

- Adds `treehouse go [target]`.
- With no target, lists all existing Treehouse-managed worktrees under the user-level Treehouse root and prompts for a numeric selection.
- With a target, resolves a unique existing worktree by exact path, basename, Treehouse state name, or unique substring.
- Opens a shell in the selected worktree using the same shell spawning path as `treehouse get`.
- Does not acquire a new worktree and does not return the selected worktree to the pool when the shell exits.
- Reuses Treehouse state/list primitives instead of adding another state source.
- Shows the interactive choices in a table with status, project, and location.
- Truncates long project names to keep the table readable while leaving full locations visible.

## Examples

Interactive navigation from anywhere:

```sh
treehouse go
```

Example output:

```text
🌳 Treehouse worktrees:
#   Status       Project               Location
--  -----------  --------------------  --------
1   [available]  jira                  ~/.treehouse/jira-abc123/1/jira
2   [leased   ]  treehouse             ~/.treehouse/treehouse-def456/2/treehouse  (held by claude)
3   [available]  otherrepo-with-a-...  ~/.treehouse/otherrepo-with-a-very-long-name-c2a333/1/otherrepo-with-a-very-long-name
Choose a worktree:
```

Direct navigation by basename:

```sh
treehouse go jira
```

Direct navigation by unique substring:

```sh
treehouse go auth-refactor
```

Direct navigation by path:

```sh
treehouse go ~/.treehouse/treehouse-def456/2/treehouse
```

Ambiguous targets fail clearly instead of choosing silently:

```text
Error: target "tree" is ambiguous; matches: t1 (...), t2 (...)
```

## Validation

- `go test ./internal/pool ./cmd -run 'Test(ListNavigation|ResolveNavigation|Go)'`
- `go test ./cmd -run TestGoInteractiveListsGlobalWorktreesAndOpensSelection`
- `go test ./cmd -run 'Test(TruncateTableCell|GoInteractiveListsGlobalWorktreesAndOpensSelection)'`
- `go test ./...`
- `GOOS=windows go build ./...`
- Lightweight code review by subagent for the changed Go files.

## Risks

- The project label is derived from the managed pool directory name. This mirrors Treehouse's existing pool layout and strips the generated hash suffix for readability.
- The command opens an interactive shell, so automated tests use the existing test shell shim rather than launching a real user shell.

## Follow-ups

- Consider adding a non-interactive `--json` or `--plain` list mode if scripts need to consume the global session list later.
- Consider optional path truncation if the location column becomes too wide in terminals.