### PR TITLE
fix(pool): recover from unregistered slot remnants

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1038,6 +1038,85 @@ func TestGetRecoversFromStaleWorktreeRegistration(t *testing.T) {
 	}
 }
 
+func TestGetSkipsNonEmptyUnregisteredSlot(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+	if err := os.WriteFile(filepath.Join(repoDir, "treehouse.toml"), []byte("max_trees = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, code := runTreehouse(t, repoDir, homeDir, nil, "status"); code != 0 {
+		t.Fatalf("initial status failed (code %d)", code)
+	}
+	matches, err := filepath.Glob(filepath.Join(homeDir, ".treehouse", filepath.Base(repoDir)+"-*"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected exactly one pool dir under %s/.treehouse, got %v: %v", homeDir, matches, err)
+	}
+	strayPath := filepath.Join(matches[0], "1", filepath.Base(repoDir))
+	if err := os.MkdirAll(strayPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(strayPath, "uncommitted.txt")
+	if err := os.WriteFile(marker, []byte("must survive\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease", "--no-fetch")
+	if code != 0 {
+		t.Fatalf("get --lease failed on non-empty unregistered slot (code %d): %s", code, stderr)
+	}
+	wantPath := filepath.Join(matches[0], "2", filepath.Base(repoDir))
+	if got := strings.TrimSpace(stdout); got != wantPath {
+		t.Fatalf("leased path = %q, want %q (stderr: %s)", got, wantPath, stderr)
+	}
+	if !strings.Contains(stderr, strayPath) || !strings.Contains(stderr, "trying the next slot") {
+		t.Fatalf("expected actionable warning naming %s, got: %s", strayPath, stderr)
+	}
+	if data, err := os.ReadFile(marker); err != nil || string(data) != "must survive\n" {
+		t.Fatalf("unmanaged work was not preserved: data=%q err=%v", data, err)
+	}
+	listOut := filepath.ToSlash(gitCmd(t, repoDir, "worktree", "list", "--porcelain"))
+	if !strings.Contains(listOut, filepath.ToSlash(wantPath)) {
+		t.Fatalf("new worktree is not registered at %s:\n%s", wantPath, listOut)
+	}
+	if strings.Contains(listOut, filepath.ToSlash(strayPath)) {
+		t.Fatalf("unmanaged slot was unexpectedly registered:\n%s", listOut)
+	}
+}
+
+func TestGetReclaimsEmptyUnregisteredSlot(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	if _, _, code := runTreehouse(t, repoDir, homeDir, nil, "status"); code != 0 {
+		t.Fatalf("initial status failed (code %d)", code)
+	}
+	matches, err := filepath.Glob(filepath.Join(homeDir, ".treehouse", filepath.Base(repoDir)+"-*"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected exactly one pool dir under %s/.treehouse, got %v: %v", homeDir, matches, err)
+	}
+	emptyPath := filepath.Join(matches[0], "1", filepath.Base(repoDir))
+	if err := os.MkdirAll(emptyPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runTreehouse(t, repoDir, homeDir, nil, "get", "--lease", "--no-fetch")
+	if code != 0 {
+		t.Fatalf("get --lease failed on empty unregistered slot (code %d): %s", code, stderr)
+	}
+	if got := strings.TrimSpace(stdout); got != emptyPath {
+		t.Fatalf("leased path = %q, want reclaimed path %q", got, emptyPath)
+	}
+	if strings.Contains(stderr, "blocked by an unmanaged path") {
+		t.Fatalf("empty slot should be reclaimed without a warning: %s", stderr)
+	}
+	listOut := filepath.ToSlash(gitCmd(t, repoDir, "worktree", "list", "--porcelain"))
+	if !strings.Contains(listOut, filepath.ToSlash(emptyPath)) {
+		t.Fatalf("reclaimed worktree is not registered at %s:\n%s", emptyPath, listOut)
+	}
+	if _, err := os.Stat(filepath.Join(emptyPath, "README.md")); err != nil {
+		t.Fatalf("reclaimed worktree was not populated: %v", err)
+	}
+}
+
 func TestReturnFromInsideWorktreeDoesNotTerminateCaller(t *testing.T) {
 	repoDir, homeDir := setupTestRepo(t)
 	env := []string{"SHELL=" + exitShellBin}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -167,9 +167,11 @@ func acquire(repoRoot, poolDir string, poolSize int, postCreate []string, opts a
 			return fmt.Errorf("all %d worktrees are in use or dirty (max_trees = %d). Run 'treehouse status' to see details, or increase max_trees in treehouse.toml", len(state.Worktrees), poolSize)
 		}
 
-		name := nextName(state)
 		repoName := filepath.Base(repoRoot)
-		wtPath := filepath.Join(poolDir, name, repoName)
+		name, wtPath, err := nextWorktreeTarget(state, poolDir, repoName, opts.hookStderr)
+		if err != nil {
+			return err
+		}
 
 		if err := os.MkdirAll(filepath.Dir(wtPath), 0755); err != nil {
 			return err
@@ -187,6 +189,9 @@ func acquire(repoRoot, poolDir string, poolSize int, postCreate []string, opts a
 		// real error if one exists.
 		if err := git.PruneWorktrees(repoRoot); err != nil {
 			fmt.Fprintf(os.Stderr, "🌳 Warning: failed to prune stale worktrees: %v\n", err)
+		}
+		if err := validateWorktreeTarget(filepath.Dir(wtPath), wtPath); err != nil {
+			return err
 		}
 
 		if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
@@ -486,12 +491,118 @@ func cwdInWorktree(cwd, worktreePath string) bool {
 	return rel == "." || !filepath.IsAbs(rel) && len(rel) >= 1 && rel[0] != '.'
 }
 
-func nextName(state State) string {
+func nextWorktreeTarget(state State, poolDir, repoName string, diagnostics io.Writer) (string, string, error) {
+	maxInt := int(^uint(0) >> 1)
 	max := 0
 	for _, wt := range state.Worktrees {
 		if n, err := strconv.Atoi(wt.Name); err == nil && n > max {
 			max = n
 		}
 	}
-	return strconv.Itoa(max + 1)
+
+	slots, err := os.ReadDir(poolDir)
+	if err != nil {
+		return "", "", fmt.Errorf("scan pool slots: %w", err)
+	}
+	maxOnDisk := max
+	for _, slot := range slots {
+		if n, err := strconv.Atoi(slot.Name()); err == nil && n > maxOnDisk {
+			maxOnDisk = n
+		}
+	}
+	if maxOnDisk == maxInt {
+		return "", "", fmt.Errorf("cannot allocate another numeric pool slot after %d", maxOnDisk)
+	}
+
+	upper := maxOnDisk + 1
+	const maxFrontierRetries = 16
+	frontierRetries := 0
+	for n := max + 1; ; n++ {
+		name := strconv.Itoa(n)
+		slotDir := filepath.Join(poolDir, name)
+		wtPath := filepath.Join(slotDir, repoName)
+
+		usable, obstaclePath, reason := prepareWorktreeTarget(slotDir, wtPath)
+		if usable {
+			return name, wtPath, nil
+		}
+		warnSkippedSlot(diagnostics, obstaclePath, name, reason)
+
+		if n == upper {
+			if frontierRetries == maxFrontierRetries || upper == maxInt {
+				return "", "", fmt.Errorf("no usable pool slot found after inspecting slots %d through %d", max+1, upper)
+			}
+			upper++
+			frontierRetries++
+		}
+	}
+}
+
+func prepareWorktreeTarget(slotDir, wtPath string) (bool, string, error) {
+	slotInfo, err := os.Lstat(slotDir)
+	switch {
+	case os.IsNotExist(err):
+		return true, "", nil
+	case err != nil:
+		return false, slotDir, err
+	case !slotInfo.IsDir():
+		return false, slotDir, fmt.Errorf("slot path is not an ordinary directory")
+	}
+
+	slotEntries, err := os.ReadDir(slotDir)
+	if err != nil {
+		return false, slotDir, err
+	}
+
+	info, err := os.Lstat(wtPath)
+	switch {
+	case os.IsNotExist(err):
+		if len(slotEntries) == 0 {
+			return true, "", nil
+		}
+		return false, slotDir, fmt.Errorf("slot contains unmanaged content")
+	case err != nil:
+		return false, wtPath, err
+	case !info.IsDir():
+		return false, wtPath, fmt.Errorf("worktree path is not an ordinary directory")
+	case len(slotEntries) != 1:
+		return false, slotDir, fmt.Errorf("slot contains unmanaged content alongside the worktree path")
+	}
+
+	entries, err := os.ReadDir(wtPath)
+	if err != nil {
+		return false, wtPath, err
+	}
+	if len(entries) != 0 {
+		return false, wtPath, fmt.Errorf("directory is not empty")
+	}
+
+	// os.Remove is the final emptiness check. If content appears after ReadDir,
+	// removal fails and the slot remains quarantined.
+	if err := os.Remove(wtPath); err != nil {
+		return false, wtPath, err
+	}
+	return true, "", nil
+}
+
+func validateWorktreeTarget(slotDir, wtPath string) error {
+	info, err := os.Lstat(slotDir)
+	if err != nil {
+		return fmt.Errorf("validate pool slot %s: %w", slotDir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("pool slot changed before worktree creation: %s is not an ordinary directory", slotDir)
+	}
+	entries, err := os.ReadDir(slotDir)
+	if err != nil {
+		return fmt.Errorf("validate pool slot %s: %w", slotDir, err)
+	}
+	if len(entries) != 0 {
+		return fmt.Errorf("pool slot changed before worktree creation: %s is no longer empty; leaving it in place", wtPath)
+	}
+	return nil
+}
+
+func warnSkippedSlot(diagnostics io.Writer, path, name string, reason error) {
+	fmt.Fprintf(diagnostics, "🌳 Warning: pool slot %s is blocked by an unmanaged path at %s; leaving it in place (%v). Inspect and move or remove it manually; trying the next slot.\n", name, path, reason)
 }

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1,11 +1,13 @@
 package pool
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -116,6 +118,163 @@ func TestAcquire_HookFailureDoesNotFailAcquire(t *testing.T) {
 	// The second hook must still have run despite the first failing.
 	if _, err := os.Stat(filepath.Join(wtPath, "second-ran.txt")); err != nil {
 		t.Fatalf("expected second hook to run despite first failing: %v", err)
+	}
+}
+
+func TestNextWorktreeTargetReclaimsEmptyDirectory(t *testing.T) {
+	poolDir := t.TempDir()
+	repoName := "myrepo"
+	emptyPath := filepath.Join(poolDir, "1", repoName)
+	if err := os.MkdirAll(emptyPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var diagnostics bytes.Buffer
+	name, path, err := nextWorktreeTarget(State{}, poolDir, repoName, &diagnostics)
+	if err != nil {
+		t.Fatalf("nextWorktreeTarget failed: %v", err)
+	}
+	if name != "1" || path != emptyPath {
+		t.Fatalf("target = (%q, %q), want (%q, %q)", name, path, "1", emptyPath)
+	}
+	if _, err := os.Stat(emptyPath); !os.IsNotExist(err) {
+		t.Fatalf("empty remnant was not removed: %v", err)
+	}
+	if diagnostics.Len() != 0 {
+		t.Fatalf("unexpected diagnostics: %s", diagnostics.String())
+	}
+}
+
+func TestNextWorktreeTargetPreservesObstaclesAndUsesNextSlot(t *testing.T) {
+	tests := []struct {
+		name  string
+		plant func(t *testing.T, target string)
+	}{
+		{
+			name: "non-empty directory",
+			plant: func(t *testing.T, target string) {
+				t.Helper()
+				if err := os.MkdirAll(target, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(target, "work.txt"), []byte("preserve\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "file",
+			plant: func(t *testing.T, target string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(target, []byte("preserve\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "unexpected slot content",
+			plant: func(t *testing.T, target string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(filepath.Dir(target), "unknown.txt"), []byte("preserve\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "empty target with unexpected sibling",
+			plant: func(t *testing.T, target string) {
+				t.Helper()
+				if err := os.MkdirAll(target, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(filepath.Dir(target), "unknown.txt"), []byte("preserve\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			poolDir := t.TempDir()
+			repoName := "myrepo"
+			obstacle := filepath.Join(poolDir, "1", repoName)
+			tt.plant(t, obstacle)
+
+			var diagnostics bytes.Buffer
+			name, path, err := nextWorktreeTarget(State{}, poolDir, repoName, &diagnostics)
+			if err != nil {
+				t.Fatalf("nextWorktreeTarget failed: %v", err)
+			}
+			wantPath := filepath.Join(poolDir, "2", repoName)
+			if name != "2" || path != wantPath {
+				t.Fatalf("target = (%q, %q), want (%q, %q)", name, path, "2", wantPath)
+			}
+			if _, err := os.Lstat(filepath.Join(poolDir, "1")); err != nil {
+				t.Fatalf("slot obstacle was not preserved: %v", err)
+			}
+			if !strings.Contains(diagnostics.String(), filepath.Join(poolDir, "1")) ||
+				!strings.Contains(diagnostics.String(), "trying the next slot") {
+				t.Fatalf("diagnostic is not actionable: %s", diagnostics.String())
+			}
+		})
+	}
+}
+
+func TestNextWorktreeTargetSkipsConsecutiveObstacles(t *testing.T) {
+	poolDir := t.TempDir()
+	repoName := "myrepo"
+	for n := 1; n <= 3; n++ {
+		target := filepath.Join(poolDir, strconv.Itoa(n), repoName)
+		if err := os.MkdirAll(target, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(target, "work.txt"), []byte("preserve\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var diagnostics bytes.Buffer
+	name, path, err := nextWorktreeTarget(State{}, poolDir, repoName, &diagnostics)
+	if err != nil {
+		t.Fatalf("nextWorktreeTarget failed: %v", err)
+	}
+	wantPath := filepath.Join(poolDir, "4", repoName)
+	if name != "4" || path != wantPath {
+		t.Fatalf("target = (%q, %q), want (%q, %q)", name, path, "4", wantPath)
+	}
+	if got := strings.Count(diagnostics.String(), "trying the next slot"); got != 3 {
+		t.Fatalf("warning count = %d, want 3: %s", got, diagnostics.String())
+	}
+}
+
+func TestAcquireLeaseSkipsNonEmptyUnmanagedSlotWithoutConsumingCapacity(t *testing.T) {
+	repoDir, poolDir := setupLocalRepo(t)
+	obstacle := filepath.Join(poolDir, "1", filepath.Base(repoDir))
+	if err := os.MkdirAll(obstacle, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(obstacle, "work.txt")
+	if err := os.WriteFile(marker, []byte("preserve\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	leased, err := AcquireLeaseInfoWithOptions(repoDir, poolDir, 1, nil, "test", AcquireOptions{SkipFetch: true})
+	if err != nil {
+		t.Fatalf("AcquireLeaseInfoWithOptions failed: %v", err)
+	}
+	want := filepath.Join(poolDir, "2", filepath.Base(repoDir))
+	if leased.Path != want {
+		t.Fatalf("leased path = %q, want %q", leased.Path, want)
+	}
+	if data, err := os.ReadFile(marker); err != nil || string(data) != "preserve\n" {
+		t.Fatalf("unmanaged work was not preserved: data=%q err=%v", data, err)
 	}
 }
 

--- a/internal/pool/state_unix_test.go
+++ b/internal/pool/state_unix_test.go
@@ -78,3 +78,55 @@ func TestList_CorruptRecoveryFailsClosedWhenSlotUnreadable(t *testing.T) {
 		t.Fatalf("state file was rewritten after incomplete recovery: %s", data)
 	}
 }
+
+func TestPrepareWorktreeTargetPreservesUnreadableEmptyDirectory(t *testing.T) {
+	poolDir := t.TempDir()
+	slotDir := filepath.Join(poolDir, "1")
+	wtPath := filepath.Join(slotDir, "myrepo")
+	if err := os.MkdirAll(wtPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(wtPath, 0); err != nil {
+		t.Fatalf("Chmod unreadable: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(wtPath, 0o755); err != nil {
+			t.Fatalf("restore permissions: %v", err)
+		}
+	})
+
+	usable, obstaclePath, err := prepareWorktreeTarget(slotDir, wtPath)
+	if usable || err == nil {
+		t.Fatalf("unreadable target result = usable %v, path %q, err %v; want preserved obstacle", usable, obstaclePath, err)
+	}
+	if obstaclePath != wtPath {
+		t.Fatalf("obstacle path = %q, want %q", obstaclePath, wtPath)
+	}
+	if _, err := os.Lstat(wtPath); err != nil {
+		t.Fatalf("unreadable target was removed: %v", err)
+	}
+}
+
+func TestPrepareWorktreeTargetDoesNotFollowSlotSymlink(t *testing.T) {
+	poolDir := t.TempDir()
+	externalSlot := filepath.Join(t.TempDir(), "external-slot")
+	externalWorktree := filepath.Join(externalSlot, "myrepo")
+	if err := os.MkdirAll(externalWorktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	slotDir := filepath.Join(poolDir, "1")
+	if err := os.Symlink(externalSlot, slotDir); err != nil {
+		t.Fatal(err)
+	}
+
+	usable, obstaclePath, err := prepareWorktreeTarget(slotDir, filepath.Join(slotDir, "myrepo"))
+	if usable || err == nil {
+		t.Fatalf("symlinked slot result = usable %v, path %q, err %v; want preserved obstacle", usable, obstaclePath, err)
+	}
+	if obstaclePath != slotDir {
+		t.Fatalf("obstacle path = %q, want %q", obstaclePath, slotDir)
+	}
+	if _, err := os.Stat(externalWorktree); err != nil {
+		t.Fatalf("external directory was removed through slot symlink: %v", err)
+	}
+}


### PR DESCRIPTION
An unregistered directory left at the next pool slot currently causes every later `treehouse get` to fail with `already exists`. Recovery must avoid deleting possible user work while still allowing the pool to allocate another isolated worktree.

## Approach

- Inspect numeric slot paths before creating a worktree.
- Reclaim only verified empty ordinary directories, using `os.Remove` as the final race-safe emptiness check.
- Preserve non-empty, unreadable, symlinked, or otherwise unexpected paths and print an actionable warning to stderr.
- Continue allocation in the next numeric slot without counting unmanaged obstacles against `max_trees`.
- Revalidate the selected slot immediately before `git worktree add` and retain the existing stale-registration prune behavior.

## Verification

- Focused pool and CLI recovery tests pass, including empty-slot reclamation, non-empty preservation, consecutive obstacles, lease allocation with `max_trees = 1`, and issue #30 regression coverage.
- Linux pool tests compile successfully, including Unix-only unreadable-directory and symlink safety cases.
- Linux and macOS cross-builds pass.
- The complete Windows E2E suite did not finish: the `cmd` package stalled in existing process-lifecycle coverage and was killed by its timeout. An earlier run also exposed the machine's `safe.bareRepository=explicit` policy in an unrelated prune test.

Closes #59