### PR TITLE
feat: make in-project worktree storage first-class (--root flag, TREEHOUSE_ROOT, .git/info/exclude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ make install
 
 Treehouse manages a **pool of git worktrees** per repository, stored under the configured treehouse root.
 The default treehouse root is `~/.treehouse/`.
+You can instead keep the pool [inside the project](#in-project-storage) with `--root .`, so it lives next to the code and is removed with the project.
 
 ```
   treehouse
@@ -312,6 +313,7 @@ max_trees = 16
 # Optional worktree root directory.
 # Empty uses $HOME/.treehouse.
 # Relative paths are resolved from the repo root for repo-scoped commands.
+# Use "." to keep the pool inside the project (see "In-project storage" below).
 # Use an absolute user-level root for treehouse prune --all.
 # root = "$HOME/worktrees"
 ```
@@ -319,6 +321,39 @@ max_trees = 16
 The repo-level config takes precedence for repo-safe settings.
 `treehouse prune --all` can run without a repository, so it uses only the user-level config and does not read per-repo `treehouse.toml` files while sweeping.
 If no config is found, the default pool size is 16.
+
+### Worktree root
+
+The worktree root can also be set without a config file, and the resolved value follows this precedence (highest first):
+
+1. The `--root` flag (e.g. `treehouse get --root .`)
+2. The `TREEHOUSE_ROOT` environment variable
+3. `root` in the repo-level `treehouse.toml`
+4. `root` in the user-level `~/.config/treehouse/config.toml`
+5. The default, `~/.treehouse`
+
+A relative value (including `.`) is resolved from the repo root, exactly like a relative `root` in config; `treehouse` is always appended, so `--root .` places the pool at `<repo>/.treehouse/`.
+
+### In-project storage
+
+By default the pool lives in the global `~/.treehouse` store. Set the root to `.` to keep it **inside the project** instead:
+
+```sh
+treehouse get --root .          # one-off
+export TREEHOUSE_ROOT=.         # for a shell session
+```
+
+or commit it for the whole repo in `treehouse.toml`:
+
+```toml
+root = "."
+```
+
+This is **opt-in**; the default global store is unchanged. In-project mode:
+
+- Places the pool at `<repo>/.treehouse/`, so worktrees sit next to the code and are **removed with the project** (`rm -rf <repo>` leaves no global orphan).
+- Ignores the pool via the repo-local, untracked `.git/info/exclude`, so it never appears in `git status` and never dirties the tracked `.gitignore`.
+- Is not reached by `treehouse prune --all`, which only sweeps the global root; in-project pools are removed with the project instead.
 
 ### Hooks
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -172,7 +172,7 @@ func resolveDestroyPoolFromTarget(targetPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to load config: %w", err)
 	}
-	return config.ResolvePoolDir(repoRoot, cfg.Root)
+	return config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 }
 
 // destroySingleExit makes a single named destruction fail loudly when the

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -52,7 +52,7 @@ func enterRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+	poolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 	if err != nil {
 		return fmt.Errorf("failed to resolve pool directory: %w", err)
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -60,13 +60,13 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+	poolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 	if err != nil {
 		return fmt.Errorf("failed to resolve pool directory: %w", err)
 	}
 
-	if err := config.EnsureGitignore(filepath.Dir(poolDir)); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to update .gitignore: %v\n", err)
+	if err := config.EnsureExcluded(filepath.Dir(poolDir)); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to update git exclude: %v\n", err)
 	}
 
 	if getLease {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -38,7 +38,7 @@ var initCmd = &cobra.Command{
 		}
 
 		// Append a comment showing the root option.
-		if _, err := f.WriteString("\n# Worktree root directory (relative to repo root or absolute path).\n# Worktrees are placed under {root}/.treehouse/. Default: $HOME\n# Example: root = \"./\"\n"); err != nil {
+		if _, err := f.WriteString("\n# Worktree root directory (relative to repo root or absolute path).\n# Worktrees are placed under {root}/.treehouse/. Default: $HOME\n# Override per-command with the --root flag or the TREEHOUSE_ROOT env var.\n# Use \".\" to keep the pool in-project at <repo>/.treehouse/ (removed with the\n# project, ignored via .git/info/exclude). Example: root = \".\"\n"); err != nil {
 			return fmt.Errorf("failed to write config: %w", err)
 		}
 

--- a/cmd/inproject_e2e_test.go
+++ b/cmd/inproject_e2e_test.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readExcludeFile returns the contents of the repo's .git/info/exclude, or "" if
+// it does not exist.
+func readExcludeFile(t *testing.T, repoDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("failed to read .git/info/exclude: %v", err)
+	}
+	return string(data)
+}
+
+// globalPoolEntries returns the names of per-repo pools under the fake home's
+// global ~/.treehouse store. In-project mode must never create any.
+func globalPoolEntries(t *testing.T, homeDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(homeDir, ".treehouse"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("failed to read global pool dir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// assertInProject runs "get --lease" with the given extra env / args and checks
+// the full in-project contract: the pool lands under <repo>/.treehouse, the
+// worktree has repo content, .git/info/exclude carries the ignore entry, the
+// tracked .gitignore stays absent, git status is clean, and no global orphan is
+// created.
+func assertInProject(t *testing.T, repoDir, homeDir string, extraEnv []string, args ...string) string {
+	t.Helper()
+
+	getArgs := append([]string{"get", "--lease"}, args...)
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, extraEnv, getArgs...)
+	if code != 0 {
+		t.Fatalf("get --lease failed (code %d): %s", code, stderr)
+	}
+	wtPath := strings.TrimSpace(stdout)
+	if wtPath == "" {
+		t.Fatal("could not capture leased worktree path")
+	}
+
+	// The pool must live inside the repo, under <repo>/.treehouse.
+	inProjectRoot := filepath.Join(repoDir, ".treehouse")
+	if !strings.HasPrefix(wtPath, inProjectRoot+string(filepath.Separator)) {
+		t.Fatalf("expected in-project worktree under %s, got %s", inProjectRoot, wtPath)
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, "README.md")); err != nil {
+		t.Fatalf("expected in-project worktree to contain repo content: %v", err)
+	}
+
+	// The ignore entry goes to .git/info/exclude, not the tracked .gitignore.
+	if exclude := readExcludeFile(t, repoDir); !strings.Contains(exclude, "/.treehouse") {
+		t.Fatalf("expected .git/info/exclude to contain /.treehouse, got:\n%s", exclude)
+	}
+	if _, err := os.Stat(filepath.Join(repoDir, ".gitignore")); !os.IsNotExist(err) {
+		t.Fatalf("expected tracked .gitignore to stay absent, stat err: %v", err)
+	}
+
+	// The working tree must read clean: neither a .gitignore diff nor the ignored
+	// pool should show up.
+	if status := gitCmd(t, repoDir, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean git status with in-project pool, got:\n%s", status)
+	}
+
+	// No global orphan may be created under ~/.treehouse.
+	if names := globalPoolEntries(t, homeDir); len(names) != 0 {
+		t.Fatalf("expected no global pool entries in in-project mode, got: %v", names)
+	}
+
+	return wtPath
+}
+
+func TestInProjectViaFlag(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	assertInProject(t, repoDir, homeDir, nil, "--root", ".")
+}
+
+func TestInProjectViaEnv(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	assertInProject(t, repoDir, homeDir, []string{"TREEHOUSE_ROOT=."})
+}
+
+func TestInProjectViaConfig(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	if err := os.WriteFile(filepath.Join(repoDir, "treehouse.toml"), []byte("root = \".\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// treehouse.toml is committed so the tree is clean before acquiring.
+	gitCmd(t, repoDir, "add", "treehouse.toml")
+	gitCmd(t, repoDir, "commit", "-m", "configure in-project root")
+
+	assertInProject(t, repoDir, homeDir, nil)
+}
+
+// TestInProjectRemovalLeavesNoGlobalOrphan mirrors deleting the project: after
+// removing the repo directory, nothing is left behind in the global store.
+func TestInProjectRemovalLeavesNoGlobalOrphan(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	assertInProject(t, repoDir, homeDir, nil, "--root", ".")
+
+	if err := os.RemoveAll(repoDir); err != nil {
+		t.Fatalf("failed to remove project: %v", err)
+	}
+	if names := globalPoolEntries(t, homeDir); len(names) != 0 {
+		t.Fatalf("expected no global orphan after project removal, got: %v", names)
+	}
+}
+
+// TestRootFlagWinsOverEnv verifies the documented precedence: the --root flag
+// overrides TREEHOUSE_ROOT. The env points at an absolute global-style root, but
+// the flag selects in-project, so the pool must land in the repo.
+func TestRootFlagWinsOverEnv(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	envRoot := t.TempDir()
+	assertInProject(t, repoDir, homeDir, []string{"TREEHOUSE_ROOT=" + envRoot}, "--root", ".")
+
+	// The env-pointed root must not have been used.
+	if _, err := os.Stat(filepath.Join(envRoot, ".treehouse")); !os.IsNotExist(err) {
+		t.Fatalf("expected env root to be ignored when --root is set, stat err: %v", err)
+	}
+}
+
+// TestDefaultRootUnchanged asserts the default (unset) behavior is untouched:
+// the pool lands under the global ~/.treehouse, and the repo working tree is not
+// modified (no .gitignore, no .git/info/exclude entry).
+func TestDefaultRootUnchanged(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease")
+	if code != 0 {
+		t.Fatalf("get --lease failed (code %d): %s", code, stderr)
+	}
+	wtPath := strings.TrimSpace(stdout)
+
+	globalRoot := filepath.Join(homeDir, ".treehouse")
+	if !strings.HasPrefix(wtPath, globalRoot+string(filepath.Separator)) {
+		t.Fatalf("expected default worktree under %s, got %s", globalRoot, wtPath)
+	}
+
+	// The repo must be untouched: no in-project pool, no ignore edits.
+	if _, err := os.Stat(filepath.Join(repoDir, ".treehouse")); !os.IsNotExist(err) {
+		t.Fatalf("expected no in-project pool for the default root, stat err: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repoDir, ".gitignore")); !os.IsNotExist(err) {
+		t.Fatalf("expected no .gitignore for the default root, stat err: %v", err)
+	}
+	if exclude := readExcludeFile(t, repoDir); strings.Contains(exclude, "/.treehouse") {
+		t.Fatalf("expected no exclude entry for the default global root, got:\n%s", exclude)
+	}
+	if status := gitCmd(t, repoDir, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean git status for the default root, got:\n%s", status)
+	}
+}

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -48,7 +48,7 @@ absolute.`,
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			poolRoot, err := config.ResolvePoolRoot("", cfg.Root)
+			poolRoot, err := config.ResolvePoolRoot("", config.ResolveRoot(rootFlag, cfg))
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ absolute.`,
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+		poolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 		if err != nil {
 			return err
 		}

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -159,7 +159,7 @@ func resolveReturnPoolDir(wtPath string, explicitPath bool) (string, error) {
 		return "", fmt.Errorf("failed to load config: %w", err)
 	}
 
-	fallbackPoolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+	fallbackPoolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,11 @@ import (
 
 var version = "dev"
 
+// rootFlag holds the value of the persistent --root flag. It overrides both the
+// TREEHOUSE_ROOT environment variable and the configured root; see
+// config.ResolveRoot for the full precedence.
+var rootFlag string
+
 func SetVersion(v string) {
 	version = v
 	rootCmd.Version = v
@@ -54,6 +59,8 @@ so that multiple AI coding agents can work on the same repo in parallel.`,
 
 func init() {
 	rootCmd.SetVersionTemplate(`{{.Version}}` + "\n")
+	rootCmd.PersistentFlags().StringVar(&rootFlag, "root", "",
+		"Worktree root directory, overriding TREEHOUSE_ROOT and config; relative paths (e.g. \".\" for an in-project pool) resolve from the repo root")
 }
 
 func Execute() error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -47,7 +47,7 @@ var statusCmd = &cobra.Command{
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+		poolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 		if err != nil {
 			return err
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,10 +20,32 @@ type Hooks struct {
 	PreDestroy []string `toml:"pre_destroy,omitempty"`
 }
 
+// RootEnvVar is the environment variable that overrides the configured
+// worktree root. It sits below the --root flag but above repo/user config in
+// the resolution precedence (see ResolveRoot).
+const RootEnvVar = "TREEHOUSE_ROOT"
+
 func DefaultConfig() Config {
 	return Config{
 		MaxTrees: 16,
 	}
+}
+
+// ResolveRoot returns the effective worktree root, honoring override precedence:
+// an explicit flag value, then the TREEHOUSE_ROOT environment variable, then the
+// root from repo/user config, then the built-in default (empty string, which
+// ResolvePoolRoot maps to ~/.treehouse). It keeps ResolvePoolRoot pure while
+// letting callers layer command-line and environment overrides on top of the
+// loaded config. A relative override is resolved from the repo root exactly like
+// a relative config root, so `--root .` selects an in-project pool.
+func ResolveRoot(flagRoot string, cfg Config) string {
+	if flagRoot != "" {
+		return flagRoot
+	}
+	if env := os.Getenv(RootEnvVar); env != "" {
+		return env
+	}
+	return cfg.Root
 }
 
 func Load(repoRoot string) (Config, error) {

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -8,10 +8,17 @@ import (
 	"github.com/kunchenguid/treehouse/internal/git"
 )
 
-// EnsureGitignore adds treehouseDir to the .gitignore of the enclosing git
-// repo, if treehouseDir is inside a git repo. It is a no-op if the directory
-// is not inside a repo or if the entry already exists.
-func EnsureGitignore(treehouseDir string) error {
+// EnsureExcluded arranges for treehouseDir to be ignored by the enclosing git
+// repository using the repo-local, untracked .git/info/exclude file. This keeps
+// an in-project pool out of `git status` and out of any commit without dirtying
+// the tracked .gitignore. It is a no-op when the directory is not inside a git
+// repo (e.g. the default global root under $HOME), matching the previous
+// behavior for the global store.
+//
+// For backward compatibility with pools created by older versions, a
+// pre-existing entry in the tracked .gitignore is left untouched and treated as
+// sufficient, so upgrading users are not surprised by a moved ignore rule.
+func EnsureExcluded(treehouseDir string) error {
 	// Walk up from treehouseDir to find an existing ancestor for the git check,
 	// since the directory itself may not exist yet.
 	checkDir := treehouseDir
@@ -28,7 +35,7 @@ func EnsureGitignore(treehouseDir string) error {
 
 	repoRoot, err := git.FindRepoRootFrom(checkDir)
 	if err != nil {
-		// Not inside a git repo — nothing to do.
+		// Not inside a git repo — nothing to do (e.g. the global ~/.treehouse root).
 		return nil
 	}
 
@@ -36,23 +43,41 @@ func EnsureGitignore(treehouseDir string) error {
 	if err != nil {
 		return nil
 	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// Directory is outside the repository working tree — nothing to do.
+		return nil
+	}
 
-	// Use forward slashes for .gitignore and prefix with /
+	// Use forward slashes and a leading slash to anchor the entry at the repo root.
 	entry := "/" + filepath.ToSlash(rel)
 
-	gitignorePath := filepath.Join(repoRoot, ".gitignore")
-	existing, err := os.ReadFile(gitignorePath)
+	// Backward compatibility: if a previous version already recorded the entry in
+	// the tracked .gitignore, leave it in place rather than writing a duplicate
+	// to .git/info/exclude.
+	if hasIgnoreEntry(filepath.Join(repoRoot, ".gitignore"), entry) {
+		return nil
+	}
+
+	commonDir, err := git.CommonGitDir(repoRoot)
+	if err != nil {
+		return err
+	}
+	excludePath := filepath.Join(commonDir, "info", "exclude")
+
+	if hasIgnoreEntry(excludePath, entry) {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+		return err
+	}
+
+	existing, err := os.ReadFile(excludePath)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	for _, line := range strings.Split(string(existing), "\n") {
-		if strings.TrimSpace(line) == entry {
-			return nil
-		}
-	}
-
-	f, err := os.OpenFile(gitignorePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(excludePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	if err != nil {
 		return err
 	}
@@ -64,4 +89,19 @@ func EnsureGitignore(treehouseDir string) error {
 	}
 	_, err = f.WriteString(prefix + entry + "\n")
 	return err
+}
+
+// hasIgnoreEntry reports whether the ignore file at path already contains entry
+// as a standalone line. A missing file reads as absent.
+func hasIgnoreEntry(path, entry string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -47,85 +47,156 @@ func run(t *testing.T, dir string, name string, args ...string) {
 	}
 }
 
-func TestEnsureGitignore_AddsEntry(t *testing.T) {
+func excludePath(repoDir string) string {
+	return filepath.Join(repoDir, ".git", "info", "exclude")
+}
+
+func readExclude(t *testing.T, repoDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(excludePath(repoDir))
+	if err != nil {
+		t.Fatalf("failed to read .git/info/exclude: %v", err)
+	}
+	return string(data)
+}
+
+func TestEnsureExcluded_WritesToGitInfoExclude(t *testing.T) {
 	repoDir := setupGitRepo(t)
 
-	treehouseDir := filepath.Join(repoDir, ".worktrees", ".treehouse")
+	treehouseDir := filepath.Join(repoDir, ".treehouse")
 
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatalf("EnsureGitignore failed: %v", err)
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
+	expected := "/.treehouse"
+	if got := readExclude(t, repoDir); !strings.Contains(got, expected) {
+		t.Errorf("expected .git/info/exclude to contain %q, got: %s", expected, got)
+	}
+
+	// The tracked .gitignore must stay clean so the repo does not read dirty.
+	if _, err := os.Stat(filepath.Join(repoDir, ".gitignore")); !os.IsNotExist(err) {
+		t.Errorf("expected no tracked .gitignore to be created, stat err: %v", err)
+	}
+}
+
+func TestEnsureExcluded_LeavesRepoClean(t *testing.T) {
+	repoDir := setupGitRepo(t)
+
+	treehouseDir := filepath.Join(repoDir, ".treehouse")
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
+	}
+
+	out, err := exec.Command("git", "-C", repoDir, "status", "--porcelain").CombinedOutput()
 	if err != nil {
-		t.Fatalf("failed to read .gitignore: %v", err)
+		t.Fatalf("git status failed: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "" {
+		t.Errorf("expected clean git status after EnsureExcluded, got:\n%s", out)
+	}
+}
+
+func TestEnsureExcluded_Idempotent(t *testing.T) {
+	repoDir := setupGitRepo(t)
+
+	treehouseDir := filepath.Join(repoDir, ".treehouse")
+
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := "/.treehouse"
+	count := strings.Count(readExclude(t, repoDir), entry)
+	if count != 1 {
+		t.Errorf("expected entry exactly once, found %d times in:\n%s", count, readExclude(t, repoDir))
+	}
+}
+
+func TestEnsureExcluded_PreservesPreexistingGitignoreEntry(t *testing.T) {
+	repoDir := setupGitRepo(t)
+
+	treehouseDir := filepath.Join(repoDir, ".treehouse")
+	entry := "/.treehouse"
+
+	// Simulate a pool created by an older version that added the entry to the
+	// tracked .gitignore.
+	gitignorePath := filepath.Join(repoDir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte(entry+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
+	}
+
+	// The pre-existing .gitignore entry must be left untouched.
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != entry {
+		t.Errorf("expected .gitignore to keep %q untouched, got: %s", entry, data)
+	}
+
+	// And no duplicate should be written to .git/info/exclude.
+	if data, err := os.ReadFile(excludePath(repoDir)); err == nil {
+		if strings.Contains(string(data), entry) {
+			t.Errorf("expected no duplicate entry in .git/info/exclude, got: %s", data)
+		}
+	}
+}
+
+func TestEnsureExcluded_NestedRoot(t *testing.T) {
+	repoDir := setupGitRepo(t)
+
+	// A relative root like ".worktrees" resolves to <repo>/.worktrees/.treehouse.
+	treehouseDir := filepath.Join(repoDir, ".worktrees", ".treehouse")
+
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
 	}
 
 	expected := "/.worktrees/.treehouse"
-	if !strings.Contains(string(data), expected) {
-		t.Errorf("expected .gitignore to contain %q, got: %s", expected, data)
+	if got := readExclude(t, repoDir); !strings.Contains(got, expected) {
+		t.Errorf("expected .git/info/exclude to contain %q, got: %s", expected, got)
 	}
 }
 
-func TestEnsureGitignore_Idempotent(t *testing.T) {
-	repoDir := setupGitRepo(t)
-
-	treehouseDir := filepath.Join(repoDir, ".worktrees", ".treehouse")
-
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatal(err)
-	}
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	entry := "/.worktrees/.treehouse"
-	count := strings.Count(string(data), entry)
-	if count != 1 {
-		t.Errorf("expected entry exactly once, found %d times in:\n%s", count, data)
-	}
-}
-
-func TestEnsureGitignore_NotInRepo(t *testing.T) {
+func TestEnsureExcluded_NotInRepo(t *testing.T) {
 	// A temp dir that is not a git repo.
 	dir := t.TempDir()
 	treehouseDir := filepath.Join(dir, ".treehouse")
 
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatalf("EnsureGitignore should be a no-op outside a repo, got: %v", err)
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded should be a no-op outside a repo, got: %v", err)
 	}
 
-	// No .gitignore should be created.
 	if _, err := os.Stat(filepath.Join(dir, ".gitignore")); !os.IsNotExist(err) {
 		t.Error("expected no .gitignore to be created outside a git repo")
 	}
 }
 
-func TestEnsureGitignore_DefaultRoot(t *testing.T) {
+func TestEnsureExcluded_DefaultRoot(t *testing.T) {
 	repoDir := setupGitRepo(t)
 
-	// When using default root ($HOME/.treehouse), the treehouse dir is outside
-	// the repo, so EnsureGitignore should be a no-op.
+	// When using the default root ($HOME/.treehouse), the treehouse dir is
+	// outside the repo, so EnsureExcluded should be a no-op and must not touch
+	// the repo's exclude file or .gitignore.
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatal(err)
 	}
 	treehouseDir := filepath.Join(home, ".treehouse")
 
-	// This should not fail even though the dir is outside the repo.
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatalf("EnsureGitignore failed: %v", err)
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
 	}
 
-	// No .gitignore should be created/modified in the repo.
 	if _, err := os.Stat(filepath.Join(repoDir, ".gitignore")); err == nil {
-		// If .gitignore exists, it shouldn't contain .treehouse (the home one
-		// is in a different repo context).
-		_ = repoDir // just ensure we don't accidentally create one
+		t.Error("expected no .gitignore to be created in the repo for the default root")
 	}
 }

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -115,3 +115,71 @@ func TestResolvePoolRoot_RelativeRootRequiresRepo(t *testing.T) {
 		t.Fatal("expected relative root without repo to fail")
 	}
 }
+
+func TestResolveRoot_Precedence(t *testing.T) {
+	cfg := Config{Root: "/from/config"}
+
+	t.Run("flag wins over env and config", func(t *testing.T) {
+		t.Setenv(RootEnvVar, "/from/env")
+		if got := ResolveRoot("/from/flag", cfg); got != "/from/flag" {
+			t.Errorf("expected flag to win, got %q", got)
+		}
+	})
+
+	t.Run("env wins over config when flag is empty", func(t *testing.T) {
+		t.Setenv(RootEnvVar, "/from/env")
+		if got := ResolveRoot("", cfg); got != "/from/env" {
+			t.Errorf("expected env to win, got %q", got)
+		}
+	})
+
+	t.Run("config used when flag and env are empty", func(t *testing.T) {
+		t.Setenv(RootEnvVar, "")
+		if got := ResolveRoot("", cfg); got != "/from/config" {
+			t.Errorf("expected config value, got %q", got)
+		}
+	})
+
+	t.Run("default empty when nothing set", func(t *testing.T) {
+		t.Setenv(RootEnvVar, "")
+		if got := ResolveRoot("", Config{}); got != "" {
+			t.Errorf("expected empty default root, got %q", got)
+		}
+	})
+}
+
+func TestResolveRoot_DefaultPathByteForByte(t *testing.T) {
+	// The default (unset) resolution must be byte-for-byte identical to calling
+	// ResolvePoolRoot with the raw config root, i.e. no override leaks in.
+	t.Setenv(RootEnvVar, "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root := ResolveRoot("", DefaultConfig())
+	poolRoot, err := ResolvePoolRoot("", root)
+	if err != nil {
+		t.Fatalf("ResolvePoolRoot failed: %v", err)
+	}
+	if expected := filepath.Join(home, ".treehouse"); poolRoot != expected {
+		t.Fatalf("expected default pool root %s, got %s", expected, poolRoot)
+	}
+}
+
+func TestResolveRoot_FlagDotSelectsInProject(t *testing.T) {
+	repoDir := setupGitRepo(t)
+	t.Setenv(RootEnvVar, "")
+
+	root := ResolveRoot(".", Config{})
+	poolDir, err := ResolvePoolDir(repoDir, root)
+	if err != nil {
+		t.Fatalf("ResolvePoolDir failed: %v", err)
+	}
+
+	repoName := filepath.Base(repoDir)
+	expected := filepath.Join(repoDir, ".treehouse", repoName)
+	if !strings.HasPrefix(poolDir, expected) {
+		t.Errorf("expected in-project pool dir under %s, got %s", expected, poolDir)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -55,6 +55,26 @@ func mainRepoRoot(repoRoot string) string {
 	return mainRoot
 }
 
+// CommonGitDir returns the absolute path to the repository's common git
+// directory for the repo containing dir. For a linked worktree this is the
+// shared .git of the main repository, so files such as info/exclude resolve to
+// the single shared location git actually reads.
+func CommonGitDir(dir string) (string, error) {
+	out, err := runGit(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		// Older git without --path-format falls back to a possibly-relative path.
+		out, err = runGit(dir, "rev-parse", "--git-common-dir")
+		if err != nil {
+			return "", err
+		}
+	}
+	p := filepath.Clean(filepath.FromSlash(out))
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(dir, p)
+	}
+	return p, nil
+}
+
 func repoRootFromCommonGitDir(dir string) (string, bool) {
 	cleaned := filepath.Clean(filepath.FromSlash(dir))
 	if filepath.Base(cleaned) != ".git" {

--- a/treehouse.toml.example
+++ b/treehouse.toml.example
@@ -5,6 +5,15 @@
 # Maximum number of worktrees in the pool
 max_trees = 16
 
+# Optional worktree root directory.
+# Empty (default) uses the global $HOME/.treehouse store.
+# Relative paths resolve from the repo root; "treehouse" is always appended.
+# Override per-command with the --root flag or the TREEHOUSE_ROOT env var
+# (precedence: --root > TREEHOUSE_ROOT > this file > user config > default).
+# Set to "." to keep the pool in-project at <repo>/.treehouse/: it is removed
+# with the project and ignored via the untracked .git/info/exclude.
+# root = "."
+
 # Lifecycle hooks are ignored in repo-level config for safety.
 # Each list runs sequentially in the worktree directory via the OS shell.
 # Failures are logged and do not fail the operation.


### PR DESCRIPTION
## Problem

Treehouse can already place its pool inside the repo via a relative `root`: setting `root = "."` in `treehouse.toml` puts the pool at `<repo>/.treehouse/`, which colocates worktrees with the project and removes them when the project is deleted (`rm -rf <repo>` leaves no global orphan). This grew out of #11 ("Support for custom worktrees root").

But the mode is **undiscoverable** (only reachable through a relative config value, documented nowhere) and has a papercut: on every `get`, treehouse appends the pool to the **tracked** `.gitignore`, so the repo reads dirty with an uncommitted `M .gitignore`.

## What this PR does

Makes in-project storage a **first-class, documented, opt-in** mode, without changing the directory layout and without touching the default global (`~/.treehouse`) behavior.

**1. `--root` flag + `TREEHOUSE_ROOT` env** (neither existed before)

A persistent `--root` flag and a `TREEHOUSE_ROOT` env var, threaded into config resolution. Precedence, highest first:

`--root` > `TREEHOUSE_ROOT` > repo `treehouse.toml` > user config > default (`~/.treehouse`)

A relative value (including `.`) resolves under the repo root exactly like a relative `root`, so in-project becomes trivial: `treehouse get --root .`. Resolution is centralized in a small `config.ResolveRoot` helper, leaving `ResolvePoolRoot` pure and its existing tests untouched.

**2. In-project ignore moves to `.git/info/exclude`** (fixes the papercut and addresses #71)

Instead of editing the tracked `.gitignore`, the in-project ignore entry is written to the repo-local, **untracked** `.git/info/exclude`, so the pool never appears in `git status` or a commit. This is git's own mechanism for local-only ignores and is exactly the fix proposed in #71 for the sibling "backing repo reads dirty" problem, implemented once here.

Backward-compat: a pre-existing `/.treehouse` line in a user's `.gitignore` is left untouched and treated as sufficient (no duplicate written). The global-root case stays a no-op, as before.

**3. Documentation** so the mode is discoverable

- `README.md`: a "Worktree root" precedence list and an "In-project storage" section.
- `treehouse.toml.example` and the `treehouse init` template: document `root = "."`, the flag/env, and the `.git/info/exclude` behavior.

**4. Tests**

Realistic E2E tests driving the built binary (`cmd/inproject_e2e_test.go`): the pool lands in-project via flag / env / config, `.git/info/exclude` gets the entry, the tracked `.gitignore` stays clean, `git status` reads clean, removal leaves no global orphan, and `--root` correctly wins over `TREEHOUSE_ROOT`. Plus unit tests for `ResolveRoot` precedence and the exclude logic, and an explicit check that the **default (unset) path is unchanged**.

## Scope / non-goals

This is intentionally small and layout-preserving. The pool still uses the existing `<repo>-<hash>/<n>/<repo>` layout; the flat, git-like layout is deliberately left for a separate follow-up so this PR stays focused (one feature per PR).

All new behavior is **opt-in**; the default global `~/.treehouse` store is byte-for-byte unchanged.

## Verification

- `make lint` - clean (`gofmt -l .` + `go vet ./...`)
- `make test` (`go test ./...`) - all green
- `GOOS=windows go build ./...` - builds (paths go through `filepath`; `.git/info/exclude` is portable)

Refs #11, #71.
