### PR TITLE
feat(config): discover treehouse.toml in ancestor directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,8 @@ This project targets Linux, macOS, and Windows. All new code **must** work on Wi
 
 ## Config
 
-Place repo-safe settings in repo root `treehouse.toml` or user-level `~/.config/treehouse/config.toml`:
+Place repo-safe settings in `treehouse.toml` at the repo root or an ancestor below `$HOME`, or in user-level `~/.config/treehouse/config.toml`.
+The nearest repo-scoped file wins, and relative roots in it resolve from that file's directory:
 
 ```toml
 max_trees = 16
@@ -86,7 +87,7 @@ post_create = ["./scripts/setup-venv.sh"]
 pre_destroy = ["./scripts/teardown.sh"]
 ```
 
-Hooks are ignored in repo-level config for safety.
+Hooks are ignored in repo-scoped config for safety.
 
 ## Maintaining this file
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Replace it with the specific `--include-*` flag(s) for the risk you actually int
 
 Create a repo config file with `treehouse init`, or add one manually:
 
-**Repo-level:** `treehouse.toml` in the repository root
+**Repo-scoped:** the nearest `treehouse.toml` from the repository root upward, stopping before `$HOME` or the filesystem root
 
 **User-level:** `~/.config/treehouse/config.toml`
 
@@ -311,19 +311,22 @@ max_trees = 16
 
 # Optional worktree root directory.
 # Empty uses $HOME/.treehouse.
