### PR TITLE
fix: restore Go installation for v2 releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ treehouse = {
 **Go**
 
 ```sh
-go install github.com/kunchenguid/treehouse@latest
+go install github.com/kunchenguid/treehouse/v2@latest
 ```
 
 **From source**

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kunchenguid/treehouse/internal/config"
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/pool"
-	"github.com/kunchenguid/treehouse/internal/ui"
+	"github.com/kunchenguid/treehouse/v2/internal/config"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/pool"
+	"github.com/kunchenguid/treehouse/v2/internal/ui"
 )
 
 var (

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kunchenguid/treehouse/internal/config"
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/pool"
-	"github.com/kunchenguid/treehouse/internal/shell"
-	"github.com/kunchenguid/treehouse/internal/ui"
+	"github.com/kunchenguid/treehouse/v2/internal/config"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/pool"
+	"github.com/kunchenguid/treehouse/v2/internal/shell"
+	"github.com/kunchenguid/treehouse/v2/internal/ui"
 )
 
 var enterCmd = &cobra.Command{

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kunchenguid/treehouse/internal/config"
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/pool"
-	"github.com/kunchenguid/treehouse/internal/process"
-	"github.com/kunchenguid/treehouse/internal/shell"
-	"github.com/kunchenguid/treehouse/internal/ui"
+	"github.com/kunchenguid/treehouse/v2/internal/config"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/pool"
+	"github.com/kunchenguid/treehouse/v2/internal/process"
+	"github.com/kunchenguid/treehouse/v2/internal/shell"
+	"github.com/kunchenguid/treehouse/v2/internal/ui"
 )
 
 var (

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,8 +8,8 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
 
-	"github.com/kunchenguid/treehouse/internal/config"
-	"github.com/kunchenguid/treehouse/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/config"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
 )
 
 var initCmd = &cobra.Command{

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kunchenguid/treehouse/internal/config"
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/pool"
-	"github.com/kunchenguid/treehouse/internal/ui"
+	"github.com/kunchenguid/treehouse/v2/internal/config"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/pool"
+	"github.com/kunchenguid/treehouse/v2/internal/ui"
 )
 
 var (

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kunchenguid/treehouse/internal/config"
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/pool"
-	"github.com/kunchenguid/treehouse/internal/ui"
+	"github.com/kunchenguid/treehouse/v2/internal/config"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/pool"
+	"github.com/kunchenguid/treehouse/v2/internal/ui"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/fatih/color"
-	"github.com/kunchenguid/treehouse/internal/updater"
+	"github.com/kunchenguid/treehouse/v2/internal/updater"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,10 +10,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/kunchenguid/treehouse/internal/config"
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/pool"
-	"github.com/kunchenguid/treehouse/internal/ui"
+	"github.com/kunchenguid/treehouse/v2/internal/config"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/pool"
+	"github.com/kunchenguid/treehouse/v2/internal/ui"
 )
 
 var statusJSON bool

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-	"github.com/kunchenguid/treehouse/internal/updater"
+	"github.com/kunchenguid/treehouse/v2/internal/updater"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kunchenguid/treehouse
+module github.com/kunchenguid/treehouse/v2
 
 go 1.25.5
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
-	"github.com/kunchenguid/treehouse/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
 )
 
 type Config struct {

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kunchenguid/treehouse/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
 )
 
 // EnsureGitignore adds treehouseDir to the .gitignore of the enclosing git

