### PR TITLE
fix(cmd): paste-safe dirty non-TTY return --force hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ With `--no-fetch`, Treehouse resets or creates the worktree from existing local 
 
 Release a lease with `treehouse return <path>`, which terminates lingering processes and verifies that no foreign process remains before it resets the worktree, clears the lease, and returns the worktree to the pool.
 If process termination or that verification fails, the command exits nonzero and leaves the worktree and lease in place instead of recycling a slot that may still be in use.
-A non-interactive dirty return aborts without cleaning: prune will not reclaim that slot. Retry with `treehouse return --force <path>` using the same path you passed. `--force` with no path only works from inside a repository.
+A non-interactive dirty return aborts without cleaning: prune will not reclaim that slot. Retry with `treehouse return --force <path>` using the same path you passed (the printed hint shell-quotes that path so copy-paste does not expand metacharacters). `--force` with no path only works from inside a repository.
 When you pass an explicit path, `treehouse return` can run from outside the repository because it resolves the managed pool from that worktree path.
 
 For retry-safe automation, condition the return on the identity from allocation or status:

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ With `--no-fetch`, Treehouse resets or creates the worktree from existing local 
 
 Release a lease with `treehouse return <path>`, which terminates lingering processes and verifies that no foreign process remains before it resets the worktree, clears the lease, and returns the worktree to the pool.
 If process termination or that verification fails, the command exits nonzero and leaves the worktree and lease in place instead of recycling a slot that may still be in use.
-A non-interactive dirty return aborts without cleaning: prune will not reclaim that slot. Retry with `treehouse return --force <path>` using the same path you passed (the printed hint shell-quotes that path so copy-paste does not expand metacharacters). `--force` with no path only works from inside a repository.
+A non-interactive dirty return aborts without cleaning: prune will not reclaim that slot. Retry by pasting the printed `treehouse return --force <quoted-path>` hint (shell-quoted so copy-paste does not expand metacharacters). `--force` with no path only works from inside a repository.
 When you pass an explicit path, `treehouse return` can run from outside the repository because it resolves the managed pool from that worktree path.
 
 For retry-safe automation, condition the return on the identity from allocation or status:

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ With `--no-fetch`, Treehouse resets or creates the worktree from existing local 
 
 Release a lease with `treehouse return <path>`, which terminates lingering processes and verifies that no foreign process remains before it resets the worktree, clears the lease, and returns the worktree to the pool.
 If process termination or that verification fails, the command exits nonzero and leaves the worktree and lease in place instead of recycling a slot that may still be in use.
-A non-interactive dirty return aborts without cleaning: prune will not reclaim that slot. Pass `--force` to clean and return without a prompt.
+A non-interactive dirty return aborts without cleaning: prune will not reclaim that slot. Retry with `treehouse return --force <path>` using the same path you passed. `--force` with no path only works from inside a repository.
 When you pass an explicit path, `treehouse return` can run from outside the repository because it resolves the managed pool from that worktree path.
 
 For retry-safe automation, condition the return on the identity from allocation or status:

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ With `--no-fetch`, Treehouse resets or creates the worktree from existing local 
 
 Release a lease with `treehouse return <path>`, which terminates lingering processes and verifies that no foreign process remains before it resets the worktree, clears the lease, and returns the worktree to the pool.
 If process termination or that verification fails, the command exits nonzero and leaves the worktree and lease in place instead of recycling a slot that may still be in use.
+A non-interactive dirty return aborts without cleaning: prune will not reclaim that slot. Pass `--force` to clean and return without a prompt.
 When you pass an explicit path, `treehouse return` can run from outside the repository because it resolves the managed pool from that worktree path.
 
 For retry-safe automation, condition the return on the identity from allocation or status:

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1209,6 +1209,40 @@ func TestGetDetachesWorktreeWhenLeavingDirty(t *testing.T) {
 	}
 }
 
