### PR TITLE
fix(updater): replace a running Windows exe without a fixed .old backup

### DIFF
--- a/internal/updater/testdata/holdopen/main.go
+++ b/internal/updater/testdata/holdopen/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "time"
+
+func main() {
+	time.Sleep(30 * time.Second)
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -619,10 +619,32 @@ func atomicReplace(target, newBinary string) error {
 
 	// Atomic rename
 	if err := os.Rename(tmpPath, target); err != nil {
+		if runtime.GOOS == "windows" {
+			if werr := replaceRunningWindows(target, tmpPath); werr == nil {
+				return nil
+			}
+		}
 		os.Remove(tmpPath)
 		return err
 	}
 
+	return nil
+}
+
+// replaceRunningWindows moves a locked running image aside, then places the
+// new binary at the original path. Windows allows renaming a mapped .exe even
+// though overwriting it in place returns Access is denied.
+func replaceRunningWindows(target, tmpPath string) error {
+	oldPath := target + ".old"
+	_ = os.Remove(oldPath)
+	if err := os.Rename(target, oldPath); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		_ = os.Rename(oldPath, target)
+		return err
+	}
+	_ = os.Remove(oldPath)
 	return nil
 }
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -634,9 +634,12 @@ func atomicReplace(target, newBinary string) error {
 // replaceRunningWindows moves a locked running image aside, then places the
 // new binary at the original path. Windows allows renaming a mapped .exe even
 // though overwriting it in place returns Access is denied.
+//
+// The backup name is unique per attempt. A prior update can leave target.old
+// mapped by a still-running process, so a fixed .old path cannot be removed
+// or reused as the next rename destination.
 func replaceRunningWindows(target, tmpPath string) error {
-	oldPath := target + ".old"
-	_ = os.Remove(oldPath)
+	oldPath := fmt.Sprintf("%s.old.%d.%d", target, os.Getpid(), time.Now().UnixNano())
 	if err := os.Rename(target, oldPath); err != nil {
 		return err
 	}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -619,6 +620,49 @@ func TestApplyE2E(t *testing.T) {
 		if info.Mode()&0o111 == 0 {
 			t.Error("expected executable permissions on replaced binary")
 		}
+	}
+}
+
+func TestAtomicReplaceRunningWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows running-image replacement")
+	}
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "hold.exe")
+	holdSrc := filepath.Join("testdata", "holdopen", "main.go")
+	build := exec.Command("go", "build", "-o", targetPath, holdSrc)
+	out, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build holdopen: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(targetPath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start holdopen: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	newBinaryPath := filepath.Join(dir, "new.bin")
+	newContent := []byte("replacement-bytes")
+	if err := os.WriteFile(newBinaryPath, newContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicReplace(targetPath, newBinaryPath); err != nil {
+		t.Fatalf("atomicReplace running windows exe: %v", err)
+	}
+
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(newContent) {
+		t.Errorf("replaced = %q, want %q", string(got), string(newContent))
 	}
 }
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -666,6 +666,53 @@ func TestAtomicReplaceRunningWindows(t *testing.T) {
 	}
 }
 