--- a/internal/pool/destroy.go
+++ b/internal/pool/destroy.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/hooks"
-	"github.com/kunchenguid/treehouse/internal/process"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/hooks"
+	"github.com/kunchenguid/treehouse/v2/internal/process"
 )
 
 // DestroyClass is the safety classification of a worktree considered for

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/hooks"
-	"github.com/kunchenguid/treehouse/internal/process"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/hooks"
+	"github.com/kunchenguid/treehouse/v2/internal/process"
 )
 
 const (

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kunchenguid/treehouse/internal/process"
+	"github.com/kunchenguid/treehouse/v2/internal/process"
 )
 
 func setupRepo(t *testing.T) (repoDir, poolDir string) {

--- a/internal/pool/prune.go
+++ b/internal/pool/prune.go
@@ -9,9 +9,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kunchenguid/treehouse/internal/git"
-	"github.com/kunchenguid/treehouse/internal/hooks"
-	"github.com/kunchenguid/treehouse/internal/process"
+	"github.com/kunchenguid/treehouse/v2/internal/git"
+	"github.com/kunchenguid/treehouse/v2/internal/hooks"
+	"github.com/kunchenguid/treehouse/v2/internal/process"
 )
 
 // PruneWorktree describes a stale or explicitly selected orphaned worktree that

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/kunchenguid/treehouse/cmd"
-	"github.com/kunchenguid/treehouse/internal/updater"
+	"github.com/kunchenguid/treehouse/v2/cmd"
+	"github.com/kunchenguid/treehouse/v2/internal/updater"
 )
 
 var version = ""

--- a/module_path_test.go
+++ b/module_path_test.go
@@ -1,0 +1,81 @@
+package main_test
+
+import (
+	"bufio"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const expectedModulePath = "github.com/kunchenguid/treehouse/v2"
+
+func TestModulePath(t *testing.T) {
+	modulePath := readModulePath(t)
+	if modulePath != expectedModulePath {
+		t.Fatalf("module path = %q, want %q", modulePath, expectedModulePath)
+	}
+
+	legacyModulePath := strings.TrimSuffix(expectedModulePath, "/v2")
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, spec := range file.Imports {
+			importPath, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				return err
+			}
+			if importPath != expectedModulePath &&
+				!strings.HasPrefix(importPath, expectedModulePath+"/") &&
+				(importPath == legacyModulePath || strings.HasPrefix(importPath, legacyModulePath+"/")) {
+				t.Errorf("%s imports legacy module path %q", path, importPath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readModulePath(t *testing.T) string {
+	t.Helper()
+
+	file, err := os.Open("go.mod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 2 && fields[0] == "module" {
+			return fields[1]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	t.Fatal("go.mod has no module directive")
+	return ""
+}


### PR DESCRIPTION
## Testing

- From the repository root, the module reports `github.com/kunchenguid/treehouse/v2`, all packages resolve under that prefix, and the existing full Go test/build matrix continues to pass on Linux, macOS, and Windows.
- The regression test fails when `go.mod` loses the `/v2` suffix or when any production or test Go source imports `github.com/kunchenguid/treehouse/...` without `/v2`.
- The README documents `go install github.com/kunchenguid/treehouse/v2@latest`, while clone URLs, GitHub release/update endpoints, Nix references, and installer repository identifiers remain unsuffixed.
- After a maintainer publishes a corrected v2 tag, installing that tag through the `/v2` module path succeeds; the release/tag verification remains an external post-merge check because an unpublished tag cannot be exercised in repository tests.

## What Changed

Change the module declaration to `github.com/kunchenguid/treehouse/v2` and migrate every Go self-import to that canonical prefix, including the import used by `internal/pool/pool_test.go`, so all packages remain within one valid v2 module. Update only the README's Go installation command to use the `/v2` path; repository URLs used for cloning, releases, badges, Nix inputs, install scripts, and updater API calls continue to identify the unchanged GitHub repository and must not gain the module suffix. Add a focused root-level regression test that derives the declared module path from `go.mod` and verifies it is the expected v2 path and that repository Go files contain no legacy unsuffixed self-imports, without introducing a production-only test seam.

## Why

Treehouse's v2 tags still declare the unsuffixed `github.com/kunchenguid/treehouse` module path, violating Go's semantic import versioning rule for major versions greater than one. Consequently, both explicit v2 installation forms fail, while the README's `@latest` command silently resolves to v1.8.0 instead of a current release. The report includes reproducible failures for v2.0.0, and a follow-up confirms the defect persists through v2.1.1. The issue is open and unassigned, with no competing or prior closed-unmerged pull requests in the supplied evidence.

Fixes #62
