### PR TITLE
feat: add --root flag and TREEHOUSE_ROOT env for the worktree root

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ make install
 
 Treehouse manages a **pool of git worktrees** per repository, stored under the configured treehouse root.
 The default treehouse root is `~/.treehouse/`.
+You can instead keep the pool [inside the project](#in-project-storage) with `--root .`, so it lives next to the code and is removed with the project.
 
 ```
   treehouse
@@ -312,6 +313,7 @@ max_trees = 16
 # Optional worktree root directory.
 # Empty uses $HOME/.treehouse.
 # Relative paths are resolved from the repo root for repo-scoped commands.
+# Use "." to keep the pool inside the project (see "In-project storage" below).
 # Use an absolute user-level root for treehouse prune --all.
 # root = "$HOME/worktrees"
 ```
@@ -319,6 +321,39 @@ max_trees = 16
 The repo-level config takes precedence for repo-safe settings.
 `treehouse prune --all` can run without a repository, so it uses only the user-level config and does not read per-repo `treehouse.toml` files while sweeping.
 If no config is found, the default pool size is 16.
+
+### Worktree root
+
+The worktree root can also be set without a config file, and the resolved value follows this precedence (highest first):
+
+1. The `--root` flag (e.g. `treehouse get --root .`)
+2. The `TREEHOUSE_ROOT` environment variable
+3. `root` in the repo-level `treehouse.toml`
+4. `root` in the user-level `~/.config/treehouse/config.toml`
+5. The default, `~/.treehouse`
+
+A relative value (including `.`) is resolved from the repo root, exactly like a relative `root` in config; `treehouse` is always appended, so `--root .` places the pool at `<repo>/.treehouse/`.
+
+### In-project storage
+
+By default the pool lives in the global `~/.treehouse` store. Set the root to `.` to keep it **inside the project** instead:
+
+```sh
+treehouse get --root .          # one-off
+export TREEHOUSE_ROOT=.         # for a shell session
+```
+
+or commit it for the whole repo in `treehouse.toml`:
+
+```toml
+root = "."
+```
+
+This is **opt-in**; the default global store is unchanged. In-project mode:
+
+- Places the pool at `<repo>/.treehouse/`, so worktrees sit next to the code and are **removed with the project** (`rm -rf <repo>` leaves no global orphan).
+- Git-ignores the pool directory automatically, so it stays out of `git add`.
+- Is not reached by `treehouse prune --all`, which only sweeps the global root; in-project pools are removed with the project instead.
 
 ### Hooks
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -172,7 +172,7 @@ func resolveDestroyPoolFromTarget(targetPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to load config: %w", err)
 	}
-	return config.ResolvePoolDir(repoRoot, cfg.Root)
+	return config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 }
 
 // destroySingleExit makes a single named destruction fail loudly when the

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -52,7 +52,7 @@ func enterRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+	poolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 	if err != nil {
 		return fmt.Errorf("failed to resolve pool directory: %w", err)
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -60,7 +60,7 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+	poolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 	if err != nil {
 		return fmt.Errorf("failed to resolve pool directory: %w", err)
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -38,7 +38,7 @@ var initCmd = &cobra.Command{
 		}
 
 		// Append a comment showing the root option.
-		if _, err := f.WriteString("\n# Worktree root directory (relative to repo root or absolute path).\n# Worktrees are placed under {root}/.treehouse/. Default: $HOME\n# Example: root = \"./\"\n"); err != nil {
+		if _, err := f.WriteString("\n# Worktree root directory (relative to repo root or absolute path).\n# Worktrees are placed under {root}/.treehouse/. Default: $HOME\n# Override per-command with the --root flag or the TREEHOUSE_ROOT env var.\n# Use \".\" to keep the pool in-project at <repo>/.treehouse/, next to the\n# code and removed with the project. Example: root = \".\"\n"); err != nil {
 			return fmt.Errorf("failed to write config: %w", err)
 		}
 

--- a/cmd/inproject_e2e_test.go
+++ b/cmd/inproject_e2e_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readExcludeFile returns the contents of the repo's .git/info/exclude, or "" if
+// it does not exist.
+func readExcludeFile(t *testing.T, repoDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("failed to read .git/info/exclude: %v", err)
+	}
+	return string(data)
+}
+
+// globalPoolEntries returns the names of per-repo pools under the fake home's
+// global ~/.treehouse store. In-project mode must never create any.
+func globalPoolEntries(t *testing.T, homeDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(homeDir, ".treehouse"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("failed to read global pool dir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// assertInProject runs "get --lease" with the given extra env / args and checks
+// the in-project contract for the root override: the pool lands under
+// <repo>/.treehouse, the worktree has repo content, and no orphan is created in
+// the global store.
+func assertInProject(t *testing.T, repoDir, homeDir string, extraEnv []string, args ...string) string {
+	t.Helper()
+
+	getArgs := append([]string{"get", "--lease"}, args...)
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, extraEnv, getArgs...)
+	if code != 0 {
+		t.Fatalf("get --lease failed (code %d): %s", code, stderr)
+	}
+	wtPath := strings.TrimSpace(stdout)
+	if wtPath == "" {
+		t.Fatal("could not capture leased worktree path")
+	}
+
+	// The pool must live inside the repo, under <repo>/.treehouse.
+	inProjectRoot := filepath.Join(repoDir, ".treehouse")
+	if !strings.HasPrefix(wtPath, inProjectRoot+string(filepath.Separator)) {
+		t.Fatalf("expected in-project worktree under %s, got %s", inProjectRoot, wtPath)
+	}
+	if _, err := os.Stat(filepath.Join(wtPath, "README.md")); err != nil {
+		t.Fatalf("expected in-project worktree to contain repo content: %v", err)
+	}
+
+	// No global orphan may be created under ~/.treehouse.
+	if names := globalPoolEntries(t, homeDir); len(names) != 0 {
+		t.Fatalf("expected no global pool entries in in-project mode, got: %v", names)
+	}
+
+	return wtPath
+}
+
+func TestInProjectViaFlag(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	assertInProject(t, repoDir, homeDir, nil, "--root", ".")
+}
+
+func TestInProjectViaEnv(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	assertInProject(t, repoDir, homeDir, []string{"TREEHOUSE_ROOT=."})
+}
+
+func TestInProjectViaConfig(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	if err := os.WriteFile(filepath.Join(repoDir, "treehouse.toml"), []byte("root = \".\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repoDir, "add", "treehouse.toml")
+	gitCmd(t, repoDir, "commit", "-m", "configure in-project root")
+
+	assertInProject(t, repoDir, homeDir, nil)
+}
+
+// TestInProjectRemovalLeavesNoGlobalOrphan mirrors deleting the project: after
+// removing the repo directory, nothing is left behind in the global store.
+func TestInProjectRemovalLeavesNoGlobalOrphan(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	assertInProject(t, repoDir, homeDir, nil, "--root", ".")
+
+	if err := os.RemoveAll(repoDir); err != nil {
+		t.Fatalf("failed to remove project: %v", err)
+	}
+	if names := globalPoolEntries(t, homeDir); len(names) != 0 {
+		t.Fatalf("expected no global orphan after project removal, got: %v", names)
+	}
+}
+
+// TestRootFlagWinsOverEnv verifies the documented precedence: the --root flag
+// overrides TREEHOUSE_ROOT. The env points at an absolute global-style root, but
+// the flag selects in-project, so the pool must land in the repo.
+func TestRootFlagWinsOverEnv(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	envRoot := t.TempDir()
+	assertInProject(t, repoDir, homeDir, []string{"TREEHOUSE_ROOT=" + envRoot}, "--root", ".")
+
+	// The env-pointed root must not have been used.
+	if _, err := os.Stat(filepath.Join(envRoot, ".treehouse")); !os.IsNotExist(err) {
+		t.Fatalf("expected env root to be ignored when --root is set, stat err: %v", err)
+	}
+}
+
+// TestDefaultRootUnchanged asserts the default (unset) behavior is untouched:
+// the pool lands under the global ~/.treehouse, and the repo working tree is not
+// modified.
+func TestDefaultRootUnchanged(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease")
+	if code != 0 {
+		t.Fatalf("get --lease failed (code %d): %s", code, stderr)
+	}
+	wtPath := strings.TrimSpace(stdout)
+
+	globalRoot := filepath.Join(homeDir, ".treehouse")
+	if !strings.HasPrefix(wtPath, globalRoot+string(filepath.Separator)) {
+		t.Fatalf("expected default worktree under %s, got %s", globalRoot, wtPath)
+	}
+
+	// The repo must be untouched: no in-project pool, no ignore edits.
+	if _, err := os.Stat(filepath.Join(repoDir, ".treehouse")); !os.IsNotExist(err) {
+		t.Fatalf("expected no in-project pool for the default root, stat err: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repoDir, ".gitignore")); !os.IsNotExist(err) {
+		t.Fatalf("expected no .gitignore for the default root, stat err: %v", err)
+	}
+	if exclude := readExcludeFile(t, repoDir); strings.Contains(exclude, "/.treehouse") {
+		t.Fatalf("expected no exclude entry for the default global root, got:\n%s", exclude)
+	}
+	if status := gitCmd(t, repoDir, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean git status for the default root, got:\n%s", status)
+	}
+}

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -48,7 +48,7 @@ absolute.`,
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			poolRoot, err := config.ResolvePoolRoot("", cfg.Root)
+			poolRoot, err := config.ResolvePoolRoot("", config.ResolveRoot(rootFlag, cfg))
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ absolute.`,
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+		poolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 		if err != nil {
 			return err
 		}

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -159,7 +159,7 @@ func resolveReturnPoolDir(wtPath string, explicitPath bool) (string, error) {
 		return "", fmt.Errorf("failed to load config: %w", err)
 	}
 
-	fallbackPoolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+	fallbackPoolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,11 @@ import (
 
 var version = "dev"
 
+// rootFlag holds the value of the persistent --root flag. It overrides both the
+// TREEHOUSE_ROOT environment variable and the configured root; see
+// config.ResolveRoot for the full precedence.
+var rootFlag string
+
 func SetVersion(v string) {
 	version = v
 	rootCmd.Version = v
@@ -54,6 +59,8 @@ so that multiple AI coding agents can work on the same repo in parallel.`,
 
 func init() {
 	rootCmd.SetVersionTemplate(`{{.Version}}` + "\n")
+	rootCmd.PersistentFlags().StringVar(&rootFlag, "root", "",
+		"Worktree root directory, overriding TREEHOUSE_ROOT and config; relative paths (e.g. \".\" for an in-project pool) resolve from the repo root")
 }
 
 func Execute() error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -47,7 +47,7 @@ var statusCmd = &cobra.Command{
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		poolDir, err := config.ResolvePoolDir(repoRoot, cfg.Root)
+		poolDir, err := config.ResolvePoolDir(repoRoot, config.ResolveRoot(rootFlag, cfg))
 		if err != nil {
 			return err
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,10 +20,32 @@ type Hooks struct {
 	PreDestroy []string `toml:"pre_destroy,omitempty"`
 }
 
+// RootEnvVar is the environment variable that overrides the configured
+// worktree root. It sits below the --root flag but above repo/user config in
+// the resolution precedence (see ResolveRoot).
+const RootEnvVar = "TREEHOUSE_ROOT"
+
 func DefaultConfig() Config {
 	return Config{
 		MaxTrees: 16,
 	}
+}
+
+// ResolveRoot returns the effective worktree root, honoring override precedence:
+// an explicit flag value, then the TREEHOUSE_ROOT environment variable, then the
+// root from repo/user config, then the built-in default (empty string, which
+// ResolvePoolRoot maps to ~/.treehouse). It keeps ResolvePoolRoot pure while
+// letting callers layer command-line and environment overrides on top of the
+// loaded config. A relative override is resolved from the repo root exactly like
+// a relative config root, so `--root .` selects an in-project pool.
+func ResolveRoot(flagRoot string, cfg Config) string {
+	if flagRoot != "" {
+		return flagRoot
+	}
+	if env := os.Getenv(RootEnvVar); env != "" {
+		return env
+	}
+	return cfg.Root
 }
 
 func Load(repoRoot string) (Config, error) {

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -115,3 +115,71 @@ func TestResolvePoolRoot_RelativeRootRequiresRepo(t *testing.T) {
 		t.Fatal("expected relative root without repo to fail")
 	}
 }
+
+func TestResolveRoot_Precedence(t *testing.T) {
+	cfg := Config{Root: "/from/config"}
+
+	t.Run("flag wins over env and config", func(t *testing.T) {
+		t.Setenv(RootEnvVar, "/from/env")
+		if got := ResolveRoot("/from/flag", cfg); got != "/from/flag" {
+			t.Errorf("expected flag to win, got %q", got)
+		}
+	})
+
+	t.Run("env wins over config when flag is empty", func(t *testing.T) {
+		t.Setenv(RootEnvVar, "/from/env")
+		if got := ResolveRoot("", cfg); got != "/from/env" {
+			t.Errorf("expected env to win, got %q", got)
+		}
+	})
+
+	t.Run("config used when flag and env are empty", func(t *testing.T) {
+		t.Setenv(RootEnvVar, "")
+		if got := ResolveRoot("", cfg); got != "/from/config" {
+			t.Errorf("expected config value, got %q", got)
+		}
+	})
+
+	t.Run("default empty when nothing set", func(t *testing.T) {
+		t.Setenv(RootEnvVar, "")
+		if got := ResolveRoot("", Config{}); got != "" {
+			t.Errorf("expected empty default root, got %q", got)
+		}
+	})
+}
+
+func TestResolveRoot_DefaultPathByteForByte(t *testing.T) {
+	// The default (unset) resolution must be byte-for-byte identical to calling
+	// ResolvePoolRoot with the raw config root, i.e. no override leaks in.
+	t.Setenv(RootEnvVar, "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	root := ResolveRoot("", DefaultConfig())
+	poolRoot, err := ResolvePoolRoot("", root)
+	if err != nil {
+		t.Fatalf("ResolvePoolRoot failed: %v", err)
+	}
+	if expected := filepath.Join(home, ".treehouse"); poolRoot != expected {
+		t.Fatalf("expected default pool root %s, got %s", expected, poolRoot)
+	}
+}
+
+func TestResolveRoot_FlagDotSelectsInProject(t *testing.T) {
+	repoDir := setupGitRepo(t)
+	t.Setenv(RootEnvVar, "")
+
+	root := ResolveRoot(".", Config{})
+	poolDir, err := ResolvePoolDir(repoDir, root)
+	if err != nil {
+		t.Fatalf("ResolvePoolDir failed: %v", err)
+	}
+
+	repoName := filepath.Base(repoDir)
+	expected := filepath.Join(repoDir, ".treehouse", repoName)
+	if !strings.HasPrefix(poolDir, expected) {
+		t.Errorf("expected in-project pool dir under %s, got %s", expected, poolDir)
+	}
+}

--- a/treehouse.toml.example
+++ b/treehouse.toml.example
@@ -5,6 +5,15 @@
 # Maximum number of worktrees in the pool
 max_trees = 16
 
+# Optional worktree root directory.
+# Empty (default) uses the global $HOME/.treehouse store.
+# Relative paths resolve from the repo root; "treehouse" is always appended.
+# Override per-command with the --root flag or the TREEHOUSE_ROOT env var
+# (precedence: --root > TREEHOUSE_ROOT > this file > user config > default).
+# Set to "." to keep the pool in-project at <repo>/.treehouse/, next to the
+# code and removed with the project.
+# root = "."
+
 # Lifecycle hooks are ignored in repo-level config for safety.
 # Each list runs sequentially in the worktree directory via the OS shell.
 # Failures are logged and do not fail the operation.


### PR DESCRIPTION
Add a `--root` flag and a `TREEHOUSE_ROOT` env var so the worktree root can be set per command, making in-project storage easy to discover and use.

### What
- New persistent `--root` flag and `TREEHOUSE_ROOT` env var, resolved by a small `config.ResolveRoot` helper. Precedence (highest first):
  `--root` > `TREEHOUSE_ROOT` > repo `treehouse.toml` > user config > default (`~/.treehouse`).
- A relative value (including `.`) resolves from the repo root, just like a relative config `root`, so `treehouse get --root .` keeps the pool in-project at `<repo>/.treehouse/` - next to the code and removed with the project.
- Docs for in-project storage in `README.md`, `treehouse.toml.example`, and the `treehouse init` template.

### Why
In-project storage already worked via a relative `root` in `treehouse.toml` (grew out of #11), but it was the only entry point and documented nowhere. A flag + env make it a first-class, discoverable, opt-in mode.

### Risk
- **Blast radius:** override plumbing only. `ResolvePoolRoot` stays pure (its tests are untouched); the new precedence lives in `ResolveRoot`.
- **Backward compat:** fully opt-in. With no flag and no env, resolution is byte-for-byte the previous behavior; the default global `~/.treehouse` store is unchanged (covered by a test).
- **Could break:** a user setting `--root`/`TREEHOUSE_ROOT` gets a different pool location - expected and explicit. Relative values still require a repo context, same as before.

### Tests
`make lint` + `make test` green (Linux/macOS/Windows build). Covers precedence, the default path being unchanged, and end-to-end in-project acquisition via flag / env / config (flag wins over env, no global orphan, removal-with-project).

Refs #11.

---

Companion PR: #92 - moves the in-project ignore from the tracked `.gitignore` to `.git/info/exclude` (fixes #71), so acquiring a pool never dirties the repo. The two are independent and can merge in either order; together they make in-project mode both discoverable and clean.
