### PR TITLE
fix(return): refuse to reset a worktree that still has live writers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ You can instead keep the pool [inside the project](#in-project-storage) with `--
            │
            ▼
   Terminate lingering worktree
-  processes, reset worktree,
-  & return to pool
+  processes and verify none remain
+           │
+           ▼
+  Reset worktree & return to pool
   (ready for next agent)
 ```
 
@@ -153,7 +155,7 @@ You can instead keep the pool [inside the project](#in-project-storage) with `--
 | `treehouse get --lease`    | Durably lease a worktree without a subshell; print its path |
 | `treehouse enter <name>`   | Open a subshell in an existing worktree by name (the number from `status`), even if it is in use; pool state is left untouched |
 | `treehouse status`         | Show pool status (highlights leased and current worktrees) |
-| `treehouse return [path]`  | Release any lease, terminate lingering worktree processes, and return it to the pool |
+| `treehouse return [path]`  | Release any lease and return a worktree only after verifying foreign processes stopped |
 | `treehouse prune`          | Dry-run removal of stale idle worktrees in the current repo pool |
 | `treehouse prune --all`    | Dry-run removal of stale idle worktrees across every managed pool |
 | `treehouse destroy <path>` | Dry-run removal of one worktree (safe by default; `--yes` to execute) |
@@ -221,7 +223,8 @@ With `--no-fetch`, Treehouse resets or creates the worktree from existing local 
 
 `treehouse status --json` returns an array with `name`, `path`, `status`, `lease_id`, `lease_holder`, `leased_at`, and `processes`. Non-leased entries use empty lease strings and a `null` timestamp. State files written before lease identities remain readable; their existing leases have an empty `lease_id` until released and acquired again.
 
-Release a lease with `treehouse return <path>`, which clears the lease, terminates any lingering processes, resets the worktree, and returns it to the pool.
+Release a lease with `treehouse return <path>`, which terminates lingering processes and verifies that no foreign process remains before it resets the worktree, clears the lease, and returns the worktree to the pool.
+If process termination or that verification fails, the command exits nonzero and leaves the worktree and lease in place instead of recycling a slot that may still be in use.
 When you pass an explicit path, `treehouse return` can run from outside the repository because it resolves the managed pool from that worktree path.
 
 For retry-safe automation, condition the return on the identity from allocation or status:

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -25,6 +25,12 @@ var (
 	getNoFetch     bool
 )
 
+// Process seams, overridable in tests, matching the pattern in internal/pool.
+var (
+	terminateWorktreeProcesses     = process.TerminateWorktreeProcesses
+	unprotectedProcessesInWorktree = process.UnprotectedProcessesInWorktree
+)
+
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Acquire a worktree from the pool and open a subshell",
@@ -109,7 +115,10 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	killLingeringProcesses(wtPath)
+	if err := killLingeringProcesses(wtPath); err != nil {
+		fmt.Fprintf(os.Stderr, "🌳 Warning: %v; leaving worktree in place.\n", err)
+		return nil
+	}
 
 	if err := pool.Release(poolDir, wtPath); err != nil {
 		fmt.Fprintf(os.Stderr, "🌳 Warning: failed to clean worktree: %v\n", err)
@@ -147,20 +156,40 @@ func getLeaseRunE(repoRoot, poolDir string, cfg config.Config) error {
 }
 
 // killLingeringProcesses terminates any process whose cwd is within the given
-// worktree. Called before returning a worktree to the pool so detached tools
-// (e.g. opencode servers that ignore SIGHUP) don't keep holding the worktree.
-func killLingeringProcesses(wtPath string) {
-	killed, err := process.TerminateWorktreeProcesses(wtPath, 2*time.Second)
+// worktree, then verifies the worktree is clear before it is handed back to the
+// pool. Detached tools (e.g. opencode servers that ignore SIGHUP) are the usual
+// reason a worktree is not quiet on return.
+//
+// It returns an error when termination cannot be proven complete: a process
+// could not be signalled (e.g. an ancestry-lookup failure), or a live writer
+// remains after termination. The point-in-time selection inside
+// TerminateWorktreeProcesses signals only what a single scan saw, so a process
+// that started during the grace period is never targeted; the re-scan below
+// catches it. Failing here makes the caller leave the slot in place rather than
+// reset a worktree another process is still writing into.
+func killLingeringProcesses(wtPath string) error {
+	killed, err := terminateWorktreeProcesses(wtPath, 2*time.Second)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "🌳 Warning: failed to scan for lingering processes: %v\n", err)
-		return
+		return fmt.Errorf("could not terminate worktree processes: %w", err)
 	}
-	if len(killed) == 0 {
-		return
+	if len(killed) > 0 {
+		names := make([]string, len(killed))
+		for i, p := range killed {
+			names[i] = p.String()
+		}
+		fmt.Fprintf(os.Stderr, "🌳 Terminated lingering processes: %s\n", strings.Join(names, ", "))
 	}
-	names := make([]string, len(killed))
-	for i, p := range killed {
-		names[i] = p.String()
+
+	survivors, err := unprotectedProcessesInWorktree(wtPath)
+	if err != nil {
+		return fmt.Errorf("could not verify worktree processes stopped: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "🌳 Terminated lingering processes: %s\n", strings.Join(names, ", "))
+	if len(survivors) > 0 {
+		names := make([]string, len(survivors))
+		for i, p := range survivors {
+			names[i] = p.String()
+		}
+		return fmt.Errorf("worktree still has live processes after termination: %s", strings.Join(names, ", "))
+	}
+	return nil
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -115,18 +115,24 @@ func getRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := killLingeringProcesses(wtPath); err != nil {
+	if err := returnWorktreeToPool(poolDir, wtPath); err != nil {
 		fmt.Fprintf(os.Stderr, "🌳 Warning: %v; leaving worktree in place.\n", err)
-		return nil
+		return err
 	}
-
-	if err := pool.Release(poolDir, wtPath); err != nil {
-		fmt.Fprintf(os.Stderr, "🌳 Warning: failed to clean worktree: %v\n", err)
-	} else {
-		fmt.Fprintln(os.Stderr, "🌳 Worktree returned to pool.")
-	}
+	fmt.Fprintln(os.Stderr, "🌳 Worktree returned to pool.")
 
 	return nil
+}
+
+// returnWorktreeToPool terminates any lingering writers and resets the worktree
+// back into the pool as a single locked transaction: killLingeringProcesses runs
+// as the release's beforeReset step, under the same state lock and immediately
+// before the reset, so a writer that re-enters the worktree cannot slip between
+// the emptiness check and the destructive reset.
+func returnWorktreeToPool(poolDir, wtPath string) error {
+	return pool.ReleaseConditional(poolDir, wtPath, pool.ReleasePreconditions{}, func() error {
+		return killLingeringProcesses(wtPath)
+	})
 }
 
 // getLeaseRunE performs a non-interactive, durable acquire. It writes either the

--- a/cmd/return_atomic_test.go
+++ b/cmd/return_atomic_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/treehouse/internal/pool"
+	"github.com/kunchenguid/treehouse/internal/process"
+)
+
+// setupAtomicFixture builds a real local repo and pool, acquires one worktree,
+// and returns the pool directory and the acquired worktree path.
+func setupAtomicFixture(t *testing.T) (poolDir, wtPath string) {
+	t.Helper()
+	base := t.TempDir()
+	base, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoDir := filepath.Join(base, "myrepo")
+	poolDir = filepath.Join(base, "pool")
+
+	git := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	git("", "init", "--initial-branch=main", repoDir)
+	git(repoDir, "config", "user.email", "test@test.com")
+	git(repoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(repoDir, "add", ".")
+	git(repoDir, "commit", "-m", "initial")
+
+	wtPath, err = pool.AcquireWithOptions(repoDir, poolDir, 4, nil, pool.AcquireOptions{SkipFetch: true})
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	return poolDir, wtPath
+}
+
+// A writer that is still live when the worktree is about to be reset must not
+// have the slot reset from under it. The emptiness check runs as the release's
+// beforeReset step - under the same state lock and immediately before the reset -
+// so a surviving writer fails the whole return without the reset ever running.
+func TestReturnWorktreeToPool_SurvivingWriterBlocksReset(t *testing.T) {
+	poolDir, wtPath := setupAtomicFixture(t)
+
+	// An untracked file that only the reset (git clean -fd) would remove.
+	marker := filepath.Join(wtPath, "writer-scratch.txt")
+	if err := os.WriteFile(marker, []byte("in use\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := swapProcessSeams(
+		func(string, time.Duration) ([]process.ProcessInfo, error) { return nil, nil },
+		func(string) ([]process.ProcessInfo, error) {
+			return []process.ProcessInfo{{PID: 4321, Name: "agent"}}, nil
+		},
+	)
+	t.Cleanup(restore)
+
+	err := returnWorktreeToPool(poolDir, wtPath)
+	if err == nil {
+		t.Fatal("expected returnWorktreeToPool to fail when a live writer remains")
+	}
+	if !strings.Contains(err.Error(), "still has live processes") {
+		t.Fatalf("expected a live-writer refusal, got: %v", err)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatalf("worktree was reset despite a surviving writer: %v", statErr)
+	}
+}
+
+// The happy path: a quiet worktree is reset and returned, proving the same
+// locked transaction still resets once the emptiness check passes.
+func TestReturnWorktreeToPool_QuietWorktreeResetsAndReturns(t *testing.T) {
+	poolDir, wtPath := setupAtomicFixture(t)
+
+	marker := filepath.Join(wtPath, "writer-scratch.txt")
+	if err := os.WriteFile(marker, []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := swapProcessSeams(
+		func(string, time.Duration) ([]process.ProcessInfo, error) { return nil, nil },
+		func(string) ([]process.ProcessInfo, error) { return nil, nil },
+	)
+	t.Cleanup(restore)
+
+	if err := returnWorktreeToPool(poolDir, wtPath); err != nil {
+		t.Fatalf("expected a quiet worktree to return cleanly, got: %v", err)
+	}
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("expected the reset to remove untracked files, stat err: %v", statErr)
+	}
+}

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -117,8 +117,7 @@ func finalizeWorktreeReturn(wtPath string) error {
 		}
 	}
 
-	killLingeringProcesses(wtPath)
-	return nil
+	return killLingeringProcesses(wtPath)
 }
 
 func resolveWorktreePath(args []string) (string, error) {

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -65,9 +65,11 @@ var returnCmd = &cobra.Command{
 				})
 			}
 		} else {
-			err = prepareWorktreeReturn(wtPath)
+			err = confirmWorktreeReturn(wtPath)
 			if err == nil {
-				err = pool.Release(poolDir, wtPath)
+				err = pool.ReleaseConditional(poolDir, wtPath, pool.ReleasePreconditions{}, func() error {
+					return finalizeWorktreeReturn(wtPath)
+				})
 			}
 		}
 		if errors.Is(err, errReturnAborted) {
@@ -88,13 +90,6 @@ func init() {
 	returnCmd.Flags().StringVar(&returnIfLeaseID, "if-lease-id", "", "Return only if the current lease has this identity")
 	returnCmd.Flags().StringVar(&returnIfLeaseHolder, "if-lease-holder", "", "Return only if the current lease has this holder")
 	rootCmd.AddCommand(returnCmd)
-}
-
-func prepareWorktreeReturn(wtPath string) error {
-	if err := confirmWorktreeReturn(wtPath); err != nil {
-		return err
-	}
-	return finalizeWorktreeReturn(wtPath)
 }
 
 func confirmWorktreeReturn(wtPath string) error {

--- a/cmd/return_safety_test.go
+++ b/cmd/return_safety_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/treehouse/internal/process"
+)
+
+// A worktree that still has a foreign live writer after termination must not be
+// handed back to the pool. The point-in-time termination scan misses a process
+// that started during the grace period, so killLingeringProcesses re-scans and
+// refuses rather than resetting a slot another agent is writing into.
+func TestKillLingeringProcesses_RefusesSurvivingLiveWriter(t *testing.T) {
+	restore := swapProcessSeams(
+		func(string, time.Duration) ([]process.ProcessInfo, error) { return nil, nil },
+		func(string) ([]process.ProcessInfo, error) {
+			return []process.ProcessInfo{{PID: 4321, Name: "agent"}}, nil
+		},
+	)
+	t.Cleanup(restore)
+
+	err := killLingeringProcesses("/pool/1/repo")
+	if err == nil {
+		t.Fatal("expected return to refuse a worktree that still has a live writer")
+	}
+	if !strings.Contains(err.Error(), "still has live processes") {
+		t.Fatalf("expected live-writer refusal, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "agent (4321)") {
+		t.Fatalf("expected the surviving writer named in the refusal, got: %v", err)
+	}
+}
+
+// A termination failure (e.g. an ancestry-lookup error that would otherwise
+// silently protect every process) must surface, and the re-scan must not run:
+// the worktree cannot be proven quiet.
+func TestKillLingeringProcesses_SurfacesTerminationFailure(t *testing.T) {
+	restore := swapProcessSeams(
+		func(string, time.Duration) ([]process.ProcessInfo, error) {
+			return nil, errors.New("cannot resolve ancestry of process 200")
+		},
+		func(string) ([]process.ProcessInfo, error) {
+			t.Fatal("re-scan must not run when termination fails")
+			return nil, nil
+		},
+	)
+	t.Cleanup(restore)
+
+	err := killLingeringProcesses("/pool/1/repo")
+	if err == nil {
+		t.Fatal("expected a termination failure to be surfaced")
+	}
+	if !strings.Contains(err.Error(), "could not terminate worktree processes") {
+		t.Fatalf("expected termination-failure wrapping, got: %v", err)
+	}
+}
+
+// The happy path: nothing to terminate and nothing left behind returns cleanly.
+func TestKillLingeringProcesses_QuietWorktreeSucceeds(t *testing.T) {
+	restore := swapProcessSeams(
+		func(string, time.Duration) ([]process.ProcessInfo, error) { return nil, nil },
+		func(string) ([]process.ProcessInfo, error) { return nil, nil },
+	)
+	t.Cleanup(restore)
+
+	if err := killLingeringProcesses("/pool/1/repo"); err != nil {
+		t.Fatalf("expected a quiet worktree to return cleanly, got: %v", err)
+	}
+}
+
+func swapProcessSeams(
+	terminate func(string, time.Duration) ([]process.ProcessInfo, error),
+	rescan func(string) ([]process.ProcessInfo, error),
+) func() {
+	origTerminate, origRescan := terminateWorktreeProcesses, unprotectedProcessesInWorktree
+	terminateWorktreeProcesses = terminate
+	unprotectedProcessesInWorktree = rescan
+	return func() {
+		terminateWorktreeProcesses = origTerminate
+		unprotectedProcessesInWorktree = origRescan
+	}
+}

--- a/internal/process/detect.go
+++ b/internal/process/detect.go
@@ -60,28 +60,41 @@ func FindProcessesInWorktree(worktreePath string) ([]ProcessInfo, error) {
 		if err != nil {
 			continue
 		}
-
-		absCwd, err := filepath.Abs(cwd)
-		if err != nil {
+		if !cwdWithinWorktree(absWorktree, cwd) {
 			continue
 		}
-		absCwd = resolvePath(absCwd)
-
-		rel, err := filepath.Rel(absWorktree, absCwd)
-		if err != nil {
-			continue
-		}
-
-		if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
-			name, _ := p.Name()
-			result = append(result, ProcessInfo{
-				PID:  p.Pid,
-				Name: name,
-			})
-		}
+		name, _ := p.Name()
+		result = append(result, ProcessInfo{
+			PID:  p.Pid,
+			Name: name,
+		})
 	}
 
 	return result, nil
+}
+
+// cwdWithinWorktree reports whether a process working directory falls inside the
+// worktree root, which must already be absolute and symlink-resolved. An empty
+// cwd never matches: gopsutil returns "" (with no error) for processes whose
+// working directory cannot be read - notably Windows system processes such as
+// System and csrss.exe - and filepath.Abs("") would otherwise resolve to the
+// caller's own directory, wrongly matching every such process whenever the
+// caller runs from inside the worktree.
+func cwdWithinWorktree(absWorktree, cwd string) bool {
+	if cwd == "" {
+		return false
+	}
+	absCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		return false
+	}
+	absCwd = resolvePath(absCwd)
+
+	rel, err := filepath.Rel(absWorktree, absCwd)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 // resolvePath returns the symlink-resolved path, or the input if resolution

--- a/internal/process/detect_test.go
+++ b/internal/process/detect_test.go
@@ -1,0 +1,43 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// gopsutil returns an empty cwd (with no error) for processes whose working
+// directory cannot be read - notably Windows system processes. Before the guard,
+// filepath.Abs("") resolved to the caller's own directory, so such a process was
+// wrongly matched whenever the caller ran from inside the worktree, which made
+// return/destroy fail with unkillable phantoms like "System (4)". An empty cwd
+// must never be treated as inside the worktree.
+func TestCwdWithinWorktree_EmptyCwdNeverMatches(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Use the caller's own directory as the worktree so the pre-fix
+	// filepath.Abs("") == wd path would have matched.
+	if cwdWithinWorktree(resolvePath(wd), "") {
+		t.Fatal("a process with an empty cwd must not be treated as inside the worktree")
+	}
+}
+
+func TestCwdWithinWorktree_MatchesRootAndDescendant(t *testing.T) {
+	root := resolvePath(t.TempDir())
+	child := filepath.Join(root, "sub", "dir")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !cwdWithinWorktree(root, root) {
+		t.Error("the worktree root itself should match")
+	}
+	if !cwdWithinWorktree(root, child) {
+		t.Error("a descendant of the worktree should match")
+	}
+	if cwdWithinWorktree(root, filepath.Dir(root)) {
+		t.Error("the worktree's parent should not match")
+	}
+}

--- a/internal/process/detect_unix_test.go
+++ b/internal/process/detect_unix_test.go
@@ -51,6 +51,59 @@ func TestFindProcessesInWorktree_ResolvesSymlinks(t *testing.T) {
 	}
 }
 
+// UnprotectedProcessesInWorktree must report a foreign process in the worktree
+// while excluding the caller, so a return run from inside its own worktree is
+// not blocked by itself yet still refuses when another writer is present.
+func TestUnprotectedProcessesInWorktree_ExcludesCallerIncludesForeign(t *testing.T) {
+	worktreeDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("sleep", "60")
+	cmd.Dir = worktreeDir
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Stand the caller inside the worktree so the exclusion is exercised.
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(worktreeDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalDir) })
+
+	procs, err := UnprotectedProcessesInWorktree(worktreeDir)
+	if err != nil {
+		t.Fatalf("UnprotectedProcessesInWorktree: %v", err)
+	}
+
+	var foundForeign, foundCaller bool
+	for _, p := range procs {
+		if int(p.PID) == cmd.Process.Pid {
+			foundForeign = true
+		}
+		if int(p.PID) == os.Getpid() {
+			foundCaller = true
+		}
+	}
+	if !foundForeign {
+		t.Fatalf("expected foreign process %d reported, got %v", cmd.Process.Pid, procs)
+	}
+	if foundCaller {
+		t.Fatalf("expected the caller %d excluded, got %v", os.Getpid(), procs)
+	}
+}
+
 func TestFindProcessesInWorktree_IncludesDotDotPrefixedChild(t *testing.T) {
 	worktreeDir := t.TempDir()
 	childDir := filepath.Join(worktreeDir, "..cache")

--- a/internal/process/terminate.go
+++ b/internal/process/terminate.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -59,7 +60,10 @@ func UnprotectedProcessesInWorktree(worktreePath string) ([]ProcessInfo, error) 
 // failure walking the ancestry is returned as an error rather than swallowed:
 // silently protecting every process would let the caller mistake "the filter
 // gave up" for "nothing needed killing" and reset the worktree with live
-// writers still inside it.
+// writers still inside it. The one benign exception is an ancestor that has
+// already exited: it ends the walk (everything below it is protected and its
+// own ancestors are gone), which is common on Windows where a parent can exit
+// and leave a dangling parent PID.
 func filterProtectedProcesses(procs []ProcessInfo, currentPID int32, lookupParent func(int32) (int32, error)) ([]ProcessInfo, error) {
 	protected := map[int32]struct{}{
 		currentPID: {},
@@ -68,6 +72,9 @@ func filterProtectedProcesses(procs []ProcessInfo, currentPID int32, lookupParen
 	for pid := currentPID; pid > 0; {
 		parent, err := lookupParent(pid)
 		if err != nil {
+			if errors.Is(err, gopsutilprocess.ErrorProcessNotRunning) {
+				break
+			}
 			return nil, fmt.Errorf("cannot resolve ancestry of process %d: %w", pid, err)
 		}
 		if parent <= 0 {

--- a/internal/process/terminate.go
+++ b/internal/process/terminate.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -21,7 +22,10 @@ func TerminateWorktreeProcesses(worktreePath string, gracePeriod time.Duration) 
 	if err != nil {
 		return nil, err
 	}
-	procs = filterProtectedProcesses(procs, int32(os.Getpid()), parentPID)
+	procs, err = filterProtectedProcesses(procs, int32(os.Getpid()), parentPID)
+	if err != nil {
+		return nil, err
+	}
 	if len(procs) == 0 {
 		return nil, nil
 	}
@@ -35,7 +39,28 @@ func TerminateWorktreeProcesses(worktreePath string, gracePeriod time.Duration) 
 	return procs, nil
 }
 
-func filterProtectedProcesses(procs []ProcessInfo, currentPID int32, lookupParent func(int32) (int32, error)) []ProcessInfo {
+// UnprotectedProcessesInWorktree returns processes whose cwd is within the
+// worktree, excluding the caller and its ancestors. These are exactly the
+// processes TerminateWorktreeProcesses would target, so a non-empty result
+// after termination means a foreign live writer remains inside the worktree.
+// Callers re-scan with it before resetting a slot so a process that started
+// during the grace period, or one an ancestry-lookup failure spared, is not
+// mistaken for a quiet worktree.
+func UnprotectedProcessesInWorktree(worktreePath string) ([]ProcessInfo, error) {
+	procs, err := FindProcessesInWorktree(worktreePath)
+	if err != nil {
+		return nil, err
+	}
+	return filterProtectedProcesses(procs, int32(os.Getpid()), parentPID)
+}
+
+// filterProtectedProcesses drops the caller and its ancestors from procs so
+// termination never signals the process running return or its parents. A
+// failure walking the ancestry is returned as an error rather than swallowed:
+// silently protecting every process would let the caller mistake "the filter
+// gave up" for "nothing needed killing" and reset the worktree with live
+// writers still inside it.
+func filterProtectedProcesses(procs []ProcessInfo, currentPID int32, lookupParent func(int32) (int32, error)) ([]ProcessInfo, error) {
 	protected := map[int32]struct{}{
 		currentPID: {},
 	}
@@ -43,7 +68,7 @@ func filterProtectedProcesses(procs []ProcessInfo, currentPID int32, lookupParen
 	for pid := currentPID; pid > 0; {
 		parent, err := lookupParent(pid)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("cannot resolve ancestry of process %d: %w", pid, err)
 		}
 		if parent <= 0 {
 			break
@@ -62,7 +87,7 @@ func filterProtectedProcesses(procs []ProcessInfo, currentPID int32, lookupParen
 		}
 		filtered = append(filtered, proc)
 	}
-	return filtered
+	return filtered, nil
 }
 
 func parentPID(pid int32) (int32, error) {

--- a/internal/process/terminate.go
+++ b/internal/process/terminate.go
@@ -14,9 +14,9 @@ import (
 // On unix it sends SIGTERM, waits up to gracePeriod for processes to exit,
 // then SIGKILLs any survivors. On windows it uses TerminateProcess.
 //
-// Returns the list of processes that were targeted. Errors only if the initial
-// scan fails; individual kill failures (e.g. process already gone) are
-// swallowed.
+// Returns the list of processes that were targeted. It returns an error when
+// process discovery or caller ancestry lookup fails. Individual kill failures
+// (e.g. a process already gone) are swallowed.
 func TerminateWorktreeProcesses(worktreePath string, gracePeriod time.Duration) ([]ProcessInfo, error) {
 	procs, err := FindProcessesInWorktree(worktreePath)
 	if err != nil {

--- a/internal/process/terminate_test.go
+++ b/internal/process/terminate_test.go
@@ -12,7 +12,7 @@ func TestFilterProtectedProcesses_SkipsCurrentProcessAndAncestors(t *testing.T) 
 		{PID: 300, Name: "server"},
 	}
 
-	filtered := filterProtectedProcesses(procs, 200, func(pid int32) (int32, error) {
+	filtered, err := filterProtectedProcesses(procs, 200, func(pid int32) (int32, error) {
 		switch pid {
 		case 200:
 			return 100, nil
@@ -24,6 +24,9 @@ func TestFilterProtectedProcesses_SkipsCurrentProcessAndAncestors(t *testing.T) 
 			return 0, errors.New("unknown pid")
 		}
 	})
+	if err != nil {
+		t.Fatalf("filterProtectedProcesses: %v", err)
+	}
 
 	if len(filtered) != 1 {
 		t.Fatalf("expected 1 process after filtering, got %d", len(filtered))
@@ -36,21 +39,25 @@ func TestFilterProtectedProcesses_SkipsCurrentProcessAndAncestors(t *testing.T) 
 	}
 }
 
-func TestFilterProtectedProcesses_SkipsTerminationWhenParentLookupFails(t *testing.T) {
+func TestFilterProtectedProcesses_ReturnsErrorWhenParentLookupFails(t *testing.T) {
 	procs := []ProcessInfo{
 		{PID: 100, Name: "shell"},
 		{PID: 200, Name: "treehouse"},
 		{PID: 300, Name: "server"},
 	}
 
-	filtered := filterProtectedProcesses(procs, 200, func(pid int32) (int32, error) {
+	// A parent-lookup failure must surface as an error, not silently protect
+	// every process and report "nothing to kill".
+	filtered, err := filterProtectedProcesses(procs, 200, func(pid int32) (int32, error) {
 		if pid == 200 {
 			return 0, errors.New("cannot inspect parent")
 		}
 		return 0, nil
 	})
-
-	if len(filtered) != 0 {
-		t.Fatalf("expected no processes after filtering, got %+v", filtered)
+	if err == nil {
+		t.Fatalf("expected an error when parent lookup fails, got filtered=%+v", filtered)
+	}
+	if filtered != nil {
+		t.Fatalf("expected no filtered processes on error, got %+v", filtered)
 	}
 }

--- a/internal/process/terminate_test.go
+++ b/internal/process/terminate_test.go
@@ -3,6 +3,8 @@ package process
 import (
 	"errors"
 	"testing"
+
+	gopsutilprocess "github.com/shirou/gopsutil/v4/process"
 )
 
 func TestFilterProtectedProcesses_SkipsCurrentProcessAndAncestors(t *testing.T) {
@@ -59,5 +61,31 @@ func TestFilterProtectedProcesses_ReturnsErrorWhenParentLookupFails(t *testing.T
 	}
 	if filtered != nil {
 		t.Fatalf("expected no filtered processes on error, got %+v", filtered)
+	}
+}
+
+// An ancestor that has already exited (gopsutil's ErrorProcessNotRunning) ends
+// the walk instead of failing termination. This is the normal Windows case
+// where a parent exits and leaves a dangling parent PID; termination must still
+// target the remaining foreign processes rather than error out.
+func TestFilterProtectedProcesses_ExitedAncestorEndsWalk(t *testing.T) {
+	procs := []ProcessInfo{
+		{PID: 100, Name: "shell"},
+		{PID: 200, Name: "treehouse"},
+		{PID: 300, Name: "server"},
+	}
+
+	filtered, err := filterProtectedProcesses(procs, 200, func(pid int32) (int32, error) {
+		if pid == 200 {
+			return 100, nil
+		}
+		// The parent (100) has exited before we could read its own parent.
+		return 0, gopsutilprocess.ErrorProcessNotRunning
+	})
+	if err != nil {
+		t.Fatalf("expected an exited ancestor to end the walk cleanly, got: %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].PID != 300 {
+		t.Fatalf("expected only the foreign process 300 to remain, got %+v", filtered)
 	}
 }


### PR DESCRIPTION
## Intent

Fix worktree-safety bug behind issue #82 in treehouse's 'return' path. Worktree process selection is a single point-in-time scan of process cwds, and 'return' acted on it without verifying the worktree was actually clear before running git reset --hard / git clean -fd. Two gaps let a live writer survive that check: (1) filterProtectedProcesses returned nil when it could not walk the caller's ancestry, so a pid vanishing mid-walk silently protected every process - TerminateWorktreeProcesses then reported nothing to kill, indistinguishable from a quiet worktree; (2) anything that started during the grace period was never signalled, and the scan was never repeated to confirm the worktree was empty. Either way return reset the slot with a process still writing into it, then handed that slot back to the pool, contaminating the next lease with foreign files and a foreign live process. Fix: make the ancestry-walk failure explicit (return an error instead of nil), and re-scan after termination through UnprotectedProcessesInWorktree - the same caller/ancestor filter termination uses, so a return from inside its own worktree is not blocked by itself. When a foreign writer remains, return fails closed: it leaves the slot in place instead of resetting it. Deliberate design: fail-closed on unproven safety, reuse the existing ancestor filter so self-return still works, unix process semantics. This is the disjoint companion fix to issue #81 (reap wait after SIGKILL), touching different code. Fixes #82.

## What Changed

- Make `treehouse return` rescan for foreign processes after termination and leave the worktree and lease intact when safety cannot be verified.
- Surface caller ancestry lookup failures instead of treating them as an empty process set, while continuing to exclude the returning process and its ancestors.
- Document the fail-closed return behavior and add coverage for surviving writers, termination failures, and self-return.

## Risk Assessment

✅ Low: The change is narrowly scoped and satisfies the required fail-closed ancestry handling and post-termination rescan without introducing a material source risk.

## Testing

Focused process and return tests passed. After discarding an initial manual setup with the wrong blocker cwd, the corrected CLI scenario proved that return fails closed, preserves the leased slot, and exposes the surviving writer without resetting its files; the worktree remained clean and test processes were removed.

<details>
<summary>Evidence: CLI fail-closed transcript</summary>

```text
Scenario: treehouse return refuses a slot when a writer starts during termination grace period

To /tmp/no-mistakes-evidence/01M0FYBSB75WFGD57HWSNEHCCH/e2e-return-live-writer.TCk4QA/remote.git
 * [new branch]      main -> main
1. Lease acquired
🌳 Setting up worktree...
🌳 Leased worktree at ~/.treehouse/repo-647f31/1/repo. Run 'treehouse return ~/.treehouse/repo-647f31/1/repo' to release it.
   path: /tmp/no-mistakes-evidence/01M0FYBSB75WFGD57HWSNEHCCH/e2e-return-live-writer.TCk4QA/home/.treehouse/repo-647f31/1/repo

2. Return invoked while an initial process holds the worktree; a second writer starts during the 2s grace period
/bin/bash: line 43: 2146477 Killed                     setsid sh -c 'target=$1; cd "$target" || exit 1; trap "" TERM; while :; do sleep 1; done' sh "$WT_PATH" > "$RUN_DIR/blocker.log" 2>&1
🌳 Terminated lingering processes: sh (2146477), sleep (2146482)
failed to return worktree: worktree still has live processes after termination: sh (2146478), sleep (2149645), sleep (2149746)
   exit code: 1

3. Slot state after refused return
1     leased       ~/.treehouse/repo-647f31/1/repo
                   sh (2146478), sleep (2149645)

4. Foreign output remains in place, proving reset/clean did not run after safety refusal
   foreign.txt: foreign writer was here
   writer pid 2146478 alive: yes

5. Acceptance checks
   PASS: return failed closed, preserved the leased slot, and left the live writer visible for operator action.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 5e3d282592dfef5e60a5027797aa917f08c6cbf0..1bf6dc6b79e11f18c37d8ea9e023dfd17ba4c76e`.</code>
- `go test ./internal/process -run 'Test(FilterProtectedProcesses_ReturnsErrorWhenParentLookupFails|UnprotectedProcessesInWorktree_ExcludesCallerIncludesForeign|TerminateWorktreeProcesses_EscalatesToKill)$' -count=1`
- `go test ./cmd -run 'Test(KillLingeringProcesses_(RefusesSurvivingLiveWriter|SurfacesTerminationFailure|QuietWorktreeSucceeds)|ReturnFromInsideWorktreeDoesNotTerminateCaller)$' -count=1`
- `Built the CLI and ran an isolated lease/return scenario where a foreign writer entered during the two-second termination grace period; verified nonzero return, leased state, persisted foreign file, and live writer.`
- <code>Checked `git status --short` and the test process list after cleanup.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
