### PR TITLE
feat: add no-fetch worktree acquisition

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ treehouse get --lease --lease-holder automation-A --json
 # {"path":"...","lease_id":"...","lease_holder":"automation-A","leased_at":"..."}
 ```
 
+Callers that already fetched the required refs can avoid another network operation with `--no-fetch`:
+
+```sh
+git fetch origin main refs/pull/123/head
+treehouse get --lease --no-fetch --json
+```
+
+With `--no-fetch`, Treehouse resets or creates the worktree from existing local refs and never contacts `origin`. The caller is responsible for ensuring those refs and objects are current.
+
 `treehouse status --json` returns an array with `name`, `path`, `status`, `lease_id`, `lease_holder`, `leased_at`, and `processes`. Non-leased entries use empty lease strings and a `null` timestamp. State files written before lease identities remain readable; their existing leases have an empty `lease_id` until released and acquired again.
 
 Release a lease with `treehouse return <path>`, which clears the lease, terminates any lingering processes, resets the worktree, and returns it to the pool.

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -504,6 +504,29 @@ func TestGetLeasePrintsOnlyPathToStdout(t *testing.T) {
 	}
 }
 
+func TestGetNoFetchUsesLocalRefs(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	missingRemote := filepath.Join(t.TempDir(), "missing.git")
+	gitCmd(t, repoDir, "remote", "set-url", "origin", missingRemote)
+
+	_, stderr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease")
+	if code == 0 || !strings.Contains(stderr, "fetch failed") {
+		t.Fatalf("get with unreachable origin should fail fetching: code=%d stderr=%q", code, stderr)
+	}
+
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease", "--no-fetch", "--json")
+	if code != 0 {
+		t.Fatalf("get --no-fetch should use local refs: code=%d stderr=%q", code, stderr)
+	}
+	var lease leaseJSONResult
+	if err := json.Unmarshal([]byte(stdout), &lease); err != nil {
+		t.Fatalf("get --no-fetch returned invalid JSON %q: %v", stdout, err)
+	}
+	if _, err := os.Stat(filepath.Join(lease.Path, "README.md")); err != nil {
+		t.Fatalf("leased worktree should contain locally available repository content: %v", err)
+	}
+}
+
 func TestGetLeaseRecordsHolder(t *testing.T) {
 	repoDir, homeDir := setupTestRepo(t)
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -22,6 +22,7 @@ var (
 	getLease       bool
 	getLeaseHolder string
 	getJSON        bool
+	getNoFetch     bool
 )
 
 var getCmd = &cobra.Command{
@@ -42,6 +43,7 @@ func init() {
 	getCmd.Flags().BoolVar(&getLease, "lease", false, "Durably lease a worktree without opening a subshell; print only its path to stdout")
 	getCmd.Flags().StringVar(&getLeaseHolder, "lease-holder", "", "Optional label recorded as the lease holder (defaults to $TREEHOUSE_LEASE_HOLDER)")
 	getCmd.Flags().BoolVar(&getJSON, "json", false, "Print lease allocation as JSON (requires --lease)")
+	getCmd.Flags().BoolVar(&getNoFetch, "no-fetch", false, "Skip fetching origin before acquiring; use existing local refs")
 	rootCmd.AddCommand(getCmd)
 }
 
@@ -73,7 +75,9 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		return getLeaseRunE(repoRoot, poolDir, cfg)
 	}
 
-	wtPath, err := pool.Acquire(repoRoot, poolDir, cfg.MaxTrees, cfg.Hooks.PostCreate)
+	wtPath, err := pool.AcquireWithOptions(repoRoot, poolDir, cfg.MaxTrees, cfg.Hooks.PostCreate, pool.AcquireOptions{
+		SkipFetch: getNoFetch,
+	})
 	if err != nil {
 		return err
 	}
@@ -121,7 +125,9 @@ func getLeaseRunE(repoRoot, poolDir string, cfg config.Config) error {
 		holder = os.Getenv("TREEHOUSE_LEASE_HOLDER")
 	}
 
-	lease, err := pool.AcquireLeaseInfo(repoRoot, poolDir, cfg.MaxTrees, cfg.Hooks.PostCreate, holder)
+	lease, err := pool.AcquireLeaseInfoWithOptions(repoRoot, poolDir, cfg.MaxTrees, cfg.Hooks.PostCreate, holder, pool.AcquireOptions{
+		SkipFetch: getNoFetch,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -44,8 +44,17 @@ type LeaseInfo struct {
 	LeasedAt    time.Time `json:"leased_at"`
 }
 
+// AcquireOptions controls optional acquisition behavior.
+type AcquireOptions struct {
+	// SkipFetch uses the repository's existing local refs instead of fetching
+	// origin before acquiring a worktree.
+	SkipFetch bool
+}
+
 // acquireOptions controls how Acquire reserves the worktree it hands out.
 type acquireOptions struct {
+	// skipFetch uses existing local refs without contacting origin.
+	skipFetch bool
 	// lease records a durable, process-independent reservation instead of the
 	// default short-lived owner reservation.
 	lease bool
@@ -61,7 +70,13 @@ type acquireOptions struct {
 // reservation (the calling process). It is the backing call for the interactive
 // `treehouse get` subshell.
 func Acquire(repoRoot, poolDir string, poolSize int, postCreate []string) (string, error) {
+	return AcquireWithOptions(repoRoot, poolDir, poolSize, postCreate, AcquireOptions{})
+}
+
+// AcquireWithOptions reserves a clean worktree with optional acquisition behavior.
+func AcquireWithOptions(repoRoot, poolDir string, poolSize int, postCreate []string, options AcquireOptions) (string, error) {
 	acquired, err := acquire(repoRoot, poolDir, poolSize, postCreate, acquireOptions{
+		skipFetch:  options.SkipFetch,
 		hookStdout: os.Stdout,
 		hookStderr: os.Stderr,
 	})
@@ -81,7 +96,13 @@ func AcquireLease(repoRoot, poolDir string, poolSize int, postCreate []string, h
 // AcquireLeaseInfo reserves a worktree exactly like AcquireLease and returns
 // the immutable identity and metadata for that acquisition.
 func AcquireLeaseInfo(repoRoot, poolDir string, poolSize int, postCreate []string, holder string) (LeaseInfo, error) {
+	return AcquireLeaseInfoWithOptions(repoRoot, poolDir, poolSize, postCreate, holder, AcquireOptions{})
+}
+
+// AcquireLeaseInfoWithOptions reserves a durable lease with optional acquisition behavior.
+func AcquireLeaseInfoWithOptions(repoRoot, poolDir string, poolSize int, postCreate []string, holder string, options AcquireOptions) (LeaseInfo, error) {
 	return acquire(repoRoot, poolDir, poolSize, postCreate, acquireOptions{
+		skipFetch:   options.SkipFetch,
 		lease:       true,
 		leaseHolder: holder,
 		hookStdout:  os.Stderr,
@@ -96,7 +117,7 @@ func acquire(repoRoot, poolDir string, poolSize int, postCreate []string, opts a
 	}
 
 	fmt.Fprintf(os.Stderr, "🌳 Setting up worktree...\n")
-	if git.HasRemote(repoRoot, "origin") {
+	if !opts.skipFetch && git.HasRemote(repoRoot, "origin") {
 		if err := git.Fetch(repoRoot); err != nil {
 			return LeaseInfo{}, fmt.Errorf("fetch failed: %w", err)
 		}


### PR DESCRIPTION
## Summary

- add `treehouse get --no-fetch` for callers that already refreshed local refs
- preserve the existing fetch-before-acquire behavior by default
- support both interactive and durable lease acquisition
- document the supervisor-managed fetch workflow

## Motivation

Automation may acquire several worktrees from one backing repository after performing a single coordinated fetch. Fetching again for every acquisition adds redundant network work and allows concurrent acquisitions to contend on shared refs. `--no-fetch` lets the caller own freshness while Treehouse continues to own pool allocation, reset, and leases.

## Testing

- `make lint`
- `make test`
- end-to-end test verifies the default path fails against an unreachable origin while `get --lease --no-fetch --json` succeeds from local refs
- local prototype acquired two distinct leases with origin intentionally unreachable, checked out two exact detached SHAs, returned both with lease fencing, reused a returned path, reset it to main, and retained an ignored warm-cache sentinel