### PR TITLE
ci: require no-mistakes pipeline step attestation on PRs

### DIFF
--- a/.github/scripts/no-mistakes-gate.sh
+++ b/.github/scripts/no-mistakes-gate.sh
@@ -4,7 +4,9 @@
 # required check.
 #
 # A PR passes when any of these hold:
-#   * its body carries the no-mistakes pipeline signature, or
+#   * its body carries the no-mistakes pipeline signature AND a parseable v1
+#     pipeline step attestation in which review, test, and document are
+#     status=completed, or
 #   * it was opened by github-actions[bot] or dependabot[bot], or
 #   * it is structurally a release-please release PR (see below).
 #
@@ -24,6 +26,9 @@
 set -eu
 
 NO_MISTAKES_MARKER='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+ATTESTATION_PREFIX='<!-- no-mistakes-pipeline-attestation:v1'
+ATTESTATION_VERSION_FLOOR='1.46.0'
+ATTESTATION_VERSION_URL='https://github.com/kunchenguid/no-mistakes/pull/670'
 RELEASE_PLEASE_MARKER='This PR was generated with [Release Please]'
 RELEASE_PLEASE_BRANCH_PREFIX='release-please--'
 RELEASE_PLEASE_LEGACY_BRANCH_PREFIX='release-please/'
@@ -66,10 +71,142 @@ has_release_please_footer() {
     body_contains "$RELEASE_PLEASE_MARKER"
 }
 
