### PR TITLE
feat: factor out package.nix from flake.nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ on:
     paths-ignore:
       - .release-please-manifest.json
       - CHANGELOG.md
+      - default.nix
       - flake.nix
+      - package.nix
 
 jobs:
   check:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,6 +20,8 @@ on:
     paths:
       - "flake.nix"
       - "flake.lock"
+      - "default.nix"
+      - "package.nix"
       - "go.mod"
       - "go.sum"
       - ".github/workflows/nix.yml"
@@ -28,14 +30,16 @@ on:
     # release-please opens its release PR with GITHUB_TOKEN, which creates a
     # pull_request run that can only sit in action_required. Its output set
     # is exactly these files (release-please-config.json extra-files includes
-    # flake.nix), so excluding them means no run is ever created on a release
-    # PR. Mirrors ci.yml. A flake.nix-only logic change that doesn't touch
+    # the Nix package files), so excluding them means no run is ever created
+    # on a release PR. Mirrors ci.yml. A flake.nix-only logic change that doesn't touch
     # any other file won't trigger PR CI here — the push trigger above covers
     # it post-merge, and workflow_dispatch allows manual runs.
     paths-ignore:
       - .release-please-manifest.json
       - CHANGELOG.md
+      - default.nix
       - flake.nix
+      - package.nix
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -3,8 +3,8 @@ name: update-vendor-hash
 on:
   pull_request:
     # vendorHash tracks the Go module graph (go.mod / go.sum), not the
-    # release-please version bump in flake.nix. Keeping flake.nix out of
-    # this paths filter means release PRs create no run here.
+    # release-please version bumps in the Nix package files. Keeping those
+    # files out of this paths filter means release PRs create no run here.
     paths:
       - go.mod
       - go.sum
@@ -41,22 +41,22 @@ jobs:
           fi
 
           echo "Updating vendorHash to $correct_hash"
-          sed -i "s|vendorHash = \".*\";|vendorHash = \"$correct_hash\";|" flake.nix
+          sed -i "s|vendorHash = \".*\";|vendorHash = \"$correct_hash\";|" package.nix
 
           # Verify it builds now
           nix build
 
       - name: Commit if changed
         run: |
-          git diff --quiet flake.nix && exit 0
+          git diff --quiet package.nix && exit 0
 
           if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            echo "::warning::vendorHash is out of date, but the PR head is a fork (${{ github.event.pull_request.head.repo.full_name }}) that this workflow's token cannot push to. The build above already verified the corrected vendorHash - update flake.nix manually on the fork, or push from a branch on ${{ github.repository }}, before merging."
+            echo "::warning::vendorHash is out of date, but the PR head is a fork (${{ github.event.pull_request.head.repo.full_name }}) that this workflow's token cannot push to. The build above already verified the corrected vendorHash - update package.nix manually on the fork, or push from a branch on ${{ github.repository }}, before merging."
             exit 1
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add flake.nix
+          git add package.nix
           git commit -m "chore: update nix vendorHash"
           git push

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {}
+, version ? "2.3.0" # x-release-please-version
+}:
+
+pkgs.callPackage ./package.nix { inherit version; }

