### PR TITLE
fix: detect squash-merged worktrees

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1870,8 +1870,8 @@ func TestPruneRefreshesOriginBeforeMergeSafety(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("prune --yes failed after remote rewrite (code %d): %s", code, pruneErr)
 	}
-	if !strings.Contains(pruneOut, "not merged") {
-		t.Fatalf("expected stale local origin to be refreshed, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	if !strings.Contains(pruneOut, "cannot verify") {
+		t.Fatalf("expected unrelated remote history to be unverified, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("worktree with remotely unmerged HEAD was removed: %v", err)
@@ -1911,8 +1911,8 @@ func TestPruneUsesCurrentRemoteDefaultBranch(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("prune --yes failed after remote default rename (code %d): %s", code, pruneErr)
 	}
-	if !strings.Contains(pruneOut, "not merged") || !strings.Contains(pruneOut, "origin/trunk") {
-		t.Fatalf("expected prune to use current remote default, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
+	if !strings.Contains(pruneOut, "cannot verify") {
+		t.Fatalf("expected prune to use current remote default and fail closed, got stdout:\n%s\nstderr:\n%s", pruneOut, pruneErr)
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("worktree unmerged into current remote default was removed: %v", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"os/exec"
@@ -257,7 +258,10 @@ func IsHeadMergedIntoDefault(repoRoot, worktreePath string) (bool, string, error
 	return merged, ref, err
 }
 
-// IsHeadMergedIntoRef reports whether worktreePath's HEAD is an ancestor of ref.
+// IsHeadMergedIntoRef reports whether worktreePath's HEAD is merged into ref.
+// Ancestry is the fast proof; when it is absent, a path-scoped tree comparison
+// detects a squash merge without treating unrelated target-branch changes as a
+// mismatch.
 func IsHeadMergedIntoRef(worktreePath, ref string) (bool, error) {
 	cmd := exec.Command("git", "merge-base", "--is-ancestor", "HEAD", ref)
 	cmd.Dir = worktreePath
@@ -266,9 +270,83 @@ func IsHeadMergedIntoRef(worktreePath, ref string) (bool, error) {
 		return true, nil
 	}
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-		return false, nil
+		return isHeadContentMergedIntoRef(worktreePath, ref)
 	}
 	return false, fmt.Errorf("git merge-base --is-ancestor HEAD %s: %s", ref, strings.TrimSpace(string(out)))
+}
+
+func isHeadContentMergedIntoRef(worktreePath, ref string) (bool, error) {
+	cmd := exec.Command("git", "merge-base", "HEAD", ref)
+	cmd.Dir = worktreePath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return false, fmt.Errorf("git merge-base HEAD %s returned no common ancestor", ref)
+		}
+		return false, fmt.Errorf("git merge-base HEAD %s: %s", ref, strings.TrimSpace(string(out)))
+	}
+	base := strings.TrimSpace(string(out))
+	if base == "" {
+		return false, fmt.Errorf("git merge-base HEAD %s returned no common ancestor", ref)
+	}
+
+	baseTree, err := readTree(worktreePath, base)
+	if err != nil {
+		return false, err
+	}
+	headTree, err := readTree(worktreePath, "HEAD")
+	if err != nil {
+		return false, err
+	}
+	targetTree, err := readTree(worktreePath, ref)
+	if err != nil {
+		return false, err
+	}
+
+	for path, baseEntry := range baseTree {
+		if baseEntry == headTree[path] {
+			continue
+		}
+		if headTree[path] != targetTree[path] {
+			return false, nil
+		}
+	}
+	for path, headEntry := range headTree {
+		if _, ok := baseTree[path]; ok {
+			continue
+		}
+		if headEntry != targetTree[path] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func readTree(repoRoot, ref string) (map[string]string, error) {
+	out, err := runGitRaw(repoRoot, "ls-tree", "-r", "-z", "--full-tree", ref)
+	if err != nil {
+		return nil, err
+	}
+
+	tree := make(map[string]string)
+	for len(out) > 0 {
+		end := bytes.IndexByte(out, 0)
+		if end == -1 {
+			return nil, fmt.Errorf("git ls-tree %s returned malformed NUL-delimited output", ref)
+		}
+		record := out[:end]
+		out = out[end+1:]
+		separator := bytes.IndexByte(record, '\t')
+		if separator == -1 || separator == len(record)-1 {
+			return nil, fmt.Errorf("git ls-tree %s returned malformed tree entry", ref)
+		}
+		path := string(record[separator+1:])
+		if _, exists := tree[path]; exists {
+			return nil, fmt.Errorf("git ls-tree %s returned duplicate path %q", ref, path)
+		}
+		tree[path] = string(record[:separator])
+	}
+	return tree, nil
 }
 
 // IsDirty reports tracked or untracked changes, ignoring status.showUntrackedFiles.
@@ -286,6 +364,14 @@ func ShortHash(s string) string {
 }
 
 func runGit(dir string, args ...string) (string, error) {
+	out, err := runGitRaw(dir, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func runGitRaw(dir string, args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
 	if dir != "" {
 		cmd.Dir = dir
@@ -293,9 +379,9 @@ func runGit(dir string, args ...string) (string, error) {
 	out, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(exitErr.Stderr)))
+			return nil, fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(exitErr.Stderr)))
 		}
-		return "", err
+		return nil, err
 	}
-	return strings.TrimSpace(string(out)), nil
+	return out, nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -303,10 +303,12 @@ func isHeadContentMergedIntoRef(worktreePath, ref string) (bool, error) {
 		return false, err
 	}
 
+	hasDelta := false
 	for path, baseEntry := range baseTree {
 		if baseEntry == headTree[path] {
 			continue
 		}
+		hasDelta = true
 		if headTree[path] != targetTree[path] {
 			return false, nil
 		}
@@ -315,9 +317,13 @@ func isHeadContentMergedIntoRef(worktreePath, ref string) (bool, error) {
 		if _, ok := baseTree[path]; ok {
 			continue
 		}
+		hasDelta = true
 		if headEntry != targetTree[path] {
 			return false, nil
 		}
+	}
+	if !hasDelta {
+		return false, nil
 	}
 	return true, nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -103,18 +103,22 @@ func TestRemoveCleanWorktreeRejectsDirtyWorktree(t *testing.T) {
 
 func TestIsHeadMergedIntoRef(t *testing.T) {
 	tests := []struct {
-		name                 string
-		ordinaryMerge        bool
-		squashMerge          bool
-		laterUnrelated       bool
-		targetFeatureContent string
-		wantMerged           bool
+		name                   string
+		ordinaryMerge          bool
+		squashMerge            bool
+		laterUnrelated         bool
+		targetFeatureContent   string
+		emptyFeatureCommit     bool
+		revertedFeatureContent bool
+		wantMerged             bool
 	}{
 		{name: "ordinary ancestry merge", ordinaryMerge: true, wantMerged: true},
 		{name: "squash merge", squashMerge: true, wantMerged: true},
 		{name: "squash merge followed by unrelated target commit", squashMerge: true, laterUnrelated: true, wantMerged: true},
 		{name: "squash merge missing final feature content", squashMerge: true, targetFeatureContent: "one\n", wantMerged: false},
 		{name: "unique unmerged content", wantMerged: false},
+		{name: "empty feature commit", emptyFeatureCommit: true, wantMerged: false},
+		{name: "feature content fully reverted", revertedFeatureContent: true, wantMerged: false},
 	}
 
 	for _, tt := range tests {
@@ -131,15 +135,29 @@ func TestIsHeadMergedIntoRef(t *testing.T) {
 			mustGit(t, repoDir, "commit", "-m", "initial")
 			mustGit(t, repoDir, "checkout", "-b", "feature")
 
-			if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("one\n"), 0o644); err != nil {
-				t.Fatal(err)
+			switch {
+			case tt.emptyFeatureCommit:
+				mustGit(t, repoDir, "commit", "--allow-empty", "-m", "empty feature commit")
+			case tt.revertedFeatureContent:
+				if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("feature\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				mustGit(t, repoDir, "commit", "-am", "feature change")
+				if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				mustGit(t, repoDir, "commit", "-am", "revert feature change")
+			default:
+				if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("one\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				mustGit(t, repoDir, "add", "feature.txt")
+				mustGit(t, repoDir, "commit", "-m", "feature one")
+				if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				mustGit(t, repoDir, "commit", "-am", "feature two")
 			}
-			mustGit(t, repoDir, "add", "feature.txt")
-			mustGit(t, repoDir, "commit", "-m", "feature one")
-			if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			mustGit(t, repoDir, "commit", "-am", "feature two")
 
 			mustGit(t, repoDir, "checkout", "main")
 			switch {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -101,6 +101,88 @@ func TestRemoveCleanWorktreeRejectsDirtyWorktree(t *testing.T) {
 	}
 }
 
+func TestIsHeadMergedIntoRef(t *testing.T) {
+	tests := []struct {
+		name           string
+		ordinaryMerge  bool
+		squashMerge    bool
+		laterUnrelated bool
+		wantMerged     bool
+	}{
+		{name: "ordinary ancestry merge", ordinaryMerge: true, wantMerged: true},
+		{name: "squash merge", squashMerge: true, wantMerged: true},
+		{name: "squash merge followed by unrelated target commit", squashMerge: true, laterUnrelated: true, wantMerged: true},
+		{name: "unique unmerged content", wantMerged: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			mustGit(t, "", "init", "--initial-branch=main", repoDir)
+			mustGit(t, repoDir, "config", "user.email", "test@test.com")
+			mustGit(t, repoDir, "config", "user.name", "Test")
+
+			if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			mustGit(t, repoDir, "add", ".")
+			mustGit(t, repoDir, "commit", "-m", "initial")
+			mustGit(t, repoDir, "checkout", "-b", "feature")
+
+			if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("one\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			mustGit(t, repoDir, "add", "feature.txt")
+			mustGit(t, repoDir, "commit", "-m", "feature one")
+			if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			mustGit(t, repoDir, "commit", "-am", "feature two")
+
+			mustGit(t, repoDir, "checkout", "main")
+			switch {
+			case tt.ordinaryMerge:
+				mustGit(t, repoDir, "merge", "--no-ff", "feature", "-m", "merge feature")
+			case tt.squashMerge:
+				mustGit(t, repoDir, "merge", "--squash", "feature")
+				mustGit(t, repoDir, "commit", "-m", "squash feature")
+			}
+			if tt.laterUnrelated {
+				if err := os.WriteFile(filepath.Join(repoDir, "unrelated.txt"), []byte("later\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				mustGit(t, repoDir, "add", "unrelated.txt")
+				mustGit(t, repoDir, "commit", "-m", "unrelated target change")
+			}
+			mustGit(t, repoDir, "checkout", "feature")
+
+			merged, err := IsHeadMergedIntoRef(repoDir, "refs/heads/main")
+			if err != nil {
+				t.Fatalf("IsHeadMergedIntoRef failed: %v", err)
+			}
+			if merged != tt.wantMerged {
+				t.Fatalf("expected merged=%t, got %t", tt.wantMerged, merged)
+			}
+		})
+	}
+}
+
+func TestIsHeadMergedIntoRefFailsClosedWhenTargetCannotBeVerified(t *testing.T) {
+	repoDir := t.TempDir()
+	mustGit(t, "", "init", "--initial-branch=main", repoDir)
+	mustGit(t, repoDir, "config", "user.email", "test@test.com")
+	mustGit(t, repoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repoDir, "add", ".")
+	mustGit(t, repoDir, "commit", "-m", "initial")
+
+	if _, err := IsHeadMergedIntoRef(repoDir, "refs/heads/missing"); err == nil {
+		t.Fatal("expected merge verification error for missing target ref")
+	}
+}
+
 func mustGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -103,15 +103,17 @@ func TestRemoveCleanWorktreeRejectsDirtyWorktree(t *testing.T) {
 
 func TestIsHeadMergedIntoRef(t *testing.T) {
 	tests := []struct {
-		name           string
-		ordinaryMerge  bool
-		squashMerge    bool
-		laterUnrelated bool
-		wantMerged     bool
+		name                 string
+		ordinaryMerge        bool
+		squashMerge          bool
+		laterUnrelated       bool
+		targetFeatureContent string
+		wantMerged           bool
 	}{
 		{name: "ordinary ancestry merge", ordinaryMerge: true, wantMerged: true},
 		{name: "squash merge", squashMerge: true, wantMerged: true},
 		{name: "squash merge followed by unrelated target commit", squashMerge: true, laterUnrelated: true, wantMerged: true},
+		{name: "squash merge missing final feature content", squashMerge: true, targetFeatureContent: "one\n", wantMerged: false},
 		{name: "unique unmerged content", wantMerged: false},
 	}
 
@@ -145,6 +147,12 @@ func TestIsHeadMergedIntoRef(t *testing.T) {
 				mustGit(t, repoDir, "merge", "--no-ff", "feature", "-m", "merge feature")
 			case tt.squashMerge:
 				mustGit(t, repoDir, "merge", "--squash", "feature")
+				if tt.targetFeatureContent != "" {
+					if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte(tt.targetFeatureContent), 0o644); err != nil {
+						t.Fatal(err)
+					}
+					mustGit(t, repoDir, "add", "feature.txt")
+				}
 				mustGit(t, repoDir, "commit", "-m", "squash feature")
 			}
 			if tt.laterUnrelated {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1152,6 +1152,44 @@ func TestPruneRemovesAvailableWorktree(t *testing.T) {
 	}
 }
 
+func TestPruneRemovesCleanIdleSquashMergedWorktree(t *testing.T) {
+	repoDir, poolDir := setupRepo(t)
+
+	wtPath, err := Acquire(repoDir, poolDir, 4, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	if err := Release(poolDir, wtPath); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	runGit(t, wtPath, "checkout", "-b", "squashed-feature")
+	if err := os.WriteFile(filepath.Join(wtPath, "feature.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, wtPath, "add", "feature.txt")
+	runGit(t, wtPath, "commit", "-m", "feature one")
+	if err := os.WriteFile(filepath.Join(wtPath, "feature.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, wtPath, "commit", "-am", "feature two")
+
+	runGit(t, repoDir, "merge", "--squash", "squashed-feature")
+	runGit(t, repoDir, "commit", "-m", "squash feature")
+	runGit(t, repoDir, "push", "origin", "main")
+
+	result, err := Prune(repoDir, poolDir, false, nil)
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+	if len(result.Pruned) != 1 || result.Pruned[0].Path != wtPath {
+		t.Fatalf("expected squash-merged worktree %s to be pruned, got %#v", wtPath, result.Pruned)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Fatalf("expected squash-merged worktree to be removed, stat err: %v", err)
+	}
+}
+
 func TestPrunePoolDerivesRepoContextFromManagedWorktree(t *testing.T) {
 	repoDir, poolDir := setupRepo(t)
 
@@ -1495,8 +1533,8 @@ func TestPruneRefreshesOriginBeforeMergeSafety(t *testing.T) {
 	if len(result.Pruned) != 0 {
 		t.Fatalf("worktree with remotely unmerged HEAD must not be pruned, got %#v", result.Pruned)
 	}
-	if !hasSkippedReason(result.Skipped, wtPath, "not merged") {
-		t.Fatalf("expected unmerged worktree skip after fetch, got %#v", result.Skipped)
+	if !hasSkippedCategory(result.Skipped, wtPath, pruneSkipCannotVerify) {
+		t.Fatalf("expected cannot-verify worktree skip after fetch, got %#v", result.Skipped)
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("expected remotely unmerged worktree to remain: %v", err)
@@ -1536,8 +1574,8 @@ func TestPruneUsesRemoteTrackingDefaultRefNotShadowingBranch(t *testing.T) {
 	if len(result.Pruned) != 0 {
 		t.Fatalf("shadowed default ref must not prune unmerged worktree, got %#v", result.Pruned)
 	}
-	if !hasSkippedReason(result.Skipped, wtPath, "not merged") {
-		t.Fatalf("expected unmerged worktree skip with shadowed ref, got %#v", result.Skipped)
+	if !hasSkippedCategory(result.Skipped, wtPath, pruneSkipCannotVerify) {
+		t.Fatalf("expected cannot-verify worktree skip with shadowed ref, got %#v", result.Skipped)
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("expected shadowed-ref worktree to remain: %v", err)
@@ -1572,8 +1610,8 @@ func TestPruneUsesFullLocalDefaultRefWithoutOrigin(t *testing.T) {
 	if len(result.Pruned) != 0 {
 		t.Fatalf("local shadowed default ref must not prune unmerged worktree, got %#v", result.Pruned)
 	}
-	if !hasSkippedReason(result.Skipped, wtPath, "refs/heads/main") {
-		t.Fatalf("expected local default branch skip, got %#v", result.Skipped)
+	if !hasSkippedCategory(result.Skipped, wtPath, pruneSkipCannotVerify) {
+		t.Fatalf("expected cannot-verify local default branch skip, got %#v", result.Skipped)
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("expected local shadowed-ref worktree to remain: %v", err)
@@ -1608,8 +1646,8 @@ func TestPruneIgnoresStaleOriginHeadWhenOriginIsAbsent(t *testing.T) {
 	if len(result.Pruned) != 0 {
 		t.Fatalf("stale origin HEAD must not choose local main, got %#v", result.Pruned)
 	}
-	if !hasSkippedReason(result.Skipped, wtPath, "refs/heads/trunk") {
-		t.Fatalf("expected local HEAD branch skip, got %#v", result.Skipped)
+	if !hasSkippedCategory(result.Skipped, wtPath, pruneSkipCannotVerify) {
+		t.Fatalf("expected cannot-verify local HEAD branch skip, got %#v", result.Skipped)
 	}
 	if _, err := os.Stat(wtPath); err != nil {
 		t.Fatalf("expected stale origin HEAD worktree to remain: %v", err)


### PR DESCRIPTION
## Summary

- preserve ancestry as the fast merge proof
- detect multi-commit squash merges with a conservative raw-tree fallback
- keep prune and destroy on the shared `git.IsHeadMergedIntoRef` safety boundary
- fail closed when Git cannot establish a common history or tree comparison

Fixes #85

## Tests

- `go test ./internal/git ./internal/pool` passed
- `go test ./... -count=1` passed
- `make lint` passed
- `make test` latest rerun was manually interrupted after starting; not claimed as passed
- `GOOS=windows go build ./...`  passed
- `git diff --check` passed

GitHub Actions is currently awaiting maintainer approval for the fork workflow.