-if body_contains "$NO_MISTAKES_MARKER"; then
-    echo "Found no-mistakes signature in PR #${pr_number} body."
-    exit 0
-fi
+json_python() {
+    local cand
+    for cand in python3 python; do
+        if command -v "$cand" >/dev/null 2>&1 && "$cand" -c 'import json,re,sys' >/dev/null 2>&1; then
+            command -v "$cand"
+            return 0
+        fi
+    done
+    return 1
+}
+
+fail_missing_or_unparseable_attestation() {
+    {
+        echo "::error::This PR has the no-mistakes signature but no parseable pipeline step attestation."
+        echo
+        echo "This repository requires no-mistakes >= ${ATTESTATION_VERSION_FLOOR} (${ATTESTATION_VERSION_URL})."
+        echo "Older no-mistakes that only writes the signature line is not enough."
+        echo "Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:"
+        echo
+        echo "    ${ATTESTATION_PREFIX} {\"head_sha\":\"...\",\"steps\":[...]} -->"
+        echo
+        echo "PR author: ${pr_author}"
+    } >&2
+    exit 1
+}
+
+fail_incomplete_attestation() {
+    {
+        echo "::error::This PR's no-mistakes pipeline attestation does not show completed required steps."
+        echo
+        echo "This repository requires review, test, and document to each have status=completed."
+        echo "Quota skips and agent skips are not compliant."
+        echo
+        printf '%s\n' "$@"
+        echo
+        echo "Re-run those steps to completion with 'git push no-mistakes'."
+        echo
+        echo "PR author: ${pr_author}"
+    } >&2
+    exit 1
+}
+
+# Reads PR_BODY and prints one of:
+#   MISSING
+#   UNPARSEABLE
+#   PARSED
+#   review=<status>
+#   test=<status>
+#   document=<status>
+# Status is "missing" when the step is absent or not a string.
+parse_pipeline_attestation() {
+    local py
+    py=$(json_python) || {
+        echo UNPARSEABLE
+        return 0
+    }
+    "$py" - <<'PY'
+import json, os, re, sys
+
+body = os.environ.get("PR_BODY", "")
+match = re.search(
+    r"<!--\s*no-mistakes-pipeline-attestation:v1\s+(.*?)\s*-->",
+    body,
+    flags=re.DOTALL,
+)
+if match is None:
+    sys.stdout.write("MISSING\n")
+    sys.exit(0)
+
+raw = match.group(1).strip()
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError:
+    sys.stdout.write("UNPARSEABLE\n")
+    sys.exit(0)
+
+if not isinstance(payload, dict):
+    sys.stdout.write("UNPARSEABLE\n")
+    sys.exit(0)
+
+head_sha = payload.get("head_sha")
+steps = payload.get("steps")
+if not isinstance(head_sha, str) or not head_sha.strip() or not isinstance(steps, list):
+    sys.stdout.write("UNPARSEABLE\n")
+    sys.exit(0)
+
+statuses = {}
+for item in steps:
+    if not isinstance(item, dict):
+        sys.stdout.write("UNPARSEABLE\n")
+        sys.exit(0)
+    name = item.get("step")
+    status = item.get("status")
+    if not isinstance(name, str) or not name:
+        sys.stdout.write("UNPARSEABLE\n")
+        sys.exit(0)
+    if name in statuses:
+        continue
+    if isinstance(status, str) and status:
+        statuses[name] = status
+    else:
+        statuses[name] = "missing"
+
+sys.stdout.write("PARSED\n")
+for name in ("review", "test", "document"):
+    sys.stdout.write("%s=%s\n" % (name, statuses.get(name, "missing")))
+PY
+}
+
+require_pipeline_attestation() {
+    local parsed kind pair name status rest
+    local -a incomplete=()
+
+    parsed=$(parse_pipeline_attestation || echo UNPARSEABLE)
+    parsed=$(printf '%s\n' "$parsed" | tr -d '\r')
+    kind=${parsed%%$'\n'*}
+    case "$kind" in
+        PARSED) ;;
+        *) fail_missing_or_unparseable_attestation ;;
+    esac
+
+    rest=${parsed#*$'\n'}
+    while IFS= read -r pair || [ -n "$pair" ]; do
+        [ -n "$pair" ] || continue
+        name=${pair%%=*}
+        status=${pair#*=}
+        if [ "$status" != completed ]; then
+            incomplete+=("  ${name}: ${status}")
+        fi
+    done <<EOF
+$rest
+EOF
+    if [ "${#incomplete[@]}" -ne 0 ]; then
+        fail_incomplete_attestation "${incomplete[@]}"
+    fi
+}
 
 if is_exempt_bot; then
     echo "PR #${pr_number} was opened by ${pr_author}; exempt from the no-mistakes signature."
@@ -78,6 +215,12 @@ fi
 
 if is_release_please_branch && is_same_repo_head && has_release_please_footer; then
     echo "PR #${pr_number} is a release-please release PR (same-repo branch '${pr_head_ref}' with the Release Please footer); exempt from the no-mistakes signature."
+    exit 0
+fi
+
+if body_contains "$NO_MISTAKES_MARKER"; then
+    require_pipeline_attestation
+    echo "Found no-mistakes signature and completed review/test/document attestation in PR #${pr_number} body."
     exit 0
 fi
 

--- a/.github/scripts/no-mistakes-gate.sh
+++ b/.github/scripts/no-mistakes-gate.sh
@@ -5,8 +5,8 @@
 #
 # A PR passes when any of these hold:
 #   * its body carries the no-mistakes pipeline signature AND a parseable v1
-#     pipeline step attestation in which review, test, and document are
-#     status=completed, or
+#     pipeline step attestation whose head_sha equals the current PR head and
+#     in which review, test, and document are status=completed, or
 #   * it was opened by github-actions[bot] or dependabot[bot], or
 #   * it is structurally a release-please release PR (see below).
 #
@@ -21,7 +21,9 @@
 # has one executable surface that tests can drive directly.
 #
 # Inputs (environment):
-#   PR_BODY, PR_AUTHOR, PR_NUMBER, PR_HEAD_REF, PR_HEAD_REPO, PR_BASE_REPO
+#   PR_BODY, PR_AUTHOR, PR_NUMBER, PR_HEAD_REF, PR_HEAD_REPO, PR_BASE_REPO,
+#   PR_HEAD_SHA (github.event.pull_request.head.sha; required on the
+#   attestation path so a later push cannot pass on a stale comment)
 # Exit status: 0 = pass, 1 = fail.
 set -eu
 
@@ -39,6 +41,8 @@ pr_number="${PR_NUMBER:-unknown}"
 pr_head_ref="${PR_HEAD_REF:-}"
 pr_head_repo="${PR_HEAD_REPO:-}"
 pr_base_repo="${PR_BASE_REPO:-}"
+pr_head_sha="${PR_HEAD_SHA:-}"
+pr_head_sha=${pr_head_sha//$'\r'/}
 
 body_contains() {
     printf '%s' "$pr_body" | grep -qF -- "$1"
@@ -113,10 +117,35 @@ fail_incomplete_attestation() {
     exit 1
 }
 
+display_sha() {
+    if [ -n "$1" ]; then
+        printf '%s' "$1"
+    else
+        printf '%s' '(missing)'
+    fi
+}
+
+fail_attestation_head_sha() {
+    local attested_sha="$1"
+    {
+        echo "::error::This PR's no-mistakes pipeline attestation is not bound to the current pull request head."
+        echo
+        echo "The attestation head_sha must equal the current pull request head SHA so a later push cannot pass on a stale attestation."
+        echo "  attestation head_sha: $(display_sha "$attested_sha")"
+        echo "  pull request head:    $(display_sha "$pr_head_sha")"
+        echo
+        echo "Re-run 'git push no-mistakes' on the current head so the PR body attestation is rewritten for this commit."
+        echo
+        echo "PR author: ${pr_author}"
+    } >&2
+    exit 1
+}
+
 # Reads PR_BODY and prints one of:
 #   MISSING
 #   UNPARSEABLE
 #   PARSED
+#   head_sha=<value>   (empty when the field is missing or not a string)
 #   review=<status>
 #   test=<status>
 #   document=<status>
@@ -151,9 +180,13 @@ if not isinstance(payload, dict):
     sys.stdout.write("UNPARSEABLE\n")
     sys.exit(0)
 
-head_sha = payload.get("head_sha")
+raw_head_sha = payload.get("head_sha")
+if isinstance(raw_head_sha, str):
+    head_sha = raw_head_sha.strip()
+else:
+    head_sha = ""
 steps = payload.get("steps")
-if not isinstance(head_sha, str) or not head_sha.strip() or not isinstance(steps, list):
+if not isinstance(steps, list):
     sys.stdout.write("UNPARSEABLE\n")
     sys.exit(0)
 
@@ -175,13 +208,14 @@ for item in steps:
         statuses[name] = "missing"
 
 sys.stdout.write("PARSED\n")
+sys.stdout.write("head_sha=%s\n" % head_sha)
 for name in ("review", "test", "document"):
     sys.stdout.write("%s=%s\n" % (name, statuses.get(name, "missing")))
 PY
 }
 
 require_pipeline_attestation() {
-    local parsed kind pair name status rest
+    local parsed kind pair name status rest attested_sha=""
     local -a incomplete=()
 
     parsed=$(parse_pipeline_attestation || echo UNPARSEABLE)
@@ -197,12 +231,19 @@ require_pipeline_attestation() {
         [ -n "$pair" ] || continue
         name=${pair%%=*}
         status=${pair#*=}
+        if [ "$name" = head_sha ]; then
+            attested_sha=$status
+            continue
+        fi
         if [ "$status" != completed ]; then
             incomplete+=("  ${name}: ${status}")
         fi
     done <<EOF
 $rest
 EOF
+    if [ -z "$attested_sha" ] || [ -z "$pr_head_sha" ] || [ "$attested_sha" != "$pr_head_sha" ]; then
+        fail_attestation_head_sha "$attested_sha"
+    fi
     if [ "${#incomplete[@]}" -ne 0 ]; then
         fail_incomplete_attestation "${incomplete[@]}"
     fi
@@ -220,7 +261,7 @@ fi
 
 if body_contains "$NO_MISTAKES_MARKER"; then
     require_pipeline_attestation
-    echo "Found no-mistakes signature and completed review/test/document attestation in PR #${pr_number} body."
+    echo "Found no-mistakes signature and completed review/test/document attestation bound to head ${pr_head_sha} in PR #${pr_number} body."
     exit 0
 fi
 

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -44,6 +44,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
         run: |
           set -eu

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ make test
 
 ## Contribution Gate
 
-- PRs to `main` must carry the no-mistakes pipeline signature. The required check is `PR must be raised via no-mistakes` (`.github/workflows/no-mistakes-required.yml`), enforced by the repository `main` ruleset; only the owner/Admin role can bypass it.
+- PRs to `main` must carry the no-mistakes pipeline signature and a v1 pipeline step attestation (`review`, `test`, and `document` each `status=completed`). Signature-only bodies from no-mistakes older than 1.46.0 fail. The required check is `PR must be raised via no-mistakes` (`.github/workflows/no-mistakes-required.yml`), enforced by the repository `main` ruleset; only the owner/Admin role can bypass it.
 - Every exemption (bots, and release-please identified structurally by branch prefix + same-repo head + Release Please body footer) lives in `.github/scripts/no-mistakes-gate.sh`, the single executable decision surface, covered by `TestNoMistakesGateDecisions`.
 - release-please opens its PRs with `GITHUB_TOKEN`, so GitHub creates **no** workflow runs on them and the gate can never report there. `release.yml`'s `release-pr-gate-status` job publishes the required context on the release PR head by running that same gate script, so release PRs go green without an owner override.
 - A workflow backing a required check must never use `paths`/`paths-ignore`: a filtered required check never reports and blocks the PR forever. `TestPullRequestWorkflowsExcludeReleasePleaseOutputs` encodes both that rule and the opposite rule for ordinary PR workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ make test
 
 ## Contribution Gate
 
-- PRs to `main` must carry the no-mistakes pipeline signature and a v1 pipeline step attestation (`review`, `test`, and `document` each `status=completed`). Signature-only bodies from no-mistakes older than 1.46.0 fail. The required check is `PR must be raised via no-mistakes` (`.github/workflows/no-mistakes-required.yml`), enforced by the repository `main` ruleset; only the owner/Admin role can bypass it.
+- PRs to `main` must carry the no-mistakes pipeline signature and a v1 pipeline step attestation whose `head_sha` matches the current PR head (`review`, `test`, and `document` each `status=completed`). Signature-only bodies from no-mistakes older than 1.46.0 fail. The required check is `PR must be raised via no-mistakes` (`.github/workflows/no-mistakes-required.yml`), enforced by the repository `main` ruleset; only the owner/Admin role can bypass it.
 - Every exemption (bots, and release-please identified structurally by branch prefix + same-repo head + Release Please body footer) lives in `.github/scripts/no-mistakes-gate.sh`, the single executable decision surface, covered by `TestNoMistakesGateDecisions`.
 - release-please opens its PRs with `GITHUB_TOKEN`, so GitHub creates **no** workflow runs on them and the gate can never report there. `release.yml`'s `release-pr-gate-status` job publishes the required context on the release PR head by running that same gate script, so release PRs go green without an owner override.
 - A workflow backing a required check must never use `paths`/`paths-ignore`: a filtered required check never reports and blocks the PR forever. `TestPullRequestWorkflowsExcludeReleasePleaseOutputs` encodes both that rule and the opposite rule for ordinary PR workflows.

--- a/no_mistakes_gate_test.go
+++ b/no_mistakes_gate_test.go
@@ -84,6 +84,7 @@ type pullRequestEvent struct {
 	author   string
 	headRef  string
 	headRepo string
+	headSHA  string
 	baseRepo string
 }
 
@@ -99,6 +100,8 @@ func (e pullRequestEvent) lookup(path string) (string, bool) {
 		return e.headRef, true
 	case "github.event.pull_request.head.repo.full_name":
 		return e.headRepo, true
+	case "github.event.pull_request.head.sha":
+		return e.headSHA, true
 	case "github.event.pull_request.base.repo.full_name":
 		return e.baseRepo, true
 	default:
@@ -162,6 +165,10 @@ func runGate(t *testing.T, step gateStep, event pullRequestEvent) (bool, string)
 
 const (
 	noMistakesSignature = "## Pipeline\n\nUpdates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)\n"
+	// attestationHeadSHA is the compact v1 comment's head_sha. Passing cases
+	// bind github.event.pull_request.head.sha to this value.
+	attestationHeadSHA = "0123456789abcdef0123456789abcdef01234567"
+	otherHeadSHA       = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	// completedAttestation matches the compact v1 comment no-mistakes >= 1.46.0 writes.
 	// pr/ci are commonly still running/pending at PR write time and are not required.
 	completedAttestation = `<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0123456789abcdef0123456789abcdef01234567","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->`
@@ -240,7 +247,7 @@ func TestNoMistakesGateDecisions(t *testing.T) {
 			name: "human PR carrying the no-mistakes signature and completed attestation passes",
 			event: pullRequestEvent{
 				number: 83, body: noMistakesBody, author: "kunchenguid",
-				headRef: "fm/some-work", headRepo: repo, baseRepo: repo,
+				headRef: "fm/some-work", headRepo: repo, headSHA: attestationHeadSHA, baseRepo: repo,
 			},
 			pass: true,
 		},
@@ -270,7 +277,7 @@ func TestNoMistakesGateDecisions(t *testing.T) {
 				number:  91,
 				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"step":"review","status":"completed"`, `"step":"review","status":"skipped"`, 1) + "\n",
 				author:  "kunchenguid",
-				headRef: "fm/skipped-review", headRepo: repo, baseRepo: repo,
+				headRef: "fm/skipped-review", headRepo: repo, headSHA: attestationHeadSHA, baseRepo: repo,
 			},
 			pass:       false,
 			wantOutput: []string{"review: skipped", "Quota skips and agent skips are not compliant"},
@@ -282,7 +289,7 @@ func TestNoMistakesGateDecisions(t *testing.T) {
 				number:  92,
 				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"step":"test","status":"completed"`, `"step":"test","status":"failed"`, 1) + "\n",
 				author:  "kunchenguid",
-				headRef: "fm/failed-test", headRepo: repo, baseRepo: repo,
+				headRef: "fm/failed-test", headRepo: repo, headSHA: attestationHeadSHA, baseRepo: repo,
 			},
 			pass:       false,
 			wantOutput: []string{"test: failed"},
@@ -294,7 +301,7 @@ func TestNoMistakesGateDecisions(t *testing.T) {
 				number:  93,
 				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"step":"document","status":"completed"`, `"step":"document","status":"pending"`, 1) + "\n",
 				author:  "kunchenguid",
-				headRef: "fm/pending-document", headRepo: repo, baseRepo: repo,
+				headRef: "fm/pending-document", headRepo: repo, headSHA: attestationHeadSHA, baseRepo: repo,
 			},
 			pass:       false,
 			wantOutput: []string{"document: pending"},
@@ -306,7 +313,7 @@ func TestNoMistakesGateDecisions(t *testing.T) {
 				number:  94,
 				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"step":"document","status":"completed"`, `"step":"document","status":"running"`, 1) + "\n",
 				author:  "kunchenguid",
-				headRef: "fm/running-document", headRepo: repo, baseRepo: repo,
+				headRef: "fm/running-document", headRepo: repo, headSHA: attestationHeadSHA, baseRepo: repo,
 			},
 			pass:       false,
 			wantOutput: []string{"document: running"},
@@ -318,10 +325,56 @@ func TestNoMistakesGateDecisions(t *testing.T) {
 				number:  95,
 				body:    noMistakesSignature + "\n<!-- no-mistakes-pipeline-attestation:v1 {\"head_sha\":\"0123456789abcdef0123456789abcdef01234567\",\"steps\":[{\"step\":\"review\",\"status\":\"completed\"},{\"step\":\"test\",\"status\":\"completed\"}]} -->\n",
 				author:  "kunchenguid",
-				headRef: "fm/missing-document", headRepo: repo, baseRepo: repo,
+				headRef: "fm/missing-document", headRepo: repo, headSHA: attestationHeadSHA, baseRepo: repo,
 			},
 			pass:       false,
 			wantOutput: []string{"document: missing"},
+			hideOutput: []string{attestationVersionFloor},
+		},
+		{
+			name: "human PR with attestation for a different head SHA fails",
+			event: pullRequestEvent{
+				number: 97, body: noMistakesBody, author: "kunchenguid",
+				headRef: "fm/stale-attestation", headRepo: repo, headSHA: otherHeadSHA, baseRepo: repo,
+			},
+			pass: false,
+			wantOutput: []string{
+				"not bound to the current pull request head",
+				"stale attestation",
+				attestationHeadSHA,
+				otherHeadSHA,
+			},
+			hideOutput: []string{attestationVersionFloor, "review: skipped"},
+		},
+		{
+			name: "human PR with empty attestation head_sha fails",
+			event: pullRequestEvent{
+				number:  98,
+				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"head_sha":"0123456789abcdef0123456789abcdef01234567"`, `"head_sha":""`, 1) + "\n",
+				author:  "kunchenguid",
+				headRef: "fm/empty-head-sha", headRepo: repo, headSHA: attestationHeadSHA, baseRepo: repo,
+			},
+			pass: false,
+			wantOutput: []string{
+				"not bound to the current pull request head",
+				"attestation head_sha: (missing)",
+				attestationHeadSHA,
+			},
+			hideOutput: []string{attestationVersionFloor},
+		},
+		{
+			name: "human PR with attestation JSON missing head_sha fails",
+			event: pullRequestEvent{
+				number:  99,
+				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"head_sha":"0123456789abcdef0123456789abcdef01234567",`, "", 1) + "\n",
+				author:  "kunchenguid",
+				headRef: "fm/missing-head-sha", headRepo: repo, headSHA: attestationHeadSHA, baseRepo: repo,
+			},
+			pass: false,
+			wantOutput: []string{
+				"not bound to the current pull request head",
+				"attestation head_sha: (missing)",
+			},
 			hideOutput: []string{attestationVersionFloor},
 		},
 		{

--- a/no_mistakes_gate_test.go
+++ b/no_mistakes_gate_test.go
@@ -161,20 +161,29 @@ func runGate(t *testing.T, step gateStep, event pullRequestEvent) (bool, string)
 }
 
 const (
-	noMistakesBody = "## Pipeline\n\nUpdates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)\n"
-	releaseBody    = ":robot: I have created a release *beep* *boop*\n---\n\n## [2.1.1](https://example.invalid)\n\n---\n" +
+	noMistakesSignature = "## Pipeline\n\nUpdates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)\n"
+	// completedAttestation matches the compact v1 comment no-mistakes >= 1.46.0 writes.
+	// pr/ci are commonly still running/pending at PR write time and are not required.
+	completedAttestation = `<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0123456789abcdef0123456789abcdef01234567","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->`
+	noMistakesBody       = noMistakesSignature + "\n" + completedAttestation + "\n"
+	releaseBody          = ":robot: I have created a release *beep* *boop*\n---\n\n## [2.1.1](https://example.invalid)\n\n---\n" +
 		"This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please)."
 	repo     = "kunchenguid/treehouse"
 	forkRepo = "someone-else/treehouse"
+
+	attestationVersionFloor = "no-mistakes >= 1.46.0"
+	attestationVersionURL   = "https://github.com/kunchenguid/no-mistakes/pull/670"
 )
 
 func TestNoMistakesGateDecisions(t *testing.T) {
 	step := loadGateStep(t)
 
 	cases := []struct {
-		name  string
-		event pullRequestEvent
-		pass  bool
+		name       string
+		event      pullRequestEvent
+		pass       bool
+		wantOutput []string
+		hideOutput []string
 	}{
 		{
 			// The live shape of treehouse's own release PRs (see PR #78).
@@ -220,12 +229,100 @@ func TestNoMistakesGateDecisions(t *testing.T) {
 			pass: true,
 		},
 		{
-			name: "human PR carrying the no-mistakes signature passes",
+			name: "github-actions bot remains exempt even with a signature-only body",
+			event: pullRequestEvent{
+				number: 96, body: noMistakesSignature, author: "github-actions[bot]",
+				headRef: "chore/bot-with-signature", headRepo: repo, baseRepo: repo,
+			},
+			pass: true,
+		},
+		{
+			name: "human PR carrying the no-mistakes signature and completed attestation passes",
 			event: pullRequestEvent{
 				number: 83, body: noMistakesBody, author: "kunchenguid",
 				headRef: "fm/some-work", headRepo: repo, baseRepo: repo,
 			},
 			pass: true,
+		},
+		{
+			name: "human PR with the signature but no attestation fails",
+			event: pullRequestEvent{
+				number: 89, body: noMistakesSignature, author: "kunchenguid",
+				headRef: "fm/old-no-mistakes", headRepo: repo, baseRepo: repo,
+			},
+			pass:       false,
+			wantOutput: []string{attestationVersionFloor, attestationVersionURL, "Older no-mistakes that only writes the signature line is not enough"},
+		},
+		{
+			name: "human PR with unparseable attestation JSON fails",
+			event: pullRequestEvent{
+				number:  90,
+				body:    noMistakesSignature + "\n<!-- no-mistakes-pipeline-attestation:v1 {not-json} -->\n",
+				author:  "kunchenguid",
+				headRef: "fm/bad-attestation", headRepo: repo, baseRepo: repo,
+			},
+			pass:       false,
+			wantOutput: []string{attestationVersionFloor, attestationVersionURL},
+		},
+		{
+			name: "human PR with skipped review fails",
+			event: pullRequestEvent{
+				number:  91,
+				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"step":"review","status":"completed"`, `"step":"review","status":"skipped"`, 1) + "\n",
+				author:  "kunchenguid",
+				headRef: "fm/skipped-review", headRepo: repo, baseRepo: repo,
+			},
+			pass:       false,
+			wantOutput: []string{"review: skipped", "Quota skips and agent skips are not compliant"},
+			hideOutput: []string{attestationVersionFloor},
+		},
+		{
+			name: "human PR with failed test fails",
+			event: pullRequestEvent{
+				number:  92,
+				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"step":"test","status":"completed"`, `"step":"test","status":"failed"`, 1) + "\n",
+				author:  "kunchenguid",
+				headRef: "fm/failed-test", headRepo: repo, baseRepo: repo,
+			},
+			pass:       false,
+			wantOutput: []string{"test: failed"},
+			hideOutput: []string{attestationVersionFloor},
+		},
+		{
+			name: "human PR with pending document fails",
+			event: pullRequestEvent{
+				number:  93,
+				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"step":"document","status":"completed"`, `"step":"document","status":"pending"`, 1) + "\n",
+				author:  "kunchenguid",
+				headRef: "fm/pending-document", headRepo: repo, baseRepo: repo,
+			},
+			pass:       false,
+			wantOutput: []string{"document: pending"},
+			hideOutput: []string{attestationVersionFloor},
+		},
+		{
+			name: "human PR with running document fails",
+			event: pullRequestEvent{
+				number:  94,
+				body:    noMistakesSignature + "\n" + strings.Replace(completedAttestation, `"step":"document","status":"completed"`, `"step":"document","status":"running"`, 1) + "\n",
+				author:  "kunchenguid",
+				headRef: "fm/running-document", headRepo: repo, baseRepo: repo,
+			},
+			pass:       false,
+			wantOutput: []string{"document: running"},
+			hideOutput: []string{attestationVersionFloor},
+		},
+		{
+			name: "human PR missing the document step fails",
+			event: pullRequestEvent{
+				number:  95,
+				body:    noMistakesSignature + "\n<!-- no-mistakes-pipeline-attestation:v1 {\"head_sha\":\"0123456789abcdef0123456789abcdef01234567\",\"steps\":[{\"step\":\"review\",\"status\":\"completed\"},{\"step\":\"test\",\"status\":\"completed\"}]} -->\n",
+				author:  "kunchenguid",
+				headRef: "fm/missing-document", headRepo: repo, baseRepo: repo,
+			},
+			pass:       false,
+			wantOutput: []string{"document: missing"},
+			hideOutput: []string{attestationVersionFloor},
 		},
 		{
 			name: "human PR without the signature fails",
@@ -274,6 +371,16 @@ func TestNoMistakesGateDecisions(t *testing.T) {
 			got, output := runGate(t, step, tc.event)
 			if got != tc.pass {
 				t.Fatalf("gate pass = %v, want %v\n%s", got, tc.pass, output)
+			}
+			for _, want := range tc.wantOutput {
+				if !strings.Contains(output, want) {
+					t.Fatalf("gate output missing %q\n%s", want, output)
+				}
+			}
+			for _, hide := range tc.hideOutput {
+				if strings.Contains(output, hide) {
+					t.Fatalf("gate output unexpectedly contains %q\n%s", hide, output)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Extend the base-branch no-mistakes gate so a valid pipeline signature is no longer enough: PRs must also carry a parseable `<!-- no-mistakes-pipeline-attestation:v1 ... -->` comment.
- Require `review`, `test`, and `document` to have `status=completed`. Missing/unparseable attestation fails with a no-mistakes >= 1.46.0 error; skipped/failed/pending/running/missing required steps fail by name.
- Bind `attestation.head_sha` to `github.event.pull_request.head.sha` so a later push cannot pass on a stale attestation. Missing/empty/mismatched `head_sha` fails. Existing bot and release-please exemptions are unchanged.

## Test plan
- [x] `go test -run TestNoMistakesGateDecisions` covers signature-only, unparseable JSON, skipped/failed/pending/running/missing required steps, completed attestation matching the PR head, SHA mismatch/empty/missing, and exemptions.
- [ ] Confirm the required check job name remains `PR must be raised via no-mistakes` after merge.