+func TestReplaceRunningWindowsStaleOld(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows running-image replacement")
+	}
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "hold.exe")
+	staleOld := targetPath + ".old"
+	holdSrc := filepath.Join("testdata", "holdopen", "main.go")
+	build := exec.Command("go", "build", "-o", staleOld, holdSrc)
+	out, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build holdopen: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(staleOld)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start leftover .old: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	if err := os.WriteFile(targetPath, []byte("current-bytes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := filepath.Join(dir, "new.bin")
+	newContent := []byte("replacement-bytes")
+	if err := os.WriteFile(tmpPath, newContent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := replaceRunningWindows(targetPath, tmpPath); err != nil {
+		t.Fatalf("replaceRunningWindows with mapped leftover .old: %v", err)
+	}
+
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(newContent) {
+		t.Errorf("replaced = %q, want %q", string(got), string(newContent))
+	}
+}
+
 func TestRequireHTTPS(t *testing.T) {
 	if err := requireHTTPS("https://example.com/file"); err != nil {
 		t.Errorf("expected no error for HTTPS URL, got: %v", err)


### PR DESCRIPTION
## Intent

Handle GitHub inbox for treehouse PR 121. Maintainer firstmate already reviewed the Windows running-exe replace as restore, Greptile is SUCCESS, and fork CI was approved. The remaining block is the required check PR must be raised via no-mistakes: the body has no Pipeline attestation. Re-raise this existing committed branch through git push no-mistakes so the PR body gets a Pipeline section bound to the current head. Do not change the Windows replaceRunningWindows behavior unless review finds a real defect. Tests: TestAtomicReplaceRunningWindows and TestReplaceRunningWindowsStaleOld on windows, plus existing updater package tests.

## What Changed

- On Windows, when `atomicReplace` cannot rename onto a mapped running image, fall back to `replaceRunningWindows`: move the locked exe aside, then place the new binary at the original path.
- Use a per-attempt backup name (`target.old.<pid>.<nanos>`) so a leftover mapped `.old` from a prior update cannot block the next rename.
- Add Windows-only coverage (`TestAtomicReplaceRunningWindows`, `TestReplaceRunningWindowsStaleOld`) plus a short-lived `testdata/holdopen` helper that keeps an exe mapped during the replace.

## Risk Assessment

✅ Low: Well-bounded Windows updater fix: rename-aside with a unique .old backup when overwrite of a mapped exe fails, covered by behavioral Windows tests, with no source-verifiable defect or intent contradiction.

## Testing

Exercised the Windows running-exe self-update path on this host: both focused replace tests and the full updater package passed, and a manual rename demo showed the same unique-backup behavior the fix relies on. No product defect turned up, so replaceRunningWindows was left unchanged.

<details>
<summary>Evidence: Focused Windows replace tests (verbose PASS)</summary>

Source: Focused Windows replace tests (verbose PASS) (local file: <code>~\.no-mistakes\evidence\01M1PZ8R00MDCAW84BF1K8RAA4\windows-replace-running-exe-tests.txt</code>)

```text
=== RUN TestAtomicReplaceRunningWindows
--- PASS: TestAtomicReplaceRunningWindows (0.60s)
=== RUN TestReplaceRunningWindowsStaleOld
--- PASS: TestReplaceRunningWindowsStaleOld (0.59s)
PASS
ok github.com/kunchenguid/treehouse/internal/updater 1.804s
```
</details>
<details>
<summary>Evidence: Full updater package test run</summary>

Source: Full updater package test run (local file: <code>~\.no-mistakes\evidence\01M1PZ8R00MDCAW84BF1K8RAA4\updater-package-tests.txt</code>)

```text
ok github.com/kunchenguid/treehouse/internal/updater 1.849s
```
</details>
<details>
<summary>Evidence: Manual Windows running-exe replace demo transcript</summary>

`PASS: unique .old.<pid>.<nanos> backup unblocks update despite leftover .old; PASS: Windows allows rename of mapped running exe then installs replacement (overwrite of mapped exe denied as expected).`

```text
﻿=== Manual Windows running-exe replace (mirrors TestReplaceRunningWindowsStaleOld) ===
Host: Microsoft Windows NT 10.0.26200.0
GOOS=windows

1) Build holdopen directly as leftover mapped .old (prior update left it running)
built staleOld=~\.no-mistakes\evidence\01M1PZ8R00MDCAW84BF1K8RAA4\manual-windows-replace-demo\hold.exe.old
stale .old running PID= HasExited=

2) Current target + replacement temp (as updater does before rename)

3) Fixed backup path target.old fails while leftover .old exists/mapped
expected fixed-.old failure: Cannot create a file when that file already exists.


4) Unique backup path (replaceRunningWindows strategy) succeeds
uniqueOld=~\.no-mistakes\evidence\01M1PZ8R00MDCAW84BF1K8RAA4\manual-windows-replace-demo\hold.exe.old.10452.639241481149394332
target after replace: replacement-bytes
PASS: unique .old.<pid>.<nanos> backup unblocks update despite mapped leftover .old

5) Also verify running-image rename is allowed (TestAtomicReplaceRunningWindows path)
running hold2 PID=15264
renamed mapped image aside to ~\.no-mistakes\evidence\01M1PZ8R00MDCAW84BF1K8RAA4\manual-windows-replace-demo\hold2.exe.old.10452.639241481157552568
new image at target2: replacement-bytes
PASS: Windows allows rename of mapped running exe; unique backup then installs replacement
cleanup complete
```
</details>

- Evidence: Updater package test inventory (local file: <code>~\.no-mistakes\evidence\01M1PZ8R00MDCAW84BF1K8RAA4\updater-test-list.txt</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c10c3829ed5c1edba5f5bcf4ba79ad754d148542","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/updater/ -run "TestAtomicReplaceRunningWindows|TestReplaceRunningWindowsStaleOld" -v -count=1`
- `go test ./internal/updater/ -count=1 -timeout 120s`
- `go test ./internal/updater/ -list "."`
- <code>Manual Windows demo: build holdopen, show mapped-exe overwrite denied, fixed `.old` rename blocked when leftover exists, unique backup path succeeds, rename-while-mapped then install replacement</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