--- a/flake.nix
+++ b/flake.nix
@@ -30,45 +30,13 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          treehouse = pkgs.buildGoModule {
-            pname = "treehouse";
-            inherit version;
-            src = pkgs.lib.cleanSource ./.;
-            vendorHash = "sha256-z8IndcHcZ6nLqhLtAYul3ppddpOA4AHGQWIlfYY/pfI=";
-            ldflags = [
-              "-X main.version=v${version}"
-            ];
-            # python3 is required by .github/scripts/no-mistakes-gate.sh,
-            # which the test suite (TestNoMistakesGateDecisions) executes via
-            # bash to parse pipeline attestation JSON. Without it the gate
-            # falls through to the wrong error path and tests fail in the
-            # Nix sandbox.
-            nativeCheckInputs = [
-              pkgs.git
-              pkgs.python3
-            ];
-            # The cmd/ package's e2e tests (cmd/e2e_test.go) build the
-            # treehouse binary, create git repos with bare remotes, and
-            # spawn treehouse as a subprocess — all of which require network
-            # access and unrestricted filesystem that the Nix sandbox does
-            # not provide. The project's own CI (.github/workflows/ci.yml)
-            # runs `go test ./...` on ubuntu, macOS, and Windows, which is
-            # more comprehensive than the Nix sandbox can do. The Nix CI
-            # workflow (.github/workflows/nix.yml) validates the binary with
-            # `nix run .#default -- --version` instead.
-            doCheck = false;
-            meta = {
-              description = "Git worktree pool manager for parallel AI coding agent workflows";
-              homepage = "https://github.com/kunchenguid/treehouse";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "treehouse";
-              platforms = systems;
-            };
+          treehouse = import ./default.nix {
+            inherit pkgs version;
           };
         in
         {
           default = treehouse;
-          treehouse = treehouse;
+          inherit treehouse;
         }
       );
 

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildGoModule
+, git
+, python3
+, version ? "2.3.0" # x-release-please-version
+}:
+
+buildGoModule {
+  pname = "treehouse";
+  inherit version;
+
+  src = lib.cleanSource ./.;
+  vendorHash = "sha256-z8IndcHcZ6nLqhLtAYul3ppddpOA4AHGQWIlfYY/pfI=";
+
+  ldflags = [
+    "-X main.version=v${version}"
+  ];
+
+  # python3 is required by .github/scripts/no-mistakes-gate.sh, which the
+  # test suite (TestNoMistakesGateDecisions) executes via bash to parse
+  # pipeline attestation JSON. Without it the gate falls through to the
+  # wrong error path and tests fail in the Nix sandbox.
+  nativeCheckInputs = [
+    git
+    python3
+  ];
+
+  # The cmd/ package's e2e tests build the treehouse binary, create git repos
+  # with bare remotes, and spawn treehouse as a subprocess — all of which
+  # require network access and unrestricted filesystem access that the Nix
+  # sandbox does not provide. The project's own CI runs `go test ./...` on
+  # ubuntu, macOS, and Windows, which is more comprehensive than the Nix
+  # sandbox can do.
+  doCheck = false;
+
+  meta = {
+    description = "Git worktree pool manager for parallel AI coding agent workflows";
+    homepage = "https://github.com/kunchenguid/treehouse";
+    license = lib.licenses.mit;
+    mainProgram = "treehouse";
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,9 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
-        "flake.nix"
+        "default.nix",
+        "flake.nix",
+        "package.nix"
       ]
     }
   },

--- a/release_ci_exclusions_test.go
+++ b/release_ci_exclusions_test.go
@@ -413,7 +413,7 @@ func TestExpectedReleaseOutputsIncludesConfiguredExtraFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{".release-please-manifest.json", "CHANGELOG.md", "flake.nix"}
+	want := []string{".release-please-manifest.json", "CHANGELOG.md", "default.nix", "flake.nix", "package.nix"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("expected %v, got %v", want, got)
 	}


### PR DESCRIPTION
## Summary

Factor the Nix package definition out of `flake.nix` into standard `package.nix` and `default.nix` files. Keeping the package definition separate makes the flake's system-specific output wiring clearer and gives us a focused package expression that can be evaluated for upstreaming to nixpkgs.

## Changes

- Add `package.nix` with the `buildGoModule` definition, metadata, build flags, vendor hash, and Nix-specific check inputs.
- Add `default.nix` so the package can be built with traditional `nix-build`/`callPackage` workflows.
- Update `flake.nix` to reuse the extracted package for every supported system while preserving the existing `default` and `treehouse` outputs.
- Update release and vendor-hash workflow wiring for the new package files.

## Validation

- `nix flake check --all-systems --no-build`
- `nix-build default.nix`
- `go test .`
