### PR TITLE
fix: ignore in-project pool via .git/info/exclude, not tracked .gitignore

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -65,8 +65,8 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to resolve pool directory: %w", err)
 	}
 
-	if err := config.EnsureGitignore(filepath.Dir(poolDir)); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to update .gitignore: %v\n", err)
+	if err := config.EnsureExcluded(filepath.Dir(poolDir)); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to update git exclude: %v\n", err)
 	}
 
 	if getLease {

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -8,10 +8,17 @@ import (
 	"github.com/kunchenguid/treehouse/internal/git"
 )
 
-// EnsureGitignore adds treehouseDir to the .gitignore of the enclosing git
-// repo, if treehouseDir is inside a git repo. It is a no-op if the directory
-// is not inside a repo or if the entry already exists.
-func EnsureGitignore(treehouseDir string) error {
+// EnsureExcluded arranges for treehouseDir to be ignored by the enclosing git
+// repository using the repo-local, untracked .git/info/exclude file. This keeps
+// an in-project pool out of `git status` and out of any commit without dirtying
+// the tracked .gitignore. It is a no-op when the directory is not inside a git
+// repo (e.g. the default global root under $HOME), matching the previous
+// behavior for the global store.
+//
+// For backward compatibility with pools created by older versions, a
+// pre-existing entry in the tracked .gitignore is left untouched and treated as
+// sufficient, so upgrading users are not surprised by a moved ignore rule.
+func EnsureExcluded(treehouseDir string) error {
 	// Walk up from treehouseDir to find an existing ancestor for the git check,
 	// since the directory itself may not exist yet.
 	checkDir := treehouseDir
@@ -28,7 +35,7 @@ func EnsureGitignore(treehouseDir string) error {
 
 	repoRoot, err := git.FindRepoRootFrom(checkDir)
 	if err != nil {
-		// Not inside a git repo — nothing to do.
+		// Not inside a git repo — nothing to do (e.g. the global ~/.treehouse root).
 		return nil
 	}
 
@@ -36,23 +43,41 @@ func EnsureGitignore(treehouseDir string) error {
 	if err != nil {
 		return nil
 	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// Directory is outside the repository working tree — nothing to do.
+		return nil
+	}
 
-	// Use forward slashes for .gitignore and prefix with /
+	// Use forward slashes and a leading slash to anchor the entry at the repo root.
 	entry := "/" + filepath.ToSlash(rel)
 
-	gitignorePath := filepath.Join(repoRoot, ".gitignore")
-	existing, err := os.ReadFile(gitignorePath)
+	// Backward compatibility: if a previous version already recorded the entry in
+	// the tracked .gitignore, leave it in place rather than writing a duplicate
+	// to .git/info/exclude.
+	if hasIgnoreEntry(filepath.Join(repoRoot, ".gitignore"), entry) {
+		return nil
+	}
+
+	commonDir, err := git.CommonGitDir(repoRoot)
+	if err != nil {
+		return err
+	}
+	excludePath := filepath.Join(commonDir, "info", "exclude")
+
+	if hasIgnoreEntry(excludePath, entry) {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+		return err
+	}
+
+	existing, err := os.ReadFile(excludePath)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	for _, line := range strings.Split(string(existing), "\n") {
-		if strings.TrimSpace(line) == entry {
-			return nil
-		}
-	}
-
-	f, err := os.OpenFile(gitignorePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(excludePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	if err != nil {
 		return err
 	}
@@ -64,4 +89,19 @@ func EnsureGitignore(treehouseDir string) error {
 	}
 	_, err = f.WriteString(prefix + entry + "\n")
 	return err
+}
+
+// hasIgnoreEntry reports whether the ignore file at path already contains entry
+// as a standalone line. A missing file reads as absent.
+func hasIgnoreEntry(path, entry string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -47,85 +47,156 @@ func run(t *testing.T, dir string, name string, args ...string) {
 	}
 }
 
-func TestEnsureGitignore_AddsEntry(t *testing.T) {
+func excludePath(repoDir string) string {
+	return filepath.Join(repoDir, ".git", "info", "exclude")
+}
+
+func readExclude(t *testing.T, repoDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(excludePath(repoDir))
+	if err != nil {
+		t.Fatalf("failed to read .git/info/exclude: %v", err)
+	}
+	return string(data)
+}
+
+func TestEnsureExcluded_WritesToGitInfoExclude(t *testing.T) {
 	repoDir := setupGitRepo(t)
 
-	treehouseDir := filepath.Join(repoDir, ".worktrees", ".treehouse")
+	treehouseDir := filepath.Join(repoDir, ".treehouse")
 
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatalf("EnsureGitignore failed: %v", err)
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
+	expected := "/.treehouse"
+	if got := readExclude(t, repoDir); !strings.Contains(got, expected) {
+		t.Errorf("expected .git/info/exclude to contain %q, got: %s", expected, got)
+	}
+
+	// The tracked .gitignore must stay clean so the repo does not read dirty.
+	if _, err := os.Stat(filepath.Join(repoDir, ".gitignore")); !os.IsNotExist(err) {
+		t.Errorf("expected no tracked .gitignore to be created, stat err: %v", err)
+	}
+}
+
+func TestEnsureExcluded_LeavesRepoClean(t *testing.T) {
+	repoDir := setupGitRepo(t)
+
+	treehouseDir := filepath.Join(repoDir, ".treehouse")
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
+	}
+
+	out, err := exec.Command("git", "-C", repoDir, "status", "--porcelain").CombinedOutput()
 	if err != nil {
-		t.Fatalf("failed to read .gitignore: %v", err)
+		t.Fatalf("git status failed: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "" {
+		t.Errorf("expected clean git status after EnsureExcluded, got:\n%s", out)
+	}
+}
+
+func TestEnsureExcluded_Idempotent(t *testing.T) {
+	repoDir := setupGitRepo(t)
+
+	treehouseDir := filepath.Join(repoDir, ".treehouse")
+
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := "/.treehouse"
+	count := strings.Count(readExclude(t, repoDir), entry)
+	if count != 1 {
+		t.Errorf("expected entry exactly once, found %d times in:\n%s", count, readExclude(t, repoDir))
+	}
+}
+
+func TestEnsureExcluded_PreservesPreexistingGitignoreEntry(t *testing.T) {
+	repoDir := setupGitRepo(t)
+
+	treehouseDir := filepath.Join(repoDir, ".treehouse")
+	entry := "/.treehouse"
+
+	// Simulate a pool created by an older version that added the entry to the
+	// tracked .gitignore.
+	gitignorePath := filepath.Join(repoDir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte(entry+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
+	}
+
+	// The pre-existing .gitignore entry must be left untouched.
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != entry {
+		t.Errorf("expected .gitignore to keep %q untouched, got: %s", entry, data)
+	}
+
+	// And no duplicate should be written to .git/info/exclude.
+	if data, err := os.ReadFile(excludePath(repoDir)); err == nil {
+		if strings.Contains(string(data), entry) {
+			t.Errorf("expected no duplicate entry in .git/info/exclude, got: %s", data)
+		}
+	}
+}
+
+func TestEnsureExcluded_NestedRoot(t *testing.T) {
+	repoDir := setupGitRepo(t)
+
+	// A relative root like ".worktrees" resolves to <repo>/.worktrees/.treehouse.
+	treehouseDir := filepath.Join(repoDir, ".worktrees", ".treehouse")
+
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
 	}
 
 	expected := "/.worktrees/.treehouse"
-	if !strings.Contains(string(data), expected) {
-		t.Errorf("expected .gitignore to contain %q, got: %s", expected, data)
+	if got := readExclude(t, repoDir); !strings.Contains(got, expected) {
+		t.Errorf("expected .git/info/exclude to contain %q, got: %s", expected, got)
 	}
 }
 
-func TestEnsureGitignore_Idempotent(t *testing.T) {
-	repoDir := setupGitRepo(t)
-
-	treehouseDir := filepath.Join(repoDir, ".worktrees", ".treehouse")
-
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatal(err)
-	}
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	entry := "/.worktrees/.treehouse"
-	count := strings.Count(string(data), entry)
-	if count != 1 {
-		t.Errorf("expected entry exactly once, found %d times in:\n%s", count, data)
-	}
-}
-
-func TestEnsureGitignore_NotInRepo(t *testing.T) {
+func TestEnsureExcluded_NotInRepo(t *testing.T) {
 	// A temp dir that is not a git repo.
 	dir := t.TempDir()
 	treehouseDir := filepath.Join(dir, ".treehouse")
 
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatalf("EnsureGitignore should be a no-op outside a repo, got: %v", err)
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded should be a no-op outside a repo, got: %v", err)
 	}
 
-	// No .gitignore should be created.
 	if _, err := os.Stat(filepath.Join(dir, ".gitignore")); !os.IsNotExist(err) {
 		t.Error("expected no .gitignore to be created outside a git repo")
 	}
 }
 
-func TestEnsureGitignore_DefaultRoot(t *testing.T) {
+func TestEnsureExcluded_DefaultRoot(t *testing.T) {
 	repoDir := setupGitRepo(t)
 
-	// When using default root ($HOME/.treehouse), the treehouse dir is outside
-	// the repo, so EnsureGitignore should be a no-op.
+	// When using the default root ($HOME/.treehouse), the treehouse dir is
+	// outside the repo, so EnsureExcluded should be a no-op and must not touch
+	// the repo's exclude file or .gitignore.
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatal(err)
 	}
 	treehouseDir := filepath.Join(home, ".treehouse")
 
-	// This should not fail even though the dir is outside the repo.
-	if err := EnsureGitignore(treehouseDir); err != nil {
-		t.Fatalf("EnsureGitignore failed: %v", err)
+	if err := EnsureExcluded(treehouseDir); err != nil {
+		t.Fatalf("EnsureExcluded failed: %v", err)
 	}
 
-	// No .gitignore should be created/modified in the repo.
 	if _, err := os.Stat(filepath.Join(repoDir, ".gitignore")); err == nil {
-		// If .gitignore exists, it shouldn't contain .treehouse (the home one
-		// is in a different repo context).
-		_ = repoDir // just ensure we don't accidentally create one
+		t.Error("expected no .gitignore to be created in the repo for the default root")
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -55,6 +55,26 @@ func mainRepoRoot(repoRoot string) string {
 	return mainRoot
 }
 
+// CommonGitDir returns the absolute path to the repository's common git
+// directory for the repo containing dir. For a linked worktree this is the
+// shared .git of the main repository, so files such as info/exclude resolve to
+// the single shared location git actually reads.
+func CommonGitDir(dir string) (string, error) {
+	out, err := runGit(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		// Older git without --path-format falls back to a possibly-relative path.
+		out, err = runGit(dir, "rev-parse", "--git-common-dir")
+		if err != nil {
+			return "", err
+		}
+	}
+	p := filepath.Clean(filepath.FromSlash(out))
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(dir, p)
+	}
+	return p, nil
+}
+
 func repoRootFromCommonGitDir(dir string) (string, bool) {
 	cleaned := filepath.Clean(filepath.FromSlash(dir))
 	if filepath.Base(cleaned) != ".git" {


### PR DESCRIPTION
Ignore an in-project pool via the untracked `.git/info/exclude` instead of appending to the tracked `.gitignore`, so acquiring a worktree no longer leaves the repo dirty.

### What
- On every `get`, treehouse appended the pool directory to the repo's **tracked** `.gitignore`, so `git status` showed an uncommitted `M .gitignore`.
- This writes the ignore entry to the repo-local, **untracked** `.git/info/exclude` instead. Same effect (the pool is ignored), but nothing tracked changes.
- `EnsureGitignore` → `EnsureExcluded`; the shared git dir is resolved via a new `git.CommonGitDir` (correct for linked worktrees), and the entry is written under `<git-common-dir>/info/exclude`.

### Why
Addresses #71 - the sibling "backing repo reads dirty" problem, whose suggested fix is exactly `.git/info/exclude`. Implemented once here.

### Risk
- **Blast radius:** only the ignore mechanism for an *in-project* pool (a relative `root`). The default global `~/.treehouse` root is outside any repo, so this stays a no-op there - unchanged.
- **Backward compat:** a pre-existing `/.treehouse` line in a user's tracked `.gitignore` is detected and left in place; no duplicate is written to `.git/info/exclude`, so upgrading users see no surprise.
- **Could break:** nothing tracked is written, so the worst case is the pool isn't ignored - it can never delete or dirty a tracked file. `.git/info/exclude` and `--git-common-dir` are portable (incl. Windows).

### Tests
`make lint` + `make test` green (Linux/macOS/Windows build). Unit tests cover: entry written to `.git/info/exclude`, tracked `.gitignore` left absent, `git status` clean, idempotent, pre-existing `.gitignore` entry preserved, nested root, and the default-root no-op.

Addresses #71.


---

Companion PR: #93 - adds the `--root` flag + `TREEHOUSE_ROOT` env and documents in-project storage. Independent of this one; the two can merge in either order.