+func TestReturnNonTTYDirtyExplainsUnreclaimableSlot(t *testing.T) {
+	repoDir, homeDir := setupTestRepo(t)
+
+	env := []string{"SHELL=" + exitShellBin}
+	_, getErr, code := runTreehouse(t, repoDir, homeDir, env, "get")
+	if code != 0 {
+		t.Fatalf("get failed (code %d): %s", code, getErr)
+	}
+	wtPath := extractWorktreePath(getErr, homeDir)
+	if wtPath == "" {
+		t.Fatal("could not extract worktree path")
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, returnErr, code := runTreehouse(t, repoDir, homeDir, nil, "return", wtPath)
+	if code != 0 {
+		t.Fatalf("expected non-TTY dirty abort to exit 0, got %d: %s", code, returnErr)
+	}
+	if !strings.Contains(returnErr, "prune will not reclaim this slot") {
+		t.Fatalf("expected unreclaimable-slot explanation, got: %s", returnErr)
+	}
+	if !strings.Contains(returnErr, "return --force") {
+		t.Fatalf("expected --force hint, got: %s", returnErr)
+	}
+
+	status := gitCmd(t, wtPath, "status", "--porcelain")
+	if status == "" {
+		t.Fatal("expected worktree to stay dirty after non-TTY abort")
+	}
+}
+
 func TestReturnForceCleansAndDetachesCheckedOutBranch(t *testing.T) {
 	repoDir, homeDir := setupTestRepo(t)
 	gitCmd(t, repoDir, "checkout", "-b", "feature")

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1236,6 +1236,9 @@ func TestReturnNonTTYDirtyExplainsUnreclaimableSlot(t *testing.T) {
 	if !strings.Contains(returnErr, "return --force") {
 		t.Fatalf("expected --force hint, got: %s", returnErr)
 	}
+	if !strings.Contains(returnErr, wtPath) {
+		t.Fatalf("expected --force hint to include worktree path %q, got: %s", wtPath, returnErr)
+	}
 
 	status := gitCmd(t, wtPath, "status", "--porcelain")
 	if status == "" {

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -1230,11 +1230,20 @@ func TestReturnNonTTYDirtyExplainsUnreclaimableSlot(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("expected non-TTY dirty abort to exit 0, got %d: %s", code, returnErr)
 	}
+	t.Logf("non-TTY dirty abort stderr:\n%s", returnErr)
 	if !strings.Contains(returnErr, "prune will not reclaim this slot") {
 		t.Fatalf("expected unreclaimable-slot explanation, got: %s", returnErr)
 	}
 	if !strings.Contains(returnErr, "return --force") {
 		t.Fatalf("expected --force hint, got: %s", returnErr)
+	}
+	// Hint must be pasteable: "Use treehouse return --force <quoted-path> ..."
+	// with no outer decorative quotes wrapping the whole command.
+	if !strings.Contains(returnErr, "Use treehouse return --force ") {
+		t.Fatalf("expected undecorated --force hint, got: %s", returnErr)
+	}
+	if strings.Contains(returnErr, "Use 'treehouse return --force") {
+		t.Fatalf("hint must not wrap the retry command in decorative quotes, got: %s", returnErr)
 	}
 	if !strings.Contains(returnErr, wtPath) {
 		t.Fatalf("expected --force hint to include worktree path %q, got: %s", wtPath, returnErr)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -126,7 +126,7 @@ func getRunE(cmd *cobra.Command, args []string) error {
 
 		ok, promptErr := ui.Confirm("Clean worktree and return to pool?", true)
 		if promptErr != nil || !ok {
-			fmt.Fprintln(os.Stderr, "🌳 Worktree left dirty. Use 'treehouse return --force' to clean it later.")
+			fmt.Fprintf(os.Stderr, "🌳 Worktree left dirty. Use 'treehouse return --force %s' to clean it later.\n", quoteReturnPath(wtPath))
 			return nil
 		}
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -126,7 +126,7 @@ func getRunE(cmd *cobra.Command, args []string) error {
 
 		ok, promptErr := ui.Confirm("Clean worktree and return to pool?", true)
 		if promptErr != nil || !ok {
-			fmt.Fprintf(os.Stderr, "🌳 Worktree left dirty. Use 'treehouse return --force %s' to clean it later.\n", quoteReturnPath(wtPath))
+			fmt.Fprintf(os.Stderr, "🌳 Worktree left dirty. Use treehouse return --force %s to clean it later.\n", quoteReturnPath(wtPath))
 			return nil
 		}
 	}

--- a/cmd/quote_return_path_test.go
+++ b/cmd/quote_return_path_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestQuotePOSIXReturnPathNeutralizesShellMetacharacters(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "plain", path: "/pool/1/repo", want: "'/pool/1/repo'"},
+		{name: "spaces", path: "/pool/my repo", want: "'/pool/my repo'"},
+		{name: "double quotes", path: `/pool/say "hi"`, want: `'/pool/say "hi"'`},
+		{name: "single quote", path: "/pool/it's", want: `'/pool/it'\''s'`},
+		{name: "command substitution", path: "/pool/$(id)", want: "'/pool/$(id)'"},
+		{name: "backticks", path: "/pool/`id`", want: "'/pool/`id`'"},
+		{name: "separators", path: "/pool/a; rm -rf /", want: "'/pool/a; rm -rf /'"},
+		{name: "pipe and and", path: "/pool/a|b&&c", want: "'/pool/a|b&&c'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := quotePOSIXReturnPath(tc.path)
+			if got != tc.want {
+				t.Fatalf("quotePOSIXReturnPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+			if !strings.HasPrefix(got, "'") || !strings.HasSuffix(got, "'") {
+				t.Fatalf("expected POSIX single quotes around %q, got %q", tc.path, got)
+			}
+		})
+	}
+}
+
+func TestQuoteWindowsReturnPathDoublesInternalQuotes(t *testing.T) {
+	t.Parallel()
+
+	got := quoteWindowsReturnPath(`C:\pool\say "hi"`)
+	want := `"C:\pool\say ""hi"""`
+	if got != want {
+		t.Fatalf("quoteWindowsReturnPath = %q, want %q", got, want)
+	}
+}
+
+func TestQuoteReturnPathEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := quoteReturnPath(""); got != "" {
+		t.Fatalf("quoteReturnPath empty = %q, want empty", got)
+	}
+}

--- a/cmd/quote_return_path_test.go
+++ b/cmd/quote_return_path_test.go
@@ -53,10 +53,13 @@ func TestQuoteWindowsReturnPathPreservesPercentSignsForPaste(t *testing.T) {
 		path string
 		want string
 	}{
-		// Interactive cmd paste must keep the real path; %% would look up a
-		// different worktree and leave the dirty slot unreclaimed.
-		{name: "env-like component", path: `C:\pool\%TARGET%\repo`, want: `"C:\pool\%TARGET%\repo"`},
-		{name: "percent and quotes", path: `C:\pool\%A%\say "hi"`, want: `"C:\pool\%A%\say ""hi"""`},
+		// Interactive cmd expands %NAME% inside double quotes. Split the
+		// name across a quote boundary so paste still looks up the same
+		// path. %% would look up a different worktree.
+		{name: "env-like component", path: `C:\pool\%TARGET%\repo`, want: `"C:\pool\%"TARGET"%\repo"`},
+		{name: "percent and quotes", path: `C:\pool\%A%\say "hi"`, want: `"C:\pool\%"A"%\say ""hi"""`},
+		{name: "username", path: `C:\Users\%USERNAME%\repo`, want: `"C:\Users\%"USERNAME"%\repo"`},
+		{name: "unpaired percent", path: `C:\100%\done`, want: `"C:\100%\done"`},
 		{name: "plain", path: `C:\pool\1\repo`, want: `"C:\pool\1\repo"`},
 	}
 	for _, tc := range cases {
@@ -67,6 +70,9 @@ func TestQuoteWindowsReturnPathPreservesPercentSignsForPaste(t *testing.T) {
 			}
 			if strings.Contains(got, "%%") {
 				t.Fatalf("quoteWindowsReturnPath must not batch-escape %% for paste, got %q", got)
+			}
+			if strings.Contains(tc.path, "%TARGET%") && strings.Contains(got, "%TARGET%") {
+				t.Fatalf("quoted form still contains expandable %%TARGET%%: %q", got)
 			}
 		})
 	}

--- a/cmd/quote_return_path_test.go
+++ b/cmd/quote_return_path_test.go
@@ -45,7 +45,7 @@ func TestQuoteWindowsReturnPathDoublesInternalQuotes(t *testing.T) {
 	}
 }
 
