### PR TITLE
docs: document agent-guide maintenance policy

### DIFF
--- a/.no-mistakes/evidence/fm/agmd-treehouse-g0/agents-governance-verification.md
+++ b/.no-mistakes/evidence/fm/agmd-treehouse-g0/agents-governance-verification.md
@@ -1,0 +1,25 @@
+# AGENTS.md governance addition - verification
+
+Target commit: `1009f1d152481b16d6b3d85d95fe61542ed9e5a9`.
+
+The change from `c76015d914e8ae7068c024c68c58860e10e8ee52` modifies only `AGENTS.md` and adds seven lines.
+
+The end-user-visible document tail is:
+
+```md
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.
+```
+
+Verified with:
+
+```sh
+git diff --check c76015d914e8ae7068c024c68c58860e10e8ee52 1009f1d152481b16d6b3d85d95fe61542ed9e5a9
+test "$(git diff --name-only c76015d914e8ae7068c024c68c58860e10e8ee52 1009f1d152481b16d6b3d85d95fe61542ed9e5a9)" = "AGENTS.md"
+test "$(git diff --numstat c76015d914e8ae7068c024c68c58860e10e8ee52 1009f1d152481b16d6b3d85d95fe61542ed9e5a9)" = "7\t0\tAGENTS.md"
+diff -u <(printf '%s\\n' '## Maintaining this file' '' 'Keep this file for knowledge useful to almost every future agent session in this project.' 'Do not repeat what the codebase already shows; point to the authoritative file or command instead.' 'Prefer rewriting or pruning existing entries over appending new ones.' 'When updating this file, preserve this bar for all agents and keep entries concise.') <(git show HEAD:AGENTS.md | tail -n 6)
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,10 @@ pre_destroy = ["./scripts/teardown.sh"]
 ```
 
 Hooks are ignored in repo-level config for safety.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.


### PR DESCRIPTION
## Intent

Fleet-wide rollout (captain policy 2026-07-06): add the canonical self-governance preamble to treehouse's existing AGENTS.md. Append the exact ## Maintaining this file section wording owned by firstmate's fm-ensure-agents-md.sh (do not rewrite that wording). Scope is intentionally minimal: one small docs change only - no feature work, no broad AGENTS.md rewrite. Content trims only where a line literally repeats the codebase or is clearly stale; none were needed beyond appending the preamble. Delivery is commit on fm/agmd-treehouse-g0 then PR via no-mistakes.

## What Changed

- Add a `Maintaining this file` section to `AGENTS.md` with guidance for keeping project agent instructions concise and authoritative.
- Add verification evidence documenting the governed `AGENTS.md` addition and its exact content checks.

## Risk Assessment

✅ Low: The commit is a narrowly scoped documentation-only addition with no code-path, API, or runtime behavior changes.

## Testing

For this docs-only change, exercised the end-user-visible document tail rather than unrelated code tests: the target cleanly appends exactly the requested six-line governance section to AGENTS.md, changes no other source file, and the captured evidence shows the rendered Markdown content.

- Evidence: [Rendered AGENTS.md governance addition verification](https://github.com/kunchenguid/treehouse/blob/a57742c454e452351565631690e3292acf82fac4/.no-mistakes/evidence/fm/agmd-treehouse-g0/agents-governance-verification.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check c76015d914e8ae7068c024c68c58860e10e8ee52 1009f1d152481b16d6b3d85d95fe61542ed9e5a9`
- <code>Exact scope assertion: target modifies only `AGENTS.md` with `7` additions and `0` deletions.</code>
- <code>Exact-content assertion comparing the final six lines of `HEAD:AGENTS.md` with the requested `## Maintaining this file` section.</code>
- <code>`git diff --exit-code HEAD -- AGENTS.md` after evidence creation, confirming validation did not alter the source document.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
