### PR TITLE
fix(nix): declare Python check dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,13 @@ jobs:
 
       - name: Build
         run: go build -o treehouse${{ matrix.os == 'windows-latest' && '.exe' || '' }} .
+
+  nix-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build Nix package
+        run: nix build -L --no-link .#default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,3 @@ jobs:
 
       - name: Build
         run: go build -o treehouse${{ matrix.os == 'windows-latest' && '.exe' || '' }} .
-
-  nix-package:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Build Nix package
-        run: nix build -L --no-link .#default

--- a/.github/workflows/nix-package.yml
+++ b/.github/workflows/nix-package.yml
@@ -1,0 +1,33 @@
+name: Nix Package
+
+# This workflow cannot live in ci.yml: ci.yml's pull_request trigger ignores
+# flake.nix, so a flake-only human PR would match every ignore pattern and
+# never receive the pre-merge package build. It cannot simply drop flake.nix
+# from that ignore list either, because release-please bumps flake.nix as an
+# extra-files output and path filters cannot express "flake.nix changed, but
+# not by release-please".
+#
+# Keying this dedicated trigger on the flake files closes that gap. The key is
+# itself a release-please output, so every job skips release-please branches
+# structurally instead; release-please's own GITHUB_TOKEN-opened PRs never
+# create runs at all.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - flake.nix
+      - flake.lock
+
+jobs:
+  nix-package:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') && !startsWith(github.head_ref, 'release-please/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build Nix package
+        run: nix build -L --no-link .#default

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,10 @@
             ldflags = [
               "-X main.version=v${version}"
             ];
-            nativeCheckInputs = [ pkgs.git ];
+            nativeCheckInputs = [
+              pkgs.git
+              pkgs.python3
+            ];
           };
         }
       );

--- a/release_ci_exclusions_test.go
+++ b/release_ci_exclusions_test.go
@@ -26,7 +26,9 @@ type releasePleasePackage struct {
 // expectedReleaseOutputs derives the complete set of paths release-please
 // writes for this repository from release-please-config.json. The set is
 // the source of truth for pull_request path filters: every PR-triggered
-// workflow must exclude every path here, or release PRs start creating
+// workflow must either exclude every path here or, when its trigger is keyed
+// ON one of these paths, guard every job against release-please PRs
+// (see releasePleaseUnguardedJobs); otherwise release PRs start creating
 // action_required runs again.
 func expectedReleaseOutputs(cfg releasePleaseConfig) ([]string, error) {
 	if len(cfg.Packages) == 0 {
@@ -312,6 +314,39 @@ func publishesRequiredCheck(data []byte) (bool, error) {
 	return false, nil
 }
 
+// releasePleaseUnguardedJobs returns the job IDs of a workflow whose `if:`
+// does not skip release-please PR branches. A workflow keyed to a
+// release-please output cannot exclude that output by path - the trigger key
+// is the output - so guarding every job is the alternative mechanism that
+// keeps automated release work quiet when a human pushes to a release branch;
+// release-please's own GITHUB_TOKEN-opened PRs create no runs at all. The
+// guard must name github.head_ref and both branch prefixes release.yml uses
+// to identify release PRs. An unguarded job fails closed.
+func releasePleaseUnguardedJobs(data []byte) ([]string, error) {
+	var wf struct {
+		Jobs map[string]struct {
+			If string `yaml:"if"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		return nil, err
+	}
+	if len(wf.Jobs) == 0 {
+		return nil, fmt.Errorf("workflow declares no jobs")
+	}
+	var unguarded []string
+	for job, spec := range wf.Jobs {
+		ok := strings.Contains(spec.If, "github.head_ref") &&
+			strings.Contains(spec.If, "'release-please--'") &&
+			strings.Contains(spec.If, "'release-please/'")
+		if !ok {
+			unguarded = append(unguarded, job)
+		}
+	}
+	sort.Strings(unguarded)
+	return unguarded, nil
+}
+
 func TestPullRequestWorkflowsExcludeReleasePleaseOutputs(t *testing.T) {
 	cfgBytes, err := os.ReadFile("release-please-config.json")
 	if err != nil {
@@ -382,8 +417,17 @@ func TestPullRequestWorkflowsExcludeReleasePleaseOutputs(t *testing.T) {
 			}
 		}
 		if len(missing) > 0 {
-			t.Errorf("%s pull_request filter must exclude every release-please output; missing: %s",
-				path, strings.Join(missing, ", "))
+			unguarded, err := releasePleaseUnguardedJobs(data)
+			if err != nil {
+				t.Fatalf("%s: %v", path, err)
+			}
+			if len(unguarded) > 0 {
+				t.Errorf("%s pull_request filter must exclude every release-please output (missing: %s), or every job must skip release-please branches via github.head_ref; jobs without the guard: %s",
+					path, strings.Join(missing, ", "), strings.Join(unguarded, ", "))
+			} else {
+				t.Logf("%s keys on a release-please output (%s); every job skips release-please branches instead",
+					path, strings.Join(missing, ", "))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- provide Python only during Nix package checks so the no-mistakes gate fixtures can parse attestation JSON
- build the default Nix package in a dedicated flake-triggered Linux workflow
- preserve quiet automated release PRs while ensuring flake-only human PRs receive pre-merge Nix coverage

## Validation

- `nix build -L --no-link .#default` (runs the full Go suite in isolated `checkPhase`)
- `go test ./...`
- focused workflow/release-policy tests
- `go vet ./...`
- `gofmt -l .`
- Windows cross-build
- verified Python is absent from the installed package runtime closure

The no-mistakes validation service was explicitly bypassed with maintainer approval after its Nix-managed validator repeatedly failed to return parseable output; the preserved review fix was recovered and all checks above were run manually.