-func TestQuoteWindowsReturnPathDoublesPercentSigns(t *testing.T) {
+func TestQuoteWindowsReturnPathPreservesPercentSignsForPaste(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -53,8 +53,10 @@ func TestQuoteWindowsReturnPathDoublesPercentSigns(t *testing.T) {
 		path string
 		want string
 	}{
-		{name: "env-like component", path: `C:\pool\%TARGET%\repo`, want: `"C:\pool\%%TARGET%%\repo"`},
-		{name: "percent and quotes", path: `C:\pool\%A%\say "hi"`, want: `"C:\pool\%%A%%\say ""hi"""`},
+		// Interactive cmd paste must keep the real path; %% would look up a
+		// different worktree and leave the dirty slot unreclaimed.
+		{name: "env-like component", path: `C:\pool\%TARGET%\repo`, want: `"C:\pool\%TARGET%\repo"`},
+		{name: "percent and quotes", path: `C:\pool\%A%\say "hi"`, want: `"C:\pool\%A%\say ""hi"""`},
 		{name: "plain", path: `C:\pool\1\repo`, want: `"C:\pool\1\repo"`},
 	}
 	for _, tc := range cases {
@@ -62,6 +64,9 @@ func TestQuoteWindowsReturnPathDoublesPercentSigns(t *testing.T) {
 			got := quoteWindowsReturnPath(tc.path)
 			if got != tc.want {
 				t.Fatalf("quoteWindowsReturnPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+			if strings.Contains(got, "%%") {
+				t.Fatalf("quoteWindowsReturnPath must not batch-escape %% for paste, got %q", got)
 			}
 		})
 	}

--- a/cmd/quote_return_path_test.go
+++ b/cmd/quote_return_path_test.go
@@ -45,6 +45,28 @@ func TestQuoteWindowsReturnPathDoublesInternalQuotes(t *testing.T) {
 	}
 }
 
+func TestQuoteWindowsReturnPathDoublesPercentSigns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "env-like component", path: `C:\pool\%TARGET%\repo`, want: `"C:\pool\%%TARGET%%\repo"`},
+		{name: "percent and quotes", path: `C:\pool\%A%\say "hi"`, want: `"C:\pool\%%A%%\say ""hi"""`},
+		{name: "plain", path: `C:\pool\1\repo`, want: `"C:\pool\1\repo"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := quoteWindowsReturnPath(tc.path)
+			if got != tc.want {
+				t.Fatalf("quoteWindowsReturnPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestQuoteReturnPathEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/quote_return_path_windows_test.go
+++ b/cmd/quote_return_path_windows_test.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestQuoteWindowsReturnPathCmdPastePreservesPercentEnv feeds the quoted form
+// through cmd.exe's command-line parser (interactive paste, not a .bat file)
+// and checks the child process argv is the literal %NAME% path. A naive
+// "%NAME%" inside one pair of double quotes expands before the process starts.
+func TestQuoteWindowsReturnPathCmdPastePreservesPercentEnv(t *testing.T) {
+	path := `C:\Users\%USERNAME%\repo`
+	quoted := quoteWindowsReturnPath(path)
+	wantLiteral := path
+
+	probe := buildCmdArgvProbe(t)
+	got := runViaCmdArgv(t, probe, quoted)
+	t.Logf("quoteWindowsReturnPath(%q) = %s", path, quoted)
+	t.Logf("cmd.exe argv after paste-style parse: %q", got)
+	if got != wantLiteral {
+		t.Fatalf("cmd paste argv = %q, want literal path %q", got, wantLiteral)
+	}
+
+	naive := `"` + path + `"`
+	expanded := runViaCmdArgv(t, probe, naive)
+	t.Logf("cmd.exe argv for naive quoted form: %q", expanded)
+	user := os.Getenv("USERNAME")
+	if expanded == wantLiteral || user == "" || !strings.Contains(expanded, user) {
+		t.Fatalf("control case should expand %%USERNAME%%, got %q", expanded)
+	}
+}
+
+func buildCmdArgvProbe(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	exe := filepath.Join(dir, "printarg.exe")
+	if err := os.WriteFile(src, []byte(`package main
+import ("fmt"; "os")
+func main() {
+	if len(os.Args) < 2 {
+		os.Exit(2)
+	}
+	fmt.Print(os.Args[1])
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mod := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(mod, []byte("module cmdargvprobe\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	build := exec.Command("go", "build", "-o", exe, ".")
+	build.Dir = dir
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build argv probe: %v\n%s", err, out)
+	}
+	return exe
+}
+
+func runViaCmdArgv(t *testing.T, probeExe, quotedArg string) string {
+	t.Helper()
+	// Interactive paste is `probe <quoted-path>`. Spawning that through
+	// `cmd /C` needs /S plus an outer quote pair so cmd's multi-quote
+	// stripping leaves the probe invocation intact (otherwise paths with
+	// %"NAME"% trip "filename syntax is incorrect"). Raw CmdLine avoids
+	// Go's Windows argv escaping rewriting the pasted quotes.
+	inner := `"` + probeExe + `" ` + quotedArg
+	cmdline := `cmd.exe /S /C "` + inner + `"`
+	cmd := exec.Command("cmd.exe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: cmdline}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cmd argv probe: %v\ncmdline=%s\n%s", err, cmdline, out)
+	}
+	return string(out)
+}

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -23,6 +23,7 @@ var (
 var (
 	errReturnWorktreeUnmanaged = errors.New("return worktree unmanaged")
 	errReturnAborted           = errors.New("return aborted")
+	errReturnAbortedNonTTY     = errors.New("return aborted: non-tty dirty")
 )
 
 var returnCmd = &cobra.Command{
@@ -72,6 +73,10 @@ var returnCmd = &cobra.Command{
 				})
 			}
 		}
