### PR TITLE
fix(cmd): resolve main repo root for pool commands run inside a worktree

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -2016,3 +2016,90 @@ func TestEnterPrintPathPrintsOnlyPathToStdout(t *testing.T) {
 		t.Errorf("printed path is not a valid worktree: %s (%v)", path, err)
 	}
 }
+
+// setupLocalOnlyRepo creates a repo with no remotes. Without a remote, the
+// pool name is hashed from the repo path, so pool resolution is sensitive to
+// which repo root a command resolves.
+func setupLocalOnlyRepo(t *testing.T) (repoDir, homeDir string) {
+	t.Helper()
+
+	base := t.TempDir()
+	base, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	homeDir = filepath.Join(base, "home")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoDir = filepath.Join(base, "myrepo")
+	gitCmd(t, "", "init", "--initial-branch=main", repoDir)
+	gitCmd(t, repoDir, "config", "user.email", "test@test.com")
+	gitCmd(t, repoDir, "config", "user.name", "Test")
+
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repoDir, "add", ".")
+	gitCmd(t, repoDir, "commit", "-m", "initial commit")
+
+	return repoDir, homeDir
+}
+
+func TestCommandsInsideWorktreeUseMainRepoPool(t *testing.T) {
+	repoDir, homeDir := setupLocalOnlyRepo(t)
+
+	leaseOut, leaseErr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease")
+	if code != 0 {
+		t.Fatalf("get --lease failed (code %d): %s", code, leaseErr)
+	}
+	wtPath := strings.TrimSpace(leaseOut)
+	if wtPath == "" {
+		t.Fatal("could not capture leased worktree path")
+	}
+
+	// status inside the worktree must resolve the main repo's pool, not hash
+	// the worktree path into a fresh empty pool.
+	statusOut, statusErr, code := runTreehouseFromDir(t, repoDir, wtPath, homeDir, nil, "status")
+	if code != 0 {
+		t.Fatalf("status inside worktree failed (code %d): %s", code, statusErr)
+	}
+	if strings.Contains(statusErr, "No worktrees in pool") {
+		t.Fatalf("status inside worktree resolved an empty pool, stderr:\n%s", statusErr)
+	}
+	if !strings.Contains(statusOut, "leased") {
+		t.Fatalf("expected leased worktree in status output, got:\n%s", statusOut)
+	}
+
+	// get inside the worktree must acquire from the same pool.
+	env := []string{"SHELL=" + exitShellBin}
+	_, getErr, code := runTreehouseFromDir(t, repoDir, wtPath, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get inside worktree failed (code %d): %s", code, getErr)
+	}
+	secondPath := extractWorktreePath(getErr, homeDir)
+	if secondPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+	poolDir := filepath.Dir(filepath.Dir(wtPath))
+	if filepath.Dir(filepath.Dir(secondPath)) != poolDir {
+		t.Fatalf("expected worktree in pool %s, got %s", poolDir, secondPath)
+	}
+
+	// No ghost pool directory may appear next to the real one.
+	entries, err := os.ReadDir(filepath.Join(homeDir, ".treehouse"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pools []string
+	for _, e := range entries {
+		if e.IsDir() {
+			pools = append(pools, e.Name())
+		}
+	}
+	if len(pools) != 1 {
+		t.Fatalf("expected exactly one pool directory, got %v", pools)
+	}
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -52,7 +52,7 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--json requires --lease")
 	}
 
-	repoRoot, err := git.FindRepoRoot()
+	repoRoot, err := git.FindMainRepoRoot()
 	if err != nil {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,7 +16,7 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Create a default treehouse.toml config file",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		repoRoot, err := git.FindRepoRoot()
+		repoRoot, err := git.FindMainRepoRoot()
 		if err != nil {
 			return fmt.Errorf("not in a git repository: %w", err)
 		}

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -66,7 +66,7 @@ absolute.`,
 			return nil
 		}
 
-		repoRoot, err := git.FindRepoRoot()
+		repoRoot, err := git.FindMainRepoRoot()
 		if err != nil {
 			return fmt.Errorf("not in a git repository: %w", err)
 		}

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -145,7 +145,7 @@ func resolveReturnPoolDir(wtPath string, explicitPath bool) (string, error) {
 	if explicitPath {
 		repoRoot, err = git.FindMainRepoRootFrom(wtPath)
 	} else {
-		repoRoot, err = git.FindRepoRoot()
+		repoRoot, err = git.FindMainRepoRoot()
 	}
 	if err != nil {
 		if explicitPath {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -37,7 +37,7 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show the status of all worktrees in the pool",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		repoRoot, err := git.FindRepoRoot()
+		repoRoot, err := git.FindMainRepoRoot()
 		if err != nil {
 			return fmt.Errorf("not in a git repository: %w", err)
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -12,6 +12,13 @@ func FindRepoRoot() (string, error) {
 	return runGit("", "rev-parse", "--show-toplevel")
 }
 
+// FindMainRepoRoot returns the main repository root for the current working
+// directory. Inside a linked worktree it resolves back to the owning
+// repository, so pool resolution is stable no matter where a command runs.
+func FindMainRepoRoot() (string, error) {
+	return FindMainRepoRootFrom("")
+}
+
 func FindRepoRootFrom(dir string) (string, error) {
 	return runGit(dir, "rev-parse", "--show-toplevel")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is a conflict-resolved rebase of #51 onto current `main`. It does **not** close #51.

Original PR: https://github.com/kunchenguid/treehouse/pull/51 (fork head `thirdreplicator:fix/pool-resolution-inside-worktree`).

## Behavior (unchanged from #51)

`get`, `status`, `prune`, `init`, and `return` (cwd fallback) resolve the owning repository via git-common-dir (`FindMainRepoRoot` / `FindMainRepoRootFrom`) so commands run inside a managed worktree use the same pool as the main repo. This matters most when there is no `origin`, because the pool name is hashed from the repo path.

The e2e regression `TestCommandsInsideWorktreeUseMainRepoPool` covers a remote-less repo: `status` inside the worktree must see the leased worktree, `get` inside the worktree must acquire from the same pool, and no ghost pool directory may appear.

## Conflict resolution only

Cherry-pick of `7fd12a0` onto current `main` conflicted in `cmd/get.go` and `cmd/e2e_test.go`:

- `get.go`: kept main's `--json requires --lease` guard and applied #51's `FindMainRepoRoot()` call.
- `e2e_test.go`: kept main's `enter` tests and appended #51's remote-less pool test.

`FindRepoRoot()` is **retained**. #51 deleted it because it became unused on that branch; current `main` still uses it from `enter` (added after #51). Changing `enter` would expand scope, so it is left as on `main`.

No other behavior changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53b46441-5c9b-44a8-af09-b37a7ad3a83f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53b46441-5c9b-44a8-af09-b37a7ad3a83f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

