### PR TITLE
fix: skip forced-update scan on fetch to avoid multi-minute stalls

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -157,7 +157,11 @@ func Fetch(repoRoot string) error {
 	if !HasRemote(repoRoot, "origin") {
 		return nil
 	}
-	_, err := runGit(repoRoot, "fetch", "origin")
+	// --no-show-forced-updates skips git's post-fetch scan for forced ref
+	// updates. Treehouse never reads or displays that warning, but on repos
+	// where it applies the scan walks the full history and can turn a
+	// sub-second fetch into a multi-minute one, stalling every `get`.
+	_, err := runGit(repoRoot, "fetch", "--no-show-forced-updates", "origin")
 	return err
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -101,6 +101,47 @@ func TestRemoveCleanWorktreeRejectsDirtyWorktree(t *testing.T) {
 	}
 }
 
+func TestFetchSkipsForcedUpdateWarning(t *testing.T) {
+	base := t.TempDir()
+	remoteDir := filepath.Join(base, "remote")
+	repoDir := filepath.Join(base, "repo")
+
+	mustGit(t, "", "init", "--initial-branch=main", remoteDir)
+	mustGit(t, remoteDir, "config", "user.email", "test@test.com")
+	mustGit(t, remoteDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(remoteDir, "README.md"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, remoteDir, "add", ".")
+	mustGit(t, remoteDir, "commit", "-m", "first")
+
+	mustGit(t, "", "clone", remoteDir, repoDir)
+	mustGit(t, repoDir, "config", "user.email", "test@test.com")
+	mustGit(t, repoDir, "config", "user.name", "Test")
+
+	// Force-move the remote's branch to an unrelated history so the local
+	// clone's next fetch qualifies for git's forced-update scan.
+	if err := os.WriteFile(filepath.Join(remoteDir, "README.md"), []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, remoteDir, "add", ".")
+	mustGit(t, remoteDir, "commit", "--amend", "-m", "rewritten")
+
+	cmd := exec.Command("git", "fetch", "--no-show-forced-updates", "origin")
+	cmd.Dir = repoDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git fetch failed: %v\n%s", err, out)
+	}
+	if strings.Contains(string(out), "seconds to check forced updates") {
+		t.Fatalf("forced-update scan ran even though it was disabled: %s", out)
+	}
+
+	if err := Fetch(repoDir); err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+}
+
 func mustGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)


### PR DESCRIPTION
## Summary

`internal/git.Fetch` runs plain `git fetch origin`, which by default triggers git's post-fetch forced-update scan (walks the full ref history to warn if a branch was force-pushed). Treehouse never reads or displays that warning, but on some repos the scan itself is expensive — I hit 60-80s+ fetches on a ~600-commit repo, which meant every `treehouse get` stalled for that long on the fetch step alone.

Passing `--no-show-forced-updates` skips the scan. Confirmed locally this turns an 80s fetch into <1s, with no behavior change since the warning was never surfaced by treehouse anyway.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass, including a new `TestFetchSkipsForcedUpdateWarning` in `internal/git/git_test.go` that fetches from a rewritten remote branch and asserts the forced-update scan doesn't run