+		if errors.Is(err, errReturnAbortedNonTTY) {
+			fmt.Fprintln(os.Stderr, "🌳 Aborted. Dirty worktree left in place; prune will not reclaim this slot. Use 'treehouse return --force' to clean and return it.")
+			return nil
+		}
 		if errors.Is(err, errReturnAborted) {
 			fmt.Fprintln(os.Stderr, "🌳 Aborted.")
 			return nil
@@ -97,7 +102,10 @@ func confirmWorktreeReturn(wtPath string) error {
 		dirty, _ := vcs.IsDirty(wtPath)
 		if dirty {
 			ok, err := ui.Confirm("Worktree has uncommitted changes. Clean and return?", true)
-			if err != nil || !ok {
+			if err != nil {
+				return errReturnAbortedNonTTY
+			}
+			if !ok {
 				return errReturnAborted
 			}
 		}

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -119,11 +119,10 @@ func quotePOSIXReturnPath(p string) string {
 func quoteWindowsReturnPath(p string) string {
 	// cmd.exe is Treehouse's Windows shell. Double quotes group the path and
 	// neutralize $(), backticks, and command separators. Doubled quotes are
-	// the cmd escape for embedded ". Percent signs still expand inside
-	// double quotes, so double them to keep a literal %NAME% component.
-	p = strings.ReplaceAll(p, `"`, `""`)
-	p = strings.ReplaceAll(p, `%`, `%%`)
-	return `"` + p + `"`
+	// the cmd escape for embedded ". Do not rewrite %: batch-style %% escaping
+	// survives paste into an interactive prompt as a different path, so the
+	// retry hint would miss the managed worktree.
+	return `"` + strings.ReplaceAll(p, `"`, `""`) + `"`
 }
 
 func confirmWorktreeReturn(wtPath string) error {

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -119,10 +119,49 @@ func quotePOSIXReturnPath(p string) string {
 func quoteWindowsReturnPath(p string) string {
 	// cmd.exe is Treehouse's Windows shell. Double quotes group the path and
 	// neutralize $(), backticks, and command separators. Doubled quotes are
-	// the cmd escape for embedded ". Do not rewrite %: batch-style %% escaping
-	// survives paste into an interactive prompt as a different path, so the
-	// retry hint would miss the managed worktree.
-	return `"` + strings.ReplaceAll(p, `"`, `""`) + `"`
+	// the cmd escape for embedded ".
+	//
+	// Interactive cmd expands %NAME% even inside double quotes, before the
+	// process starts. Batch-style %% doubling is not paste-safe: a prompt
+	// keeps the extra percents, so lookup misses the managed worktree.
+	// Split %NAME% across a quote boundary (%"NAME"%) so cmd concatenates
+	// the original path and does not expand NAME.
+	var b strings.Builder
+	b.Grow(len(p) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(p); {
+		switch p[i] {
+		case '"':
+			b.WriteString(`""`)
+			i++
+		case '%':
+			j := i + 1
+			for j < len(p) && isCmdEnvNameChar(p[j]) {
+				j++
+			}
+			if j > i+1 && j < len(p) && p[j] == '%' {
+				b.WriteString(`%"`)
+				b.WriteString(p[i+1 : j])
+				b.WriteString(`"%`)
+				i = j + 1
+			} else {
+				b.WriteByte('%')
+				i++
+			}
+		default:
+			b.WriteByte(p[i])
+			i++
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func isCmdEnvNameChar(c byte) bool {
+	return c == '_' ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9')
 }
 
 func confirmWorktreeReturn(wtPath string) error {

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -76,7 +76,7 @@ var returnCmd = &cobra.Command{
 			}
 		}
 		if errors.Is(err, errReturnAbortedNonTTY) {
-			fmt.Fprintf(os.Stderr, "🌳 Aborted. Dirty worktree left in place; prune will not reclaim this slot. Use 'treehouse return --force %s' to clean and return it.\n", quoteReturnPath(wtPath))
+			fmt.Fprintf(os.Stderr, "🌳 Aborted. Dirty worktree left in place; prune will not reclaim this slot. Use treehouse return --force %s to clean and return it.\n", quoteReturnPath(wtPath))
 			return nil
 		}
 		if errors.Is(err, errReturnAborted) {

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -98,14 +99,27 @@ func init() {
 	rootCmd.AddCommand(returnCmd)
 }
 
+// quoteReturnPath makes a worktree path safe to paste after
+// `treehouse return --force`. Unquoted or double-quoted paths can still
+// expand $(), backticks, or command separators in POSIX shells.
 func quoteReturnPath(p string) string {
 	if p == "" {
 		return p
 	}
-	if strings.ContainsAny(p, " \t\"'") {
-		return `"` + strings.ReplaceAll(p, `"`, `\"`) + `"`
+	if runtime.GOOS == "windows" {
+		return quoteWindowsReturnPath(p)
 	}
-	return p
+	return quotePOSIXReturnPath(p)
+}
+
+func quotePOSIXReturnPath(p string) string {
+	return "'" + strings.ReplaceAll(p, "'", `'\''`) + "'"
+}
+
+func quoteWindowsReturnPath(p string) string {
+	// cmd.exe is Treehouse's Windows shell. Double quotes group the path;
+	// doubled quotes are the cmd escape. $() is not expanded there.
+	return `"` + strings.ReplaceAll(p, `"`, `""`) + `"`
 }
 
 func confirmWorktreeReturn(wtPath string) error {

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -74,7 +75,7 @@ var returnCmd = &cobra.Command{
 			}
 		}
 		if errors.Is(err, errReturnAbortedNonTTY) {
-			fmt.Fprintln(os.Stderr, "🌳 Aborted. Dirty worktree left in place; prune will not reclaim this slot. Use 'treehouse return --force' to clean and return it.")
+			fmt.Fprintf(os.Stderr, "🌳 Aborted. Dirty worktree left in place; prune will not reclaim this slot. Use 'treehouse return --force %s' to clean and return it.\n", quoteReturnPath(wtPath))
 			return nil
 		}
 		if errors.Is(err, errReturnAborted) {
@@ -95,6 +96,16 @@ func init() {
 	returnCmd.Flags().StringVar(&returnIfLeaseID, "if-lease-id", "", "Return only if the current lease has this identity")
 	returnCmd.Flags().StringVar(&returnIfLeaseHolder, "if-lease-holder", "", "Return only if the current lease has this holder")
 	rootCmd.AddCommand(returnCmd)
+}
+
+func quoteReturnPath(p string) string {
+	if p == "" {
+		return p
+	}
+	if strings.ContainsAny(p, " \t\"'") {
+		return `"` + strings.ReplaceAll(p, `"`, `\"`) + `"`
+	}
+	return p
 }
 
 func confirmWorktreeReturn(wtPath string) error {

--- a/cmd/return_cmd.go
+++ b/cmd/return_cmd.go
@@ -117,9 +117,13 @@ func quotePOSIXReturnPath(p string) string {
 }
 
 func quoteWindowsReturnPath(p string) string {
-	// cmd.exe is Treehouse's Windows shell. Double quotes group the path;
-	// doubled quotes are the cmd escape. $() is not expanded there.
-	return `"` + strings.ReplaceAll(p, `"`, `""`) + `"`
+	// cmd.exe is Treehouse's Windows shell. Double quotes group the path and
+	// neutralize $(), backticks, and command separators. Doubled quotes are
+	// the cmd escape for embedded ". Percent signs still expand inside
+	// double quotes, so double them to keep a literal %NAME% component.
+	p = strings.ReplaceAll(p, `"`, `""`)
+	p = strings.ReplaceAll(p, `%`, `%%`)
+	return `"` + p + `"`
 }
 
 func confirmWorktreeReturn(wtPath string) error {


### PR DESCRIPTION
## Intent

Handle GitHub inbox for treehouse PR 122. Maintainer firstmate is holding merge on Greptile 3/5: quoteWindowsReturnPath still leaves cmd.exe %NAME% expansion inside double quotes. Batch-style %% doubling was already tried and reverted because interactive paste keeps the extra percents, so managed-worktree lookup misses the dirty slot. Another approach (not %%): split %NAME% across a quote boundary (%NAME%) so interactive cmd concatenates the original path and does not expand NAME. POSIX single-quote escaping is unchanged. Dirty non-TTY return stays fail-closed: no auto-clean, prune still will not reclaim the slot. The printed hint remains treehouse return --force <quoted-path> with no outer decorative quotes. Run go test ./cmd for TestQuotePOSIXReturnPathNeutralizesShellMetacharacters, TestQuoteWindowsReturnPathDoublesInternalQuotes, TestQuoteWindowsReturnPathPreservesPercentSignsForPaste, TestQuoteReturnPathEmpty, and TestReturnNonTTYDirtyExplainsUnreclaimableSlot, and report those executed tests in the tested array. Re-raise through no-mistakes so the Pipeline attestation binds to the new head.

## What Changed
- Dirty non-TTY `treehouse return` now aborts fail-closed with an explicit message that prune will not reclaim the slot, and prints a pasteable `treehouse return --force <quoted-path>` hint (no outer decorative quotes); the same quoted-path form is used from dirty `get` confirmation aborts.
- Adds `quoteReturnPath` with POSIX single-quote escaping and Windows cmd.exe double-quote escaping that splits `%NAME%` across a quote boundary so interactive paste keeps the real path (no `%%` doubling).
- Documents the non-interactive dirty-return behavior in the README and covers quoting plus non-TTY dirty return with cmd-level tests.

## Risk Assessment

✅ Low: Bounded cmd-paste-safe %NAME% quote-splitting and fail-closed non-TTY dirty return messaging match the stated intent, with no remaining decorative outer quotes and no newly reachable wrong-path or auto-clean behavior.

## Testing

Ran the five required cmd selectors plus a new Windows-only cmd paste argv test; all passed. Captured the real non-TTY dirty abort stderr (undecorated --force hint, slot left dirty) and a cmd.exe paste transcript proving %"USERNAME"% stays literal while naive double quotes expand. Strengthened the non-TTY dirty assertions and added the Windows paste probe during this test phase.

<details>
<summary>Evidence: Non-TTY dirty return CLI stderr (fail-closed + undecorated --force hint)</summary>

`Worktree has uncommitted changes. Clean and return? [Y/n] Aborted. Dirty worktree left in place; prune will not reclaim this slot. Use treehouse return --force "~\AppData\Local\Temp\...\myrepo" to clean and return it.`

```text
﻿Worktree has uncommitted changes. Clean and return? [Y/n] ≡ƒî│ Aborted. Dirty worktree left in place; prune will not reclaim this slot. Use treehouse return --force "~\AppData\Local\Temp\TestReturnNonTTYDirtyExplainsUnreclaimableSlot738063212\001\home\.treehouse\myrepo-c5b459\1\myrepo" to clean and return it.
```
</details>
<details>
<summary>Evidence: cmd.exe interactive paste: quote-boundary vs naive %USERNAME%</summary>

`Quoted form: "~"USERNAME"%\repo" -> argv ~\repo (literal). Naive "~\repo" -> argv ~\repo (expanded). Hint: Use treehouse return --force "~"USERNAME"%\repo" to clean and return it.`

```text
﻿=== End-user cmd.exe paste: argv received by process ===
Quoted form from quoteWindowsReturnPath: "~"USERNAME"%\repo"
Argv after cmd parse (quote-boundary): ~\repo
Argv after cmd parse (naive double quotes): ~\repo
USERNAME env: Knock

=== Expected paste hint (no outer decorative quotes) ===
Use treehouse return --force "~"USERNAME"%\repo" to clean and return it.

PASS criteria:
- quote-boundary argv equals ~\repo (literal percents, no expansion)
- naive argv contains expanded username and does not keep %USERNAME%
- automated coverage: TestQuoteWindowsReturnPathCmdPastePreservesPercentEnv
```
</details>
<details>
<summary>Evidence: Automated cmd paste test logs</summary>

`quoteWindowsReturnPath = "~"USERNAME"%\repo"; cmd argv after paste-style parse = ~\repo; naive argv = ~\repo; PASS`

```text
﻿=== RUN   TestQuoteWindowsReturnPathDoublesInternalQuotes
=== PAUSE TestQuoteWindowsReturnPathDoublesInternalQuotes
=== RUN   TestQuoteWindowsReturnPathPreservesPercentSignsForPaste
=== PAUSE TestQuoteWindowsReturnPathPreservesPercentSignsForPaste
=== RUN   TestQuoteWindowsReturnPathCmdPastePreservesPercentEnv
    quote_return_path_windows_test.go:25: quoteWindowsReturnPath("~\\repo") = "~"USERNAME"%\repo"
    quote_return_path_windows_test.go:26: cmd.exe argv after paste-style parse: "~\\repo"
    quote_return_path_windows_test.go:33: cmd.exe argv for naive quoted form: "~\\repo"
--- PASS: TestQuoteWindowsReturnPathCmdPastePreservesPercentEnv (0.50s)
=== CONT  TestQuoteWindowsReturnPathDoublesInternalQuotes
--- PASS: TestQuoteWindowsReturnPathDoublesInternalQuotes (0.00s)
=== CONT  TestQuoteWindowsReturnPathPreservesPercentSignsForPaste
=== RUN   TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/env-like_component
=== RUN   TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/percent_and_quotes
=== RUN   TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/username
=== RUN   TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/unpaired_percent
=== RUN   TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/plain
--- PASS: TestQuoteWindowsReturnPathPreservesPercentSignsForPaste (0.00s)
    --- PASS: TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/env-like_component (0.00s)
    --- PASS: TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/percent_and_quotes (0.00s)
    --- PASS: TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/username (0.00s)
    --- PASS: TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/unpaired_percent (0.00s)
    --- PASS: TestQuoteWindowsReturnPathPreservesPercentSignsForPaste/plain (0.00s)
```
</details>

- Evidence: Full targeted go test -v transcript (local file: <code>~\.no-mistakes\evidence\01M1QMCHFEH8GVQSC37V5ZCP0Q\go-test-required-and-cmd-paste.txt</code>)

<details>
<summary>Evidence: cmd /c vs /S /C invocation style check</summary>

```text
﻿style=powershell_call
safe=~\repo
naive=~\repo
style=S_C_outer_quotes
safe=~\repo
naive=~\repo
```
</details>
- Outcome: ⚠️ 1 info across 1 run (8m12s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e66c45c5175d571c3532d97eb2ee9d1897f5d7c6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `cmd/quote_return_path_windows_test.go` - new test file written by agent: cmd/quote_return_path_windows_test.go
- `go test ./cmd -count=1 -run "TestQuotePOSIXReturnPathNeutralizesShellMetacharacters|TestQuoteWindowsReturnPathDoublesInternalQuotes|TestQuoteWindowsReturnPathPreservesPercentSignsForPaste|TestQuoteReturnPathEmpty|TestReturnNonTTYDirtyExplainsUnreclaimableSlot|TestQuoteWindowsReturnPathCmdPastePreservesPercentEnv" -v`
- `TestQuotePOSIXReturnPathNeutralizesShellMetacharacters`
- `TestQuoteWindowsReturnPathDoublesInternalQuotes`
- `TestQuoteWindowsReturnPathPreservesPercentSignsForPaste`
- `TestQuoteReturnPathEmpty`
- `TestReturnNonTTYDirtyExplainsUnreclaimableSlot`
- <code>`TestQuoteWindowsReturnPathCmdPastePreservesPercentEnv` (Windows cmd.exe argv paste probe)</code>
- <code>Manual cmd.exe argv demo: quote-boundary form yields `~\repo`; naive `&#34;%USERNAME%&#34;` expands to `~\repo`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
