### PR TITLE
feat(pool): copy .worktreeinclude files into worktrees

### DIFF
--- a/internal/config/worktreeinclude.go
+++ b/internal/config/worktreeinclude.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CopyWorktreeIncludes copies gitignored files listed in .worktreeinclude from
+// repoRoot into the new worktree at wtPath. Lines starting with # are comments;
+// each other non-empty line is a path pattern relative to repoRoot (globs ok).
+// Missing .worktreeinclude or missing source files are silently skipped.
+func CopyWorktreeIncludes(repoRoot, wtPath string) error {
+	includePath := filepath.Join(repoRoot, ".worktreeinclude")
+	f, err := os.Open(includePath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	patterns, err := parseWorktreeInclude(f)
+	if err != nil {
+		return err
+	}
+
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(repoRoot, pattern))
+		if err != nil {
+			continue // malformed pattern — skip
+		}
+		for _, src := range matches {
+			rel, err := filepath.Rel(repoRoot, src)
+			if err != nil {
+				continue
+			}
+			dst := filepath.Join(wtPath, rel)
+			if err := copyFile(src, dst); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func parseWorktreeInclude(r io.Reader) ([]string, error) {
+	var patterns []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+	return patterns, scanner.Err()
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/config/worktreeinclude_test.go
+++ b/internal/config/worktreeinclude_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyWorktreeIncludes_NoFile(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	if err := CopyWorktreeIncludes(src, dst); err != nil {
+		t.Fatalf("expected no error when .worktreeinclude absent, got: %v", err)
+	}
+}
+
+func TestCopyWorktreeIncludes_CopiesListedFiles(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, ".env"), []byte("SECRET=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".worktreeinclude"), []byte(".env\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyWorktreeIncludes(src, dst); err != nil {
+		t.Fatalf("CopyWorktreeIncludes failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dst, ".env"))
+	if err != nil {
+		t.Fatalf("expected .env copied to worktree: %v", err)
+	}
+	if string(data) != "SECRET=1\n" {
+		t.Fatalf("unexpected content: %q", data)
+	}
+}
+
+func TestCopyWorktreeIncludes_SkipsCommentsAndBlanks(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, ".worktreeinclude"), []byte("# a comment\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyWorktreeIncludes(src, dst); err != nil {
+		t.Fatalf("CopyWorktreeIncludes failed: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dst)
+	if len(entries) != 0 {
+		t.Fatalf("expected no files copied for comment-only include, got %v", entries)
+	}
+}
+
+func TestCopyWorktreeIncludes_SkipsMissingSourceFile(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, ".worktreeinclude"), []byte("does-not-exist.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyWorktreeIncludes(src, dst); err != nil {
+		t.Fatalf("expected missing source file to be silently skipped, got: %v", err)
+	}
+}
+
+func TestCopyWorktreeIncludes_GlobPattern(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	secretsDir := filepath.Join(src, "secrets")
+	if err := os.MkdirAll(secretsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secretsDir, "a.json"), []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secretsDir, "b.json"), []byte(`{"b":2}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".worktreeinclude"), []byte("secrets/*.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyWorktreeIncludes(src, dst); err != nil {
+		t.Fatalf("CopyWorktreeIncludes failed: %v", err)
+	}
+
+	for _, name := range []string{"a.json", "b.json"} {
+		if _, err := os.Stat(filepath.Join(dst, "secrets", name)); err != nil {
+			t.Fatalf("expected secrets/%s copied: %v", name, err)
+		}
+	}
+}
+
+func TestCopyWorktreeIncludes_CreatesParentDirs(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	nested := filepath.Join(src, "a", "b")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "config.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".worktreeinclude"), []byte("a/b/config.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyWorktreeIncludes(src, dst); err != nil {
+		t.Fatalf("CopyWorktreeIncludes failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, "a", "b", "config.json")); err != nil {
+		t.Fatalf("expected nested file copied with parent dirs: %v", err)
+	}
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kunchenguid/treehouse/internal/config"
 	"github.com/kunchenguid/treehouse/internal/git"
 	"github.com/kunchenguid/treehouse/internal/hooks"
 	"github.com/kunchenguid/treehouse/internal/process"
@@ -158,6 +159,9 @@ func acquire(repoRoot, poolDir string, poolSize int, postCreate []string, opts a
 		return "", err
 	}
 	if runPostCreate {
+		if err := config.CopyWorktreeIncludes(repoRoot, acquired); err != nil {
+			fmt.Fprintf(os.Stderr, "🌳 Warning: failed to copy .worktreeinclude files: %v\n", err)
+		}
 		hooks.Run(postCreate, acquired, opts.hookStdout, opts.hookStderr)
 	}
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -2213,3 +2213,58 @@ func quoteForShell(p string) string {
 	// Double-quote works in both sh and cmd.exe for paths without quotes.
 	return `"` + p + `"`
 }
+
+func TestAcquire_CopiesWorktreeIncludesOnCreate(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	if err := os.WriteFile(filepath.Join(repoDir, ".env"), []byte("SECRET=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".worktreeinclude"), []byte(".env\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(wtPath, ".env")); err != nil {
+		t.Fatalf("expected .env copied into new worktree: %v", err)
+	}
+}
+
+func TestAcquire_CopiesWorktreeIncludesOnReuse(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	// Create and return a worktree so it sits idle in the pool.
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("first Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	// Now add .worktreeinclude + the file to the repo.
+	if err := os.WriteFile(filepath.Join(repoDir, ".env"), []byte("SECRET=2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".worktreeinclude"), []byte(".env\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reuse the idle worktree.
+	wtPath2, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("second Acquire failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(wtPath2, ".env"))
+	if err != nil {
+		t.Fatalf("expected .env copied into reused worktree: %v", err)
+	}
+	if string(data) != "SECRET=2\n" {
+		t.Fatalf("unexpected .env content: %q", data)
+	}
+}


### PR DESCRIPTION
## What

When `treehouse get` hands out a worktree (new or reused), it now reads `.worktreeinclude` from the repo root and copies any listed files into the worktree — mirroring how Claude Code handles `.worktreeinclude`.

## Why

Worktrees don't inherit gitignored files (`.env`, secrets, local config). Agents get a clean checkout but are missing credentials or tooling config they need to actually run.

## How it works

- `.worktreeinclude` lives at the repo root, one path pattern per line (globs supported)
- Lines starting with `#` and blank lines are ignored
- Missing source files are silently skipped
- Copy runs after `git add-worktree`/`git reset` but before `post_create` hooks, so hooks can rely on the files already being present
- Works for both new worktrees and pooled worktrees being reused after reset

## Example

```
# .worktreeinclude
.env
secrets/*.json
```