### PR TITLE
fix(nix): add python3 to nativeCheckInputs for the gate tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,11 @@
             ldflags = [
               "-X main.version=v${version}"
             ];
-            nativeCheckInputs = [ pkgs.git ];
+            # git for the VCS tests; python3 for the no-mistakes gate
+            # script's attestation parser, which the gate tests execute
+            # (GitHub runners have python3 ambiently, the nix sandbox does
+            # not - see issue #115).
+            nativeCheckInputs = [ pkgs.git pkgs.python3 ];
           };
         }
       );


### PR DESCRIPTION
## Intent

Fix upstream issue kunchenguid/treehouse#115: nix sandbox builds of the flake package fail in the check phase because TestNoMistakesGateDecisions executes .github/scripts/no-mistakes-gate.sh, whose attestation parser requires python3, and nativeCheckInputs only declared git (GitHub runners have python3 ambiently; the hermetic sandbox does not). One one-line-plus-comment commit adds pkgs.python3 to nativeCheckInputs. Verified for real: nix build .#default now passes the full check phase in the sandbox (it fails identically to the issue repro without the fix). This is a nix packaging fix only; no Go code changes. Do not expand scope.

## What Changed
- Added `pkgs.python3` to `nativeCheckInputs` in `flake.nix` so the flake package's check phase can run `TestNoMistakesGateDecisions`, which executes `.github/scripts/no-mistakes-gate.sh` and its python3-based attestation parser. Hermetic nix sandbox builds previously failed here because only `git` was declared (GitHub runners provide python3 ambiently; the sandbox does not — issue #115).
- Added a comment on the `nativeCheckInputs` line documenting why both inputs are required.

## Risk Assessment

✅ Low: A one-line nix packaging change adding python3 to check-phase inputs, matching a verified runtime dependency of the gate script the tests execute, with no Go code or behavior changes.

## Testing

Reproduced issue #115 for real: with the fix reverted, nix build .#default fails in the check phase with TestNoMistakesGateDecisions failures caused by python3 being absent from the build PATH; with the fix restored, a forced fresh rebuild passes the entire check phase and yields a working treehouse v2.3.0 binary. Note this machine has nix sandbox=false (macOS), but nix's input-restricted build PATH reproduces the identical failure mechanism the sandbox exposes on Linux.

<details>
<summary>Evidence: nix build failure without the fix (check-phase FAIL excerpt)</summary>

<code>--- FAIL: TestNoMistakesGateDecisions (0.61s)&#10;--- FAIL: TestNoMistakesGateDecisions/human_PR_carrying_the_no-mistakes_signature_and_completed_attestation_passes (0.02s)&#10;--- FAIL: TestNoMistakesGateDecisions/human_PR_with_skipped_review_fails (0.03s)&#10;... (all attestation subtests fail: gate script finds neither python3 nor python on the nix build PATH)&#10;FAIL github.com/kunchenguid/treehouse 1.295s</code>

```text
treehouse>     --- FAIL: TestNoMistakesGateDecisions/human_PR_with_attestation_JSON_missing_head_sha_fails (0.03s)
treehouse>         no_mistakes_gate_test.go:486: gate output missing "not bound to the current pull request head"
treehouse>             ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
treehouse> 
treehouse>             This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
treehouse>             Older no-mistakes that only writes the signature line is not enough.
treehouse>             Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
treehouse> 
treehouse>                 <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
treehouse> 
treehouse>             PR author: kunchenguid
treehouse> --- FAIL: TestReleaseWorkflowGateStatusWiring (0.48s)
treehouse>     --- FAIL: TestReleaseWorkflowGateStatusWiring/attestation_cannot_widen_structural_release_path (0.16s)
treehouse>         no_mistakes_gate_test.go:670: missing rejection output "pull request head:    (missing)":
treehouse>             ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
treehouse> 
treehouse>             This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
treehouse>             Older no-mistakes that only writes the signature line is not enough.
treehouse>             Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
treehouse> 
treehouse>                 <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
treehouse> 
treehouse>             PR author: structural-release-please-check
treehouse>             PR #78 is not a structural release-please PR; leaving it to the required check.
treehouse> FAIL
treehouse> FAIL github.com/kunchenguid/treehouse        1.295s
treehouse> FAIL
❌ git+file:///Users/Jack/.no-mistakes/worktrees/e98804941861/01M0QE2BJ2T0G2MK6BXVJR0E5D#default
error: Cannot build '/nix/store/p897csp36pch0jzdij48jsswb24rk7i7-treehouse-2.3.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/r32fi65ax2v0sl047yyqbpm0286nxxyd-treehouse-2.3.0
       Last 25 log lines:
       >             ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
       >
       >             This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
       >             Older no-mistakes that only writes the signature line is not enough.
       >             Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
       >
       >                 <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
       >
       >             PR author: kunchenguid
       > --- FAIL: TestReleaseWorkflowGateStatusWiring (0.48s)
       >     --- FAIL: TestReleaseWorkflowGateStatusWiring/attestation_cannot_widen_structural_release_path (0.16s)
       >         no_mistakes_gate_test.go:670: missing rejection output "pull request head:    (missing)":
       >             ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
       >
       >             This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
       >             Older no-mistakes that only writes the signature line is not enough.
       >             Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
       >
       >                 <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
       >
       >             PR author: structural-release-please-check
       >             PR #78 is not a structural release-please PR; leaving it to the required check.
       > FAIL
       > FAIL   github.com/kunchenguid/treehouse        1.295s
       > FAIL
       For full logs, run:
         nix log /nix/store/p897csp36pch0jzdij48jsswb24rk7i7-treehouse-2.3.0.drv
```
</details>
<details>
<summary>Evidence: full unfixed build log</summary>

```text
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/ynb07wdrl6pp99nzvzv0a4q3fdcmcyry-dvp4yazwfqcsk6z6wr6adb975z7xwbqh-source
source root is dvp4yazwfqcsk6z6wr6adb975z7xwbqh-source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Building subPackage .
Building subPackage ./cmd
Building subPackage ./internal/config
Building subPackage ./internal/hooks
Building subPackage ./internal/pool
Building subPackage ./internal/process
Building subPackage ./internal/shell
Building subPackage ./internal/ui
Building subPackage ./internal/updater
Building subPackage ./internal/vcs
Building subPackage ./internal/vcs/gitvcs
Building subPackage ./internal/vcs/jjvcs
Running phase: checkPhase
@nix { "action": "setPhase", "phase": "checkPhase" }
--- FAIL: TestNoMistakesGateDecisions (0.61s)
    --- FAIL: TestNoMistakesGateDecisions/human_PR_carrying_the_no-mistakes_signature_and_completed_attestation_passes (0.02s)
        no_mistakes_gate_test.go:482: gate pass = false, want true
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
    --- FAIL: TestNoMistakesGateDecisions/human_PR_with_skipped_review_fails (0.03s)
        no_mistakes_gate_test.go:486: gate output missing "review: skipped"
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
    --- FAIL: TestNoMistakesGateDecisions/human_PR_with_failed_test_fails (0.03s)
        no_mistakes_gate_test.go:486: gate output missing "test: failed"
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
    --- FAIL: TestNoMistakesGateDecisions/human_PR_with_pending_document_fails (0.03s)
        no_mistakes_gate_test.go:486: gate output missing "document: pending"
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
    --- FAIL: TestNoMistakesGateDecisions/human_PR_with_running_document_fails (0.03s)
        no_mistakes_gate_test.go:486: gate output missing "document: running"
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
    --- FAIL: TestNoMistakesGateDecisions/human_PR_missing_the_document_step_fails (0.03s)
        no_mistakes_gate_test.go:486: gate output missing "document: missing"
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
    --- FAIL: TestNoMistakesGateDecisions/human_PR_with_attestation_for_a_different_head_SHA_fails (0.03s)
        no_mistakes_gate_test.go:486: gate output missing "not bound to the current pull request head"
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
    --- FAIL: TestNoMistakesGateDecisions/human_PR_with_empty_attestation_head_sha_fails (0.03s)
        no_mistakes_gate_test.go:486: gate output missing "not bound to the current pull request head"
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
    --- FAIL: TestNoMistakesGateDecisions/human_PR_with_attestation_JSON_missing_head_sha_fails (0.03s)
        no_mistakes_gate_test.go:486: gate output missing "not bound to the current pull request head"
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: kunchenguid
--- FAIL: TestReleaseWorkflowGateStatusWiring (0.48s)
    --- FAIL: TestReleaseWorkflowGateStatusWiring/attestation_cannot_widen_structural_release_path (0.16s)
        no_mistakes_gate_test.go:670: missing rejection output "pull request head:    (missing)":
            ::error::This PR has the no-mistakes signature but no parseable pipeline step attestation.
            
            This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670).
            Older no-mistakes that only writes the signature line is not enough.
            Submit via 'git push no-mistakes' with a current no-mistakes so the PR body includes:
            
                <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->
            
            PR author: structural-release-please-check
            PR #78 is not a structural release-please PR; leaving it to the required check.
FAIL
FAIL	github.com/kunchenguid/treehouse	1.295s
FAIL
```
</details>
<details>
<summary>Evidence: nix build with the fix — fresh forced rebuild, full check phase passes</summary>

<code>Running phase: checkPhase&#10;ok github.com/kunchenguid/treehouse 1.828s&#10;ok github.com/kunchenguid/treehouse/cmd 41.809s&#10;... all 10 packages ok ...&#10;Running phase: installPhase&#10;$ /nix/store/j6rm...-treehouse-2.3.0/bin/treehouse --version&#10;v2.3.0</code>

```text
checking outputs of '/nix/store/3sy4nj0l738vckfxkbvhy4gl9f2z1vz1-treehouse-2.3.0.drv'...
treehouse> Running phase: unpackPhase
treehouse> unpacking source archive /nix/store/z2pk2yx41bvbfvqq7kdv79fibgpvg6pc-1pa922kv56hm0l46y3bfx3vafcsv6yfh-source
treehouse> source root is 1pa922kv56hm0l46y3bfx3vafcsv6yfh-source
treehouse> Running phase: patchPhase
treehouse> Running phase: updateAutotoolsGnuConfigScriptsPhase
treehouse> Running phase: configurePhase
treehouse> Running phase: buildPhase
treehouse> Building subPackage .
treehouse> Building subPackage ./cmd
treehouse> Building subPackage ./internal/config
treehouse> Building subPackage ./internal/hooks
treehouse> Building subPackage ./internal/pool
treehouse> Building subPackage ./internal/process
treehouse> Building subPackage ./internal/shell
treehouse> Building subPackage ./internal/ui
treehouse> Building subPackage ./internal/updater
treehouse> Building subPackage ./internal/vcs
treehouse> Building subPackage ./internal/vcs/gitvcs
treehouse> Building subPackage ./internal/vcs/jjvcs
treehouse> Running phase: checkPhase
treehouse> ok   github.com/kunchenguid/treehouse        1.828s
treehouse> ok   github.com/kunchenguid/treehouse/cmd    41.809s
treehouse> ok   github.com/kunchenguid/treehouse/internal/config        2.349s
treehouse> ok   github.com/kunchenguid/treehouse/internal/hooks 0.144s
treehouse> ok   github.com/kunchenguid/treehouse/internal/pool  39.302s
treehouse> ok   github.com/kunchenguid/treehouse/internal/process       6.562s
treehouse> ok   github.com/kunchenguid/treehouse/internal/updater       0.195s
treehouse> ok   github.com/kunchenguid/treehouse/internal/vcs   0.297s
treehouse> ok   github.com/kunchenguid/treehouse/internal/vcs/gitvcs    3.578s
treehouse> ok   github.com/kunchenguid/treehouse/internal/vcs/jjvcs     0.149s
treehouse> checkPhase completed in 1 minutes 49 seconds
treehouse> Running phase: installPhase
treehouse> Running phase: fixupPhase
treehouse> checking for references to /nix/var/nix/builds/nix-56310-1814706186/ in /nix/store/m1sdgx6d0r4zl0xli46q1r9jghs6i0v4-treehouse-2.3.0...
treehouse> patching script interpreter paths in /nix/store/m1sdgx6d0r4zl0xli46q1r9jghs6i0v4-treehouse-2.3.0
treehouse> stripping (with command strip and flags -S) in  /nix/store/m1sdgx6d0r4zl0xli46q1r9jghs6i0v4-treehouse-2.3.0/bin
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"04be0fed50928e1014b99e803eea09a3eb719ff7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 5aafb9e..04be0fe` — confirmed the change is exactly the one-line nativeCheckInputs addition plus comment in flake.nix, no Go changes</code>
- <code>Negative repro: reverted `nativeCheckInputs` to `[ pkgs.git ]` and ran `nix build .#default -L` — check phase failed with `--- FAIL: TestNoMistakesGateDecisions` (all attestation subtests) because the gate script&#39;s python3/python PATH lookup finds nothing in the restricted nix build environment</code>
- <code>Positive: restored flake.nix to the target commit (verified via `git diff --quiet 04be0fe -- flake.nix`) and ran `nix build .#default -L --rebuild` — forced fresh build passed the full checkPhase, all 10 Go packages ok including the root package containing TestNoMistakesGateDecisions</code>
- <code>Ran the built artifact `/nix/store/...-treehouse-2.3.0/bin/treehouse --version` → v2.3.0</code>
- <code>Confirmed worktree left clean (`git status --short` empty; used --no-link so no result symlink)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
