### PR TITLE
ci: require PRs to main to come through no-mistakes

### DIFF
--- a/.github/scripts/no-mistakes-gate.sh
+++ b/.github/scripts/no-mistakes-gate.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Decides whether a pull request satisfies the "PR must be raised via no-mistakes"
+# required check.
+#
+# A PR passes when any of these hold:
+#   * its body carries the no-mistakes pipeline signature, or
+#   * it was opened by github-actions[bot] or dependabot[bot], or
+#   * it is structurally a release-please release PR (see below).
+#
+# The release-please exemption is deliberately STRUCTURAL, never author identity.
+# Today release-please opens treehouse's release PRs as github-actions[bot], so
+# the bot exemption already covers them, but the structural test keeps them
+# covered if release-please is ever switched to a PAT and starts arriving as the
+# human `kunchenguid`, who also opens ordinary human PRs. Exempting that login
+# would exempt every human PR too.
+#
+# Every exemption lives here rather than in a job-level `if:` so the whole gate
+# has one executable surface that tests can drive directly.
+#
+# Inputs (environment):
+#   PR_BODY, PR_AUTHOR, PR_NUMBER, PR_HEAD_REF, PR_HEAD_REPO, PR_BASE_REPO
+# Exit status: 0 = pass, 1 = fail.
+set -eu
+
+NO_MISTAKES_MARKER='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+RELEASE_PLEASE_MARKER='This PR was generated with [Release Please]'
+RELEASE_PLEASE_BRANCH_PREFIX='release-please--'
+RELEASE_PLEASE_LEGACY_BRANCH_PREFIX='release-please/'
+
+pr_body="${PR_BODY:-}"
+pr_author="${PR_AUTHOR:-unknown}"
+pr_number="${PR_NUMBER:-unknown}"
+pr_head_ref="${PR_HEAD_REF:-}"
+pr_head_repo="${PR_HEAD_REPO:-}"
+pr_base_repo="${PR_BASE_REPO:-}"
+
+body_contains() {
+    printf '%s' "$pr_body" | grep -qF -- "$1"
+}
+
+is_exempt_bot() {
+    case "$pr_author" in
+        'github-actions[bot]' | 'dependabot[bot]') return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Condition 1: a branch under release-please's reserved branch prefix. The
+# legacy `release-please/` prefix is accepted for older release-please setups.
+is_release_please_branch() {
+    case "$pr_head_ref" in
+        "$RELEASE_PLEASE_BRANCH_PREFIX"* | "$RELEASE_PLEASE_LEGACY_BRANCH_PREFIX"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Condition 2: same-repo head. A fork can copy the branch name and the body but
+# cannot make its head repository be this repository.
+is_same_repo_head() {
+    [ -n "$pr_head_repo" ] && [ -n "$pr_base_repo" ] && [ "$pr_head_repo" = "$pr_base_repo" ]
+}
+
+# Condition 3: release-please's generated body footer.
+has_release_please_footer() {
+    body_contains "$RELEASE_PLEASE_MARKER"
+}
+
+if body_contains "$NO_MISTAKES_MARKER"; then
+    echo "Found no-mistakes signature in PR #${pr_number} body."
+    exit 0
+fi
+
+if is_exempt_bot; then
+    echo "PR #${pr_number} was opened by ${pr_author}; exempt from the no-mistakes signature."
+    exit 0
+fi
+
+if is_release_please_branch && is_same_repo_head && has_release_please_footer; then
+    echo "PR #${pr_number} is a release-please release PR (same-repo branch '${pr_head_ref}' with the Release Please footer); exempt from the no-mistakes signature."
+    exit 0
+fi
+
+{
+    echo "::error::This PR was not raised through no-mistakes."
+    echo
+    echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+    echo "That pipeline runs the required review/test/lint/CI steps and writes a"
+    echo "deterministic '## Pipeline' section into the PR body containing:"
+    echo
+    echo "    $NO_MISTAKES_MARKER"
+    echo
+    echo "The only other way to pass is release-please's own release PR, which must"
+    echo "satisfy all three structural conditions: a '${RELEASE_PLEASE_BRANCH_PREFIX}'"
+    echo "(or legacy '${RELEASE_PLEASE_LEGACY_BRANCH_PREFIX}') head branch, a"
+    echo "same-repository (non-fork) head, and the Release Please body footer."
+    echo
+    echo "PR author: ${pr_author}"
+    echo "Head branch: ${pr_head_ref:-unknown}"
+    echo "Head repository: ${pr_head_repo:-unknown} (base ${pr_base_repo:-unknown})"
+} >&2
+exit 1

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,0 +1,48 @@
+name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
+
+# No paths / paths-ignore filter here, deliberately. This workflow backs a
+# required status check, and a path-filtered required check never reports at
+# all, leaving the PR blocked on a status that can never arrive.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
+concurrency:
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: PR must be raised via no-mistakes
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the BASE branch, never the PR head: the gate script must come
+      # from trusted, already-merged code so a pull request cannot weaken the
+      # check that judges it.
+      - name: Check out the gate script from the base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Verify no-mistakes signature in PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        run: bash ./.github/scripts/no-mistakes-gate.sh

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -45,4 +45,13 @@ jobs:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-        run: bash ./.github/scripts/no-mistakes-gate.sh
+        run: |
+          set -eu
+          script=./.github/scripts/no-mistakes-gate.sh
+          if [ ! -f "$script" ]; then
+            # The script is read from the base branch on purpose, so a PR based
+            # on a main that predates it must say so rather than exit 127.
+            echo "::error::The no-mistakes gate script is missing from the base branch. Rebase onto a main that contains ${script}." >&2
+            exit 1
+          fi
+          bash "$script"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,68 @@ jobs:
           name: archive-${{ matrix.goos }}-${{ matrix.goarch }}
           path: treehouse-v${{ needs.release-please.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.*
 
+  # release-please opens its release PR with GITHUB_TOKEN, and GitHub creates no
+  # workflow runs for such PRs (verified: release PR head commits carry zero
+  # check runs). The "PR must be raised via no-mistakes" required check can
+  # therefore never report on a release PR by itself, which would leave every
+  # release blocked on a status that can never arrive.
+  #
+  # Publish that status here instead, reusing the very same gate script the
+  # required check runs, so the exemption decision has exactly one
+  # implementation. The status is only ever written for a PR the script itself
+  # accepts as structurally release-please's own.
+  release-pr-gate-status:
+    needs: release-please
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish the no-mistakes gate status on the release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          pr_numbers=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+            --jq '.[] | select(.head.ref | startswith("release-please--") or startswith("release-please/")) | .number')
+
+          if [ -z "$pr_numbers" ]; then
+            echo "No open release-please PR; nothing to stamp."
+            exit 0
+          fi
+
+          for pr in $pr_numbers; do
+            eval "$(gh api "repos/${REPO}/pulls/${pr}" --jq '
+              "PR_NUMBER=" + (.number|tostring|@sh) +
+              " PR_AUTHOR=" + (.user.login|@sh) +
+              " PR_HEAD_REF=" + (.head.ref|@sh) +
+              " PR_HEAD_REPO=" + (.head.repo.full_name|@sh) +
+              " PR_BASE_REPO=" + (.base.repo.full_name|@sh) +
+              " PR_HEAD_SHA=" + (.head.sha|@sh) +
+              " PR_BODY=" + ((.body // "")|@sh)')"
+            export PR_NUMBER PR_AUTHOR PR_HEAD_REF PR_HEAD_REPO PR_BASE_REPO PR_BODY
+
+            # Overriding PR_AUTHOR defeats the script's bot exemption on
+            # purpose, so a status is stamped only when the STRUCTURAL
+            # release-please conditions hold, never because a bot opened the PR.
+            if PR_AUTHOR="structural-release-please-check" ./.github/scripts/no-mistakes-gate.sh; then
+              echo "Stamping the gate status on PR #${PR_NUMBER} (${PR_HEAD_SHA})."
+              gh api --method POST "repos/${REPO}/statuses/${PR_HEAD_SHA}" \
+                -f state=success \
+                -f context='PR must be raised via no-mistakes' \
+                -f description='release-please release PR: structurally exempt' \
+                -f target_url="${RUN_URL}" >/dev/null
+            else
+              echo "PR #${PR_NUMBER} is not a structural release-please PR; leaving it to the required check."
+            fi
+          done
+
   notify-issues:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,13 @@ make test
 - Git operations shell out to `git` (go-git has incomplete worktree support)
 - Self-healing: stale state entries are auto-removed
 
+## Contribution Gate
+
+- PRs to `main` must carry the no-mistakes pipeline signature. The required check is `PR must be raised via no-mistakes` (`.github/workflows/no-mistakes-required.yml`), enforced by the repository `main` ruleset; only the owner/Admin role can bypass it.
+- Every exemption (bots, and release-please identified structurally by branch prefix + same-repo head + Release Please body footer) lives in `.github/scripts/no-mistakes-gate.sh`, the single executable decision surface, covered by `TestNoMistakesGateDecisions`.
+- release-please opens its PRs with `GITHUB_TOKEN`, so GitHub creates **no** workflow runs on them and the gate can never report there. `release.yml`'s `release-pr-gate-status` job publishes the required context on the release PR head by running that same gate script, so release PRs go green without an owner override.
+- A workflow backing a required check must never use `paths`/`paths-ignore`: a filtered required check never reports and blocks the PR forever. `TestPullRequestWorkflowsExcludeReleasePleaseOutputs` encodes both that rule and the opposite rule for ordinary PR workflows.
+
 ## Windows Compatibility
 
 This project targets Linux, macOS, and Windows. All new code **must** work on Windows. Follow these rules:

--- a/no_mistakes_gate_test.go
+++ b/no_mistakes_gate_test.go
@@ -1,0 +1,303 @@
+package main_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// requiredCheckContext is the status check context this repository's main
+// ruleset requires. The workflow job name must match it exactly, or the
+// ruleset waits forever on a check nothing ever reports.
+const requiredCheckContext = "PR must be raised via no-mistakes"
+
+const gateWorkflowPath = ".github/workflows/no-mistakes-required.yml"
+
+// gateStep is the one workflow step that decides the required check.
+type gateStep struct {
+	env map[string]string
+	run string
+}
+
+type workflowFile struct {
+	Jobs map[string]struct {
+		Name  string `yaml:"name"`
+		If    string `yaml:"if"`
+		Steps []struct {
+			Name string            `yaml:"name"`
+			Run  string            `yaml:"run"`
+			Env  map[string]string `yaml:"env"`
+		} `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+// loadGateStep reads the real workflow and returns the step that runs the gate,
+// so the test drives the shipped configuration rather than a copy of it.
+func loadGateStep(t *testing.T) gateStep {
+	t.Helper()
+
+	data, err := os.ReadFile(gateWorkflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", gateWorkflowPath, err)
+	}
+	var wf workflowFile
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse %s: %v", gateWorkflowPath, err)
+	}
+
+	for jobID, job := range wf.Jobs {
+		if job.Name != requiredCheckContext {
+			continue
+		}
+		// Every exemption must live in the script, not in a job-level `if:`,
+		// so the gate has a single executable decision surface.
+		if strings.TrimSpace(job.If) != "" {
+			t.Fatalf("job %q must not carry a job-level if:, it decides exemptions in the gate script", jobID)
+		}
+		for _, step := range job.Steps {
+			if strings.TrimSpace(step.Run) == "" {
+				continue
+			}
+			return gateStep{env: step.Env, run: step.Run}
+		}
+		t.Fatalf("job %q has no run: step", jobID)
+	}
+
+	t.Fatalf("%s has no job named %q", gateWorkflowPath, requiredCheckContext)
+	return gateStep{}
+}
+
+var expressionPattern = regexp.MustCompile(`\$\{\{\s*([^}]+?)\s*\}\}`)
+
+// pullRequestEvent is the subset of a GitHub `pull_request` event payload the
+// gate step reads through its env: block.
+type pullRequestEvent struct {
+	number   int
+	body     string
+	author   string
+	headRef  string
+	headRepo string
+	baseRepo string
+}
+
+func (e pullRequestEvent) lookup(path string) (string, bool) {
+	switch path {
+	case "github.event.pull_request.number":
+		return fmt.Sprint(e.number), true
+	case "github.event.pull_request.body":
+		return e.body, true
+	case "github.event.pull_request.user.login":
+		return e.author, true
+	case "github.event.pull_request.head.ref":
+		return e.headRef, true
+	case "github.event.pull_request.head.repo.full_name":
+		return e.headRepo, true
+	case "github.event.pull_request.base.repo.full_name":
+		return e.baseRepo, true
+	default:
+		return "", false
+	}
+}
+
+// resolveEnv expands the step's `${{ ... }}` expressions against the event, the
+// same substitution the Actions runner performs before running the step.
+func resolveEnv(t *testing.T, step gateStep, event pullRequestEvent) []string {
+	t.Helper()
+
+	if len(step.env) == 0 {
+		t.Fatal("gate step declares no env:, so it can never see the pull request")
+	}
+
+	out := make([]string, 0, len(step.env))
+	for name, raw := range step.env {
+		value := expressionPattern.ReplaceAllStringFunc(raw, func(match string) string {
+			path := expressionPattern.FindStringSubmatch(match)[1]
+			resolved, ok := event.lookup(path)
+			if !ok {
+				t.Fatalf("env %s references unsupported expression %q", name, path)
+			}
+			return resolved
+		})
+		out = append(out, name+"="+value)
+	}
+	return out
+}
+
+// runGate executes the workflow step's shell exactly as the runner would, from
+// the repository root, and reports whether the required check would pass.
+func runGate(t *testing.T, step gateStep, event pullRequestEvent) (bool, string) {
+	t.Helper()
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available; the gate step runs on ubuntu-latest")
+	}
+
+	root, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	cmd := exec.Command(bash, "-e", "-c", step.run)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), resolveEnv(t, step, event)...)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, string(output)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return false, string(output)
+	}
+	t.Fatalf("run gate step: %v (%s)", err, output)
+	return false, ""
+}
+
+const (
+	noMistakesBody = "## Pipeline\n\nUpdates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)\n"
+	releaseBody    = ":robot: I have created a release *beep* *boop*\n---\n\n## [2.1.1](https://example.invalid)\n\n---\n" +
+		"This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please)."
+	repo     = "kunchenguid/treehouse"
+	forkRepo = "someone-else/treehouse"
+)
+
+func TestNoMistakesGateDecisions(t *testing.T) {
+	step := loadGateStep(t)
+
+	cases := []struct {
+		name  string
+		event pullRequestEvent
+		pass  bool
+	}{
+		{
+			// The live shape of treehouse's own release PRs (see PR #78).
+			name: "release-please release PR is exempt",
+			event: pullRequestEvent{
+				number: 78, body: releaseBody, author: "github-actions[bot]",
+				headRef: "release-please--branches--main", headRepo: repo, baseRepo: repo,
+			},
+			pass: true,
+		},
+		{
+			// Structural, not identity: the same PR under a PAT identity, which
+			// is what release-please would become if it ever used one.
+			name: "release-please release PR authored by a human identity is exempt",
+			event: pullRequestEvent{
+				number: 79, body: releaseBody, author: "kunchenguid",
+				headRef: "release-please--branches--main", headRepo: repo, baseRepo: repo,
+			},
+			pass: true,
+		},
+		{
+			name: "legacy release-please branch prefix is exempt",
+			event: pullRequestEvent{
+				number: 80, body: releaseBody, author: "kunchenguid",
+				headRef: "release-please/branches/main", headRepo: repo, baseRepo: repo,
+			},
+			pass: true,
+		},
+		{
+			name: "github-actions bot is exempt",
+			event: pullRequestEvent{
+				number: 81, body: "chore: routine bot update", author: "github-actions[bot]",
+				headRef: "chore/bot", headRepo: repo, baseRepo: repo,
+			},
+			pass: true,
+		},
+		{
+			name: "dependabot is exempt",
+			event: pullRequestEvent{
+				number: 82, body: "Bumps a dependency.", author: "dependabot[bot]",
+				headRef: "dependabot/go_modules/example-1.2.3", headRepo: repo, baseRepo: repo,
+			},
+			pass: true,
+		},
+		{
+			name: "human PR carrying the no-mistakes signature passes",
+			event: pullRequestEvent{
+				number: 83, body: noMistakesBody, author: "kunchenguid",
+				headRef: "fm/some-work", headRepo: repo, baseRepo: repo,
+			},
+			pass: true,
+		},
+		{
+			name: "human PR without the signature fails",
+			event: pullRequestEvent{
+				number: 84, body: "## Summary\n\nA hand-written pull request.", author: "kunchenguid",
+				headRef: "fix/something", headRepo: repo, baseRepo: repo,
+			},
+			pass: false,
+		},
+		{
+			name: "empty body fails",
+			event: pullRequestEvent{
+				number: 85, body: "", author: "kunchenguid",
+				headRef: "fix/something", headRepo: repo, baseRepo: repo,
+			},
+			pass: false,
+		},
+		{
+			name: "borrowed release branch name alone fails",
+			event: pullRequestEvent{
+				number: 86, body: "## Summary\n\nNot a release PR.", author: "kunchenguid",
+				headRef: "release-please--branches--main", headRepo: repo, baseRepo: repo,
+			},
+			pass: false,
+		},
+		{
+			name: "fork copying the release body fails",
+			event: pullRequestEvent{
+				number: 87, body: releaseBody, author: "outside-contributor",
+				headRef: "release-please--branches--main", headRepo: forkRepo, baseRepo: repo,
+			},
+			pass: false,
+		},
+		{
+			name: "release body on an ordinary same-repo branch fails",
+			event: pullRequestEvent{
+				number: 88, body: releaseBody, author: "kunchenguid",
+				headRef: "feat/pretend", headRepo: repo, baseRepo: repo,
+			},
+			pass: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, output := runGate(t, step, tc.event)
+			if got != tc.pass {
+				t.Fatalf("gate pass = %v, want %v\n%s", got, tc.pass, output)
+			}
+		})
+	}
+}
+
+// The required check must always report on a pull request. A path filter would
+// silently withhold the status and block the PR forever.
+func TestGateWorkflowHasNoPathFilter(t *testing.T) {
+	data, err := os.ReadFile(gateWorkflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", gateWorkflowPath, err)
+	}
+	on, err := parseWorkflowOn(data)
+	if err != nil {
+		t.Fatalf("parse on: %v", err)
+	}
+	filter, hasPR, err := pullRequestPathFilter(on)
+	if err != nil {
+		t.Fatalf("read pull_request filter: %v", err)
+	}
+	if !hasPR {
+		t.Fatal("gate workflow must trigger on pull_request")
+	}
+	if filter.kind != "none" {
+		t.Fatalf("gate workflow must not filter by path, got %s filter %v", filter.kind, filter.patterns)
+	}
+}

--- a/release_ci_exclusions_test.go
+++ b/release_ci_exclusions_test.go
@@ -273,6 +273,45 @@ func matchGitHubPath(pattern, path string) bool {
 	return false
 }
 
+// workflowJobNames returns every job `name:` declared by a workflow. A workflow
+// that publishes a required status check is identified by these names, since a
+// required check's context is the job name GitHub reports.
+func workflowJobNames(data []byte) ([]string, error) {
+	var wf struct {
+		Jobs map[string]struct {
+			Name string `yaml:"name"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(wf.Jobs))
+	for _, job := range wf.Jobs {
+		if job.Name != "" {
+			names = append(names, job.Name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// publishesRequiredCheck reports whether a workflow backs a required status
+// check on main. Such a workflow must NOT filter by path: a required check that
+// never runs never reports, and the pull request waits on it forever. Release
+// PRs are handled by the gate's own release-please exemption instead.
+func publishesRequiredCheck(data []byte) (bool, error) {
+	names, err := workflowJobNames(data)
+	if err != nil {
+		return false, err
+	}
+	for _, name := range names {
+		if name == requiredCheckContext {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func TestPullRequestWorkflowsExcludeReleasePleaseOutputs(t *testing.T) {
 	cfgBytes, err := os.ReadFile("release-please-config.json")
 	if err != nil {
@@ -297,7 +336,7 @@ func TestPullRequestWorkflowsExcludeReleasePleaseOutputs(t *testing.T) {
 		t.Fatalf("read .github/workflows: %v", err)
 	}
 
-	var prWorkflows int
+	var prWorkflows, requiredCheckWorkflows int
 	for _, ent := range entries {
 		if ent.IsDir() {
 			continue
@@ -322,6 +361,18 @@ func TestPullRequestWorkflowsExcludeReleasePleaseOutputs(t *testing.T) {
 		if !hasPR {
 			continue
 		}
+		required, err := publishesRequiredCheck(data)
+		if err != nil {
+			t.Fatalf("parse jobs in %s: %v", path, err)
+		}
+		if required {
+			requiredCheckWorkflows++
+			t.Logf("%s backs the %q required check; path filters are forbidden there, not required", path, requiredCheckContext)
+			if filter.kind != "none" {
+				t.Errorf("%s backs a required check and must not filter by path (a filtered required check never reports)", path)
+			}
+			continue
+		}
 		prWorkflows++
 
 		var missing []string
@@ -338,6 +389,12 @@ func TestPullRequestWorkflowsExcludeReleasePleaseOutputs(t *testing.T) {
 
 	if prWorkflows == 0 {
 		t.Fatal("no pull_request-triggered workflows found under .github/workflows")
+	}
+	// Exactly the no-mistakes gate is exempt today. A second exemption means a
+	// new workflow claimed the required-check name, which needs a look.
+	if requiredCheckWorkflows != 1 {
+		t.Fatalf("expected exactly 1 pull_request workflow backing the %q required check, found %d",
+			requiredCheckContext, requiredCheckWorkflows)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the `PR must be raised via no-mistakes` required check to treehouse, matching firstmate and SSHHIP, with a release-please exemption so release PRs are never blocked.

This is a bootstrapping change: the check cannot gate the PR that adds it, so this PR is raised directly rather than through the no-mistakes pipeline.

## What changed

- `.github/workflows/no-mistakes-required.yml` - job named exactly `PR must be raised via no-mistakes`, on `pull_request` to `main`. The gate script is checked out from the **base** SHA, so a PR cannot weaken the check that judges it.
- `.github/scripts/no-mistakes-gate.sh` - the single executable decision surface. A PR passes when it carries the marker `Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)` (confirmed against this repo's own pipeline PRs, e.g. #68), or is opened by `github-actions[bot]`/`dependabot[bot]`, or is **structurally** release-please's own PR: reserved head branch prefix (`release-please--`, plus the legacy `release-please/`) **and** same-repo (non-fork) head **and** the `This PR was generated with [Release Please]` body footer. Never author identity, so a future PAT switch stays covered and a human PR or fork spoofing the release body still fails.
- `no_mistakes_gate_test.go` - behavioral test that parses the real workflow, resolves its `env:` `${{ github.event.pull_request.* }}` expressions against synthesized GitHub payloads, and executes the actual step shell. Covers: release-please PR exempt (bot- and human-authored), legacy branch prefix exempt, both bots exempt, human PR with signature passes, human PR without signature fails, empty body fails, borrowed release branch name alone fails, fork copying the release body fails, release body on an ordinary branch fails.

## Release PRs would otherwise be blocked

release-please opens treehouse's release PRs with `GITHUB_TOKEN`, and GitHub creates **no** workflow runs for those PRs. Verified empirically: the head commits of release PRs #78, #69, #56 and #38 carry **zero** check runs, both before and after the #77 path exclusions. A required check therefore could never report on a release PR, and every release would sit blocked on a status that can never arrive - owner-override only.

So `release.yml` gains a `release-pr-gate-status` job that publishes the required context on the open release PR's head SHA. It runs the *same* gate script with `PR_AUTHOR` deliberately overridden, which defeats the bot exemption, so a status is stamped only when the structural release-please conditions hold. Verified locally against the real payloads of #78 (stamped) and #94 (skipped, fork).

Also: the gate workflow deliberately has **no** path filter, because a path-filtered required check never reports and blocks the PR forever. `TestPullRequestWorkflowsExcludeReleasePleaseOutputs` now encodes both rules - required-check workflows must not filter by path, every other `pull_request` workflow must still exclude the release-please output set - and fails if a second workflow ever claims the required-check name.

## Sequencing

The workflow lands on `main` first; the required-status-check ruleset (`PR must be raised via no-mistakes`, Admin bypass) is added right after, so no PR is ever left waiting on a check that cannot run.

## Testing

- `go test ./...` - all green
- `go vet ./...`, `gofmt -l .` - clean
- gate script exercised against the real GitHub payloads of PR #78 (release, exempt) and PR #94 (fork, not exempt)