-# Relative paths are resolved from the repo root for repo-scoped commands.
+# Relative paths in treehouse.toml are resolved from that file's directory.
 # Use an absolute user-level root for treehouse prune --all.
 # root = "$HOME/worktrees"
 ```
 
-The repo-level config takes precedence for repo-safe settings.
-`treehouse prune --all` can run without a repository, so it uses only the user-level config and does not read per-repo `treehouse.toml` files while sweeping.
+Treehouse selects one repo-scoped file: the nearest file wins, so a file in the repository root overrides a file in a parent context directory.
+This lets related repositories share operator settings from a file such as `~/Workspace/personal/treehouse.toml` while retaining repository-specific overrides.
+`treehouse init` always creates a file in the repository root.
+Repo-scoped config takes precedence for repo-safe settings, and hooks from it are ignored for safety.
+`treehouse prune --all` can run without a repository, so it uses only the user-level config and does not read repo-scoped `treehouse.toml` files while sweeping.
 If no config is found, the default pool size is 16.
 
 ### Hooks
 
 You can run commands automatically at worktree lifecycle points by adding a `[hooks]` section to the user-level config at `~/.config/treehouse/config.toml`.
-Hooks in repo-level `treehouse.toml` are ignored for safety.
+Hooks in repo-scoped `treehouse.toml` are ignored for safety.
 `treehouse destroy` always reads `pre_destroy` from the user-level config because it can target a pool by path.
 
 ```toml

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -895,7 +895,7 @@ func TestReturnExplicitPathFromLinkedWorktreePool(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repoDir, "treehouse.toml"), []byte("root = \"../treehouse-pool\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	gitCmd(t, repoDir, "add", "treehouse.toml")
+	gitCmd(t, repoDir, "add", "-f", "treehouse.toml")
 	gitCmd(t, repoDir, "commit", "-m", "configure treehouse root")
 
 	linkedDir := filepath.Join(filepath.Dir(repoDir), "agent-home")
@@ -1262,7 +1262,7 @@ func TestDestroyAllFromManagedWorktreeSubdirUsesMainRepoPool(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repoDir, "treehouse.toml"), []byte("root = \"../treehouse-pool\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	gitCmd(t, repoDir, "add", "treehouse.toml")
+	gitCmd(t, repoDir, "add", "-f", "treehouse.toml")
 	gitCmd(t, repoDir, "commit", "-m", "configure treehouse root")
 	gitCmd(t, repoDir, "push", "origin", "main")
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -38,7 +38,7 @@ var initCmd = &cobra.Command{
 		}
 
 		// Append a comment showing the root option.
-		if _, err := f.WriteString("\n# Worktree root directory (relative to repo root or absolute path).\n# Worktrees are placed under {root}/.treehouse/. Default: $HOME\n# Example: root = \"./\"\n"); err != nil {
+		if _, err := f.WriteString("\n# Worktree root directory (relative to this file or absolute path).\n# Worktrees are placed under {root}/.treehouse/. Default: $HOME\n# Example: root = \"./\"\n"); err != nil {
 			return fmt.Errorf("failed to write config: %w", err)
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,14 +29,16 @@ func DefaultConfig() Config {
 func Load(repoRoot string) (Config, error) {
 	cfg := DefaultConfig()
 
-	repoPath := filepath.Join(repoRoot, "treehouse.toml")
-	hasRepoConfig := false
-	if _, err := os.Stat(repoPath); err == nil {
-		hasRepoConfig = true
+	repoPath, hasRepoConfig, err := findRepoConfig(repoRoot)
+	if err != nil {
+		return cfg, err
+	}
+	if hasRepoConfig {
 		if _, err := toml.DecodeFile(repoPath, &cfg); err != nil {
 			return cfg, err
 		}
 		cfg.Hooks = Hooks{}
+		cfg.Root = resolveRootFrom(cfg.Root, filepath.Dir(repoPath))
 	}
 
 	userCfg, hasUserConfig, err := loadUser()
@@ -52,6 +54,53 @@ func Load(repoRoot string) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func findRepoConfig(repoRoot string) (string, bool, error) {
+	dir, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return "", false, err
+	}
+	dir = filepath.Clean(dir)
+
+	home := ""
+	if userHome, err := os.UserHomeDir(); err == nil {
+		if absoluteHome, err := filepath.Abs(userHome); err == nil {
+			home = filepath.Clean(absoluteHome)
+		}
+	}
+
+	for {
+		if dir == home {
+			return "", false, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false, nil
+		}
+
+		path := filepath.Join(dir, "treehouse.toml")
+		if _, err := os.Stat(path); err == nil {
+			return path, true, nil
+		} else if !os.IsNotExist(err) {
+			return "", false, err
+		}
+
+		dir = parent
+	}
+}
+
+func resolveRootFrom(root string, dir string) string {
+	if root == "" {
+		return ""
+	}
+
+	expanded := os.ExpandEnv(root)
+	if filepath.IsAbs(expanded) {
+		return expanded
+	}
+	return filepath.Join(dir, expanded)
 }
 
 // LoadGlobal returns the default configuration merged with user-level config.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,7 +71,7 @@ func findRepoConfig(repoRoot string) (string, bool, error) {
 	}
 
 	for {
-		if dir == home {
+		if samePath(dir, home) {
 			return "", false, nil
 		}
 

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,0 +1,180 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_FindsNearestAncestorConfig(t *testing.T) {
+	home := t.TempDir()
+	setUserHome(t, home)
+
+	contextDir := filepath.Join(home, "Workspace", "personal")
+	repoDir := filepath.Join(contextDir, "projects", "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeConfig(t, contextDir, "max_trees = 8\n")
+	writeConfig(t, filepath.Dir(repoDir), "max_trees = 4\n")
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.MaxTrees != 4 {
+		t.Fatalf("MaxTrees: got %d, want 4", cfg.MaxTrees)
+	}
+}
+
+func TestLoad_RepoConfigOverridesAncestorConfig(t *testing.T) {
+	home := t.TempDir()
+	setUserHome(t, home)
+
+	contextDir := filepath.Join(home, "Workspace", "personal")
+	repoDir := filepath.Join(contextDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeConfig(t, contextDir, "max_trees = 8\nroot = \"./\"\n")
+	writeConfig(t, repoDir, "max_trees = 2\n")
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.MaxTrees != 2 {
+		t.Fatalf("MaxTrees: got %d, want 2", cfg.MaxTrees)
+	}
+	if cfg.Root != "" {
+		t.Fatalf("Root: got %q, want empty repo override", cfg.Root)
+	}
+}
+
+func TestLoad_DoesNotDiscoverConfigAtHome(t *testing.T) {
+	home := t.TempDir()
+	setUserHome(t, home)
+
+	repoDir := filepath.Join(home, "Workspace", "personal", "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, home, "max_trees = 3\n")
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.MaxTrees != DefaultConfig().MaxTrees {
+		t.Fatalf("MaxTrees: got %d, want default %d", cfg.MaxTrees, DefaultConfig().MaxTrees)
+	}
+}
+
+func TestLoad_FindsAncestorConfigOutsideHome(t *testing.T) {
+	setUserHome(t, t.TempDir())
+
+	contextDir := t.TempDir()
+	repoDir := filepath.Join(contextDir, "projects", "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, contextDir, "max_trees = 6\n")
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.MaxTrees != 6 {
+		t.Fatalf("MaxTrees: got %d, want 6", cfg.MaxTrees)
+	}
+}
+
+func TestLoad_ResolvesRelativeRootFromConfigDirectory(t *testing.T) {
+	home := t.TempDir()
+	setUserHome(t, home)
+
+	contextDir := filepath.Join(home, "Workspace", "personal")
+	repoDir := filepath.Join(contextDir, "projects", "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, contextDir, "root = \"./\"\n")
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	poolRoot, err := ResolvePoolRoot(repoDir, cfg.Root)
+	if err != nil {
+		t.Fatalf("ResolvePoolRoot failed: %v", err)
+	}
+
+	want := filepath.Join(contextDir, ".treehouse")
+	if poolRoot != want {
+		t.Fatalf("pool root: got %q, want %q", poolRoot, want)
+	}
+}
+
+func TestLoad_MalformedNearestConfigDoesNotFallBack(t *testing.T) {
+	home := t.TempDir()
+	setUserHome(t, home)
+
+	contextDir := filepath.Join(home, "Workspace", "personal")
+	projectDir := filepath.Join(contextDir, "projects")
+	repoDir := filepath.Join(projectDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, contextDir, "max_trees = 8\n")
+	writeConfig(t, projectDir, "max_trees = [\n")
+
+	if _, err := Load(repoDir); err == nil {
+		t.Fatal("expected malformed nearest config to fail")
+	}
+}
+
+func TestLoad_IgnoresAncestorHooksAndKeepsUserHooks(t *testing.T) {
+	home := t.TempDir()
+	setUserHome(t, home)
+
+	contextDir := filepath.Join(home, "Workspace", "personal")
+	repoDir := filepath.Join(contextDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, contextDir, `
+max_trees = 4
+
+[hooks]
+post_create = ["echo unsafe"]
+`)
+
+	userConfigDir := filepath.Join(home, ".config", "treehouse")
+	if err := os.MkdirAll(userConfigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(userConfigDir, "config.toml"),
+		[]byte("[hooks]\npost_create = [\"echo safe\"]\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(repoDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if len(cfg.Hooks.PostCreate) != 1 || cfg.Hooks.PostCreate[0] != "echo safe" {
+		t.Fatalf("PostCreate: got %v, want user-level hook", cfg.Hooks.PostCreate)
+	}
+}
+
+func writeConfig(t *testing.T, dir string, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "treehouse.toml"), []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/config/load_windows_test.go
+++ b/internal/config/load_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoad_HomeBoundaryIsCaseInsensitive(t *testing.T) {
+	home := t.TempDir()
+	setUserHome(t, home)
+
+	repoDir := filepath.Join(home, "Workspace", "personal", "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, home, "max_trees = 3\n")
+
+	cfg, err := Load(strings.ToUpper(repoDir))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.MaxTrees != DefaultConfig().MaxTrees {
+		t.Fatalf("MaxTrees: got %d, want default %d", cfg.MaxTrees, DefaultConfig().MaxTrees)
+	}
+}

--- a/internal/config/path_equal_other.go
+++ b/internal/config/path_equal_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package config
+
+import "path/filepath"
+
+func samePath(a string, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
+}

--- a/internal/config/path_equal_windows.go
+++ b/internal/config/path_equal_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package config
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func samePath(a string, b string) bool {
+	return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+}

--- a/treehouse.toml.example
+++ b/treehouse.toml.example
@@ -1,11 +1,15 @@
 # Treehouse configuration
-# Place repo-safe settings at <repo_root>/treehouse.toml.
+# Place repo-safe settings at <repo_root>/treehouse.toml or in an ancestor
+# directory below $HOME. The nearest file wins.
 # Place executable hooks only in ~/.config/treehouse/config.toml.
 
 # Maximum number of worktrees in the pool
 max_trees = 16
 
-# Lifecycle hooks are ignored in repo-level config for safety.
+# Relative roots are resolved from this file's directory.
+# root = "./"
+
+# Lifecycle hooks are ignored in repo-scoped config for safety.
 # Each list runs sequentially in the worktree directory via the OS shell.
 # Failures are logged and do not fail the operation.
 # [hooks]


### PR DESCRIPTION
## Summary

- discover the nearest `treehouse.toml` from the repository root upward
- stop before `$HOME` or the filesystem root
- resolve relative `root` values from the selected config file's directory
- preserve repo-root precedence, user-level hooks, global config, and global prune behavior
- document ancestor configuration and make config-committing E2E fixtures independent of global ignore rules

## Why

Pool placement is operator and machine policy, but repository-root-only discovery requires duplicating the same untracked configuration across every repository in a context. Ancestor discovery lets a context directory such as `~/Workspace/personal` own that policy while repository-root files remain available as explicit overrides.

The implementation stays behind the existing `config.Load(repoRoot)` interface, so all repo-scoped commands receive the behavior consistently without changing their callers.

## Compatibility

- existing repository-root files remain the nearest file and keep precedence
- only one repo-scoped file is selected; configs are not cascaded or merged
- `$HOME/treehouse.toml` is not treated as a second global config
- malformed nearest configs fail instead of silently falling back
- hooks in every repo-scoped config remain ignored
- `treehouse init`, user-level config, and `prune --all` retain their existing roles

## Validation

- `make lint`
- `make test`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `git diff --check`

Closes #75
