### PR TITLE
docs: document the no-mistakes contribution gate in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,9 @@ if the stored token lacks it. Fix it before pushing:
 
 ```sh
 # Add the workflow scope to your gh credentials, then configure git to use it.
-# gh auth refresh re-runs the OAuth flow to add the scope. If you authenticated
+# gh auth refresh re-runs the OAuth flow to add the scope. If you authenticate
 # with a PAT, its scopes are immutable — create a new PAT that includes the
-# workflow scope on GitHub, then re-authenticate with it: gh auth login -s workflow
+# workflow scope on GitHub and re-authenticate with gh auth login --with-token.
 gh auth refresh -s workflow
 gh auth setup-git
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,9 @@ if the stored token lacks it. Fix it before pushing:
 
 ```sh
 # Add the workflow scope to your gh credentials, then configure git to use it.
-# gh auth refresh re-runs the OAuth flow; if it fails (e.g. you authenticated
-# with a PAT), re-authenticate instead: gh auth login -s workflow
+# gh auth refresh re-runs the OAuth flow to add the scope. If you authenticated
+# with a PAT, its scopes are immutable — create a new PAT that includes the
+# workflow scope on GitHub, then re-authenticate with it: gh auth login -s workflow
 gh auth refresh -s workflow
 gh auth setup-git
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,9 @@ attestation whose `head_sha` matches the PR head; a hand-added marker is not eno
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 no-mistakes doctor   # needs git + a supported agent runner + gh
 
-# In your fork clone, keep origin on your fork and add the parent as upstream
-git remote add upstream https://github.com/kunchenguid/treehouse.git
-
-# Point the gate at your fork
+# In your fork clone, keep origin on the parent (kunchenguid/treehouse)
+# and point the gate at your fork via --fork-url. The gate pushes validated
+# branches to your fork while opening PRs against the parent (origin).
 no-mistakes init --fork-url https://github.com/<you>/treehouse.git
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,8 @@ credential with the `workflow` scope. GitHub rejects the push with
 if the stored token lacks it. Fix it before pushing:
 
 ```sh
-# Create a PAT at https://github.com/settings/tokens with workflow + repo scope,
-# then store it for the fork host:
-echo "https://<you>:<PAT>@github.com" >> ~/.no-mistakes/.git-credentials
-# (or: gh auth setup-git if your gh token already has workflow scope)
+# Ensure your gh token has workflow + repo scope, then configure git to use it:
+gh auth setup-git
 ```
 
 ### Tips

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,9 @@ attestation whose `head_sha` matches the PR head; a hand-added marker is not eno
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 no-mistakes doctor   # needs git + a supported agent runner + gh
 
-# no-mistakes opens PRs against your `origin` remote, so keep origin on the
-# parent (kunchenguid/treehouse). If you cloned your fork, reset origin first:
+# no-mistakes opens PRs against your `origin` remote, so origin must point to
+# the parent (kunchenguid/treehouse). If you cloned the parent directly you're
+# already set; if you cloned your fork instead, reset origin first:
 #   git remote set-url origin https://github.com/kunchenguid/treehouse.git
 # Then point the gate at your fork via --fork-url. The gate pushes validated
 # branches to your fork while opening PRs against the parent (origin).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,72 @@ make test
 1. Fork the repo and create a branch from `main`.
 2. Make your changes.
 3. Run `make lint` and `make test` to verify.
-4. Open a pull request.
+4. Open a pull request (see **Contribution Gate** below).
+
+## Contribution Gate
+
+PRs to `main` must be raised through [no-mistakes](https://github.com/kunchenguid/no-mistakes).
+The required check `PR must be raised via no-mistakes` enforces this — a hand-opened PR
+will stay red until the branch is pushed through the gate. The gate writes a pipeline
+attestation whose `head_sha` matches the PR head; a hand-added marker is not enough.
+
+### Setup (one-time)
+
+```sh
+# Install no-mistakes
+curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
+no-mistakes doctor   # needs git + a supported agent runner + gh
+
+# In your fork clone, keep origin on your fork and add the parent as upstream
+git remote add upstream https://github.com/kunchenguid/treehouse.git
+
+# Point the gate at your fork
+no-mistakes init --fork-url https://github.com/<you>/treehouse.git
+```
+
+### Raising a PR
+
+```sh
+# On your feature branch, push through the gate (not git push origin)
+git push no-mistakes
+
+# Drive the pipeline to completion
+no-mistakes                    # TUI, or:
+no-mistakes axi run --intent "<what you set out to accomplish>"
+# Loop on gate: with no-mistakes axi respond --action approve|fix|skip
+# until outcome: checks-passed
+```
+
+The gate pushes your branch to your fork, opens (or updates) the PR against the parent
+repo, and writes the attestation into the PR body. Once the pipeline hits
+`checks-passed`, the `PR must be raised via no-mistakes` check goes green on its own.
+
+### Workflow file changes
+
+If your PR touches `.github/workflows/*.yml`, the push to your fork requires a git
+credential with the `workflow` scope. GitHub rejects the push with
+`refusing to allow an OAuth App to create or update workflow ... without workflow scope`
+if the stored token lacks it. Fix it before pushing:
+
+```sh
+# Create a PAT at https://github.com/settings/tokens with workflow + repo scope,
+# then store it for the fork host:
+echo "https://<you>:<PAT>@github.com" >> ~/.no-mistakes/.git-credentials
+# (or: gh auth setup-git if your gh token already has workflow scope)
+```
+
+### Tips
+
+- The attestation's `head_sha` must match the current PR head. If you force-push,
+  rebase, or the pipeline auto-fixes land new commits, re-run
+  `no-mistakes axi run` (or `no-mistakes rerun`) to produce a fresh attestation —
+  do not hand-edit the PR body.
+- Let the pipeline make its own fix commits (review/test/lint auto-fixes land on
+  the branch). Don't abort-and-restart to fix a finding yourself mid-run; respond
+  at the gate instead.
+
+See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/)
+for the full walkthrough.
 
 ## Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,8 @@ credential with the `workflow` scope. GitHub rejects the push with
 if the stored token lacks it. Fix it before pushing:
 
 ```sh
-# Ensure your gh token has workflow + repo scope, then configure git to use it:
+# Add the workflow scope to your gh token, then configure git to use it:
+gh auth refresh -s workflow
 gh auth setup-git
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,9 @@ credential with the `workflow` scope. GitHub rejects the push with
 if the stored token lacks it. Fix it before pushing:
 
 ```sh
-# Add the workflow scope to your gh token, then configure git to use it:
+# Add the workflow scope to your gh credentials, then configure git to use it.
+# gh auth refresh re-runs the OAuth flow; if it fails (e.g. you authenticated
+# with a PAT), re-authenticate instead: gh auth login -s workflow
 gh auth refresh -s workflow
 gh auth setup-git
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,10 @@ attestation whose `head_sha` matches the PR head; a hand-added marker is not eno
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 no-mistakes doctor   # needs git + a supported agent runner + gh
 
-# In your fork clone, keep origin on the parent (kunchenguid/treehouse)
-# and point the gate at your fork via --fork-url. The gate pushes validated
+# no-mistakes opens PRs against your `origin` remote, so keep origin on the
+# parent (kunchenguid/treehouse). If you cloned your fork, reset origin first:
+#   git remote set-url origin https://github.com/kunchenguid/treehouse.git
+# Then point the gate at your fork via --fork-url. The gate pushes validated
 # branches to your fork while opening PRs against the parent (origin).
 no-mistakes init --fork-url https://github.com/<you>/treehouse.git
 ```


### PR DESCRIPTION
## What Changed
- Adds a **Contribution Gate** section to `CONTRIBUTING.md` explaining that PRs to `main` must be raised through no-mistakes, enforced by the `PR must be raised via no-mistakes` required check.
- Documents one-time setup (install, `no-mistakes doctor`, origin-remote alignment, and `no-mistakes init --fork-url`), the PR-raising flow (`git push no-mistakes` + `no-mistakes axi run`/`respond`), and the workflow-scope credential requirements for PRs touching `.github/workflows/*.yml`.
- Adds tips on keeping the attestation `head_sha` in sync (re-run the pipeline after force-push/rebase/auto-fix) and letting the pipeline make its own fix commits, plus a link to the no-mistakes quick start.

## Risk Assessment

✅ Low: A well-bounded docs-only change to CONTRIBUTING.md whose every command, URL, and behavioral claim was verified against upstream no-mistakes docs and the repo's own required-check workflow, with all prior review concerns resolved in the final state.

## Testing

Confirmed the change is docs-only (only CONTRIBUTING.md, +70/-1; treehouse Go CLI unchanged). Verified the documented external resources resolve (4/4 URLs HTTP 200, install script is the genuine no-mistakes installer) and that every referenced no-mistakes and gh subcommand exists. The documented contribution gate workflow itself cannot be driven live because it is operated by no-mistakes, which this phase is forbidden from invoking, and it requires a personal fork plus the parent repo's GitHub required check. No live treehouse product surface exists to drive, so the verdict is no-surface.

- Live validation: ⚠️ no-surface - 0 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Contributor installs no-mistakes via the documented curl\|sh command and runs `no-mistakes doctor` — tooling health check passes. | ⏸️ untested | no | Driving the no-mistakes install/run is outside this phase&#39;s authority (forbidden to invoke no-mistakes init/axi run/rerun/respond), and it exercises external tooling, not the treehouse product surface… |
| Contributor points origin at the parent repo and runs `no-mistakes init --fork-url &lt;fork&gt;` — the gate initializes for the repository. | ⏸️ untested | no | Forbidden to run no-mistakes init; also requires a personal GitHub fork and credentials not available in this isolated worktree. |
| Contributor pushes via `git push no-mistakes` and drives `no-mistakes axi run --intent` to checks-passed — the `PR must be raised via no-mistakes` required check goes green. | ⏸️ untested | no | Forbidden to run no-mistakes axi run; requires GitHub credentials and the parent repo&#39;s required check, neither drivable from this isolated worktree. |
| Contributor with a workflow-file PR fixes credential scope via `gh auth refresh -s workflow` + `gh auth setup-git` — push to fork succeeds. | ⏸️ untested | no | Requires GitHub authentication and a fork with workflow-file changes to observe a push outcome; not the treehouse product surface and not drivable here. |
| Adversarial: a hand-opened PR (not pushed through the gate) stays red on `PR must be raised via no-mistakes` because the attestation head_sha must match the PR head. | ⏸️ untested | no | Requires the actual GitHub required check on the parent repo and a hand-opened PR; cannot be driven from this isolated worktree, and the gate behavior is owned by no-mistakes which this phase is forbi… |

<details>
<summary>Evidence: docs-external-resources-check</summary>

`docs-external-resources-check: URLs 200, no-mistakes + gh subcommands exist, docs-only change, no-surface`

```text
docs-external-resources-check: URLs 200, no-mistakes + gh subcommands exist, docs-only change, no-surface
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (4m31s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b2bc7cf6df0bbc0493739391598b03b0ff59c7a5","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"no-surface","live":0,"total":5}} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ this change has no live-validatable surface; proceed without live validation? (0 of 5 scenarios were driven live against the product); Contributor installs no-mistakes via the documented curl|sh command and runs `no-mistakes doctor` — tooling health check passes.: Driving the no-mistakes install/run is outside this phase&#39;s authority (forbidden to invoke no-mistakes init/axi run/rerun/respond), and it exercises external tooling, not the treehouse product surface.; Contributor points origin at the parent repo and runs `no-mistakes init --fork-url &lt;fork&gt;` — the gate initializes for the repository.: Forbidden to run no-mistakes init; also requires a personal GitHub fork and credentials not available in this isolated worktree.; Contributor pushes via `git push no-mistakes` and drives `no-mistakes axi run --intent` to checks-passed — the `PR must be raised via no-mistakes` required check goes green.: Forbidden to run no-mistakes axi run; requires GitHub credentials and the parent repo&#39;s required check, neither drivable from this isolated worktree.; Contributor with a workflow-file PR fixes credential scope via `gh auth refresh -s workflow` + `gh auth setup-git` — push to fork succeeds.: Requires GitHub authentication and a fork with workflow-file changes to observe a push outcome; not the treehouse product surface and not drivable here.; Adversarial: a hand-opened PR (not pushed through the gate) stays red on `PR must be raised via no-mistakes` because the attestation head_sha must match the PR head.: Requires the actual GitHub required check on the parent repo and a hand-opened PR; cannot be driven from this isolated worktree, and the gate behavior is owned by no-mistakes which this phase is forbidden to invoke.
- Live validation: ⚠️ no-surface - 0 of 5 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Contributor installs no-mistakes via the documented curl\|sh command and runs `no-mistakes doctor` — tooling health check passes. | ⏸️ untested | no | Driving the no-mistakes install/run is outside this phase&#39;s authority (forbidden to invoke no-mistakes init/axi run/rerun/respond), and it exercises external tooling, not the treehouse product surface… |
| Contributor points origin at the parent repo and runs `no-mistakes init --fork-url &lt;fork&gt;` — the gate initializes for the repository. | ⏸️ untested | no | Forbidden to run no-mistakes init; also requires a personal GitHub fork and credentials not available in this isolated worktree. |
| Contributor pushes via `git push no-mistakes` and drives `no-mistakes axi run --intent` to checks-passed — the `PR must be raised via no-mistakes` required check goes green. | ⏸️ untested | no | Forbidden to run no-mistakes axi run; requires GitHub credentials and the parent repo&#39;s required check, neither drivable from this isolated worktree. |
| Contributor with a workflow-file PR fixes credential scope via `gh auth refresh -s workflow` + `gh auth setup-git` — push to fork succeeds. | ⏸️ untested | no | Requires GitHub authentication and a fork with workflow-file changes to observe a push outcome; not the treehouse product surface and not drivable here. |
| Adversarial: a hand-opened PR (not pushed through the gate) stays red on `PR must be raised via no-mistakes` because the attestation head_sha must match the PR head. | ⏸️ untested | no | Requires the actual GitHub required check on the parent repo and a hand-opened PR; cannot be driven from this isolated worktree, and the gate behavior is owned by no-mistakes which this phase is forbi… |

- <code>`git diff 67c9f2f..b2bc7cf --name-only` -&gt; only CONTRIBUTING.md changed (docs-only)</code>
- <code>`git diff 67c9f2f..b2bc7cf -- CONTRIBUTING.md` -&gt; reviewed the added Contribution Gate section</code>
- <code>`curl -s -o /dev/null -w &#39;%{http_code}&#39; -L` against all 4 documented URLs -&gt; 200 for install.sh, quick-start, no-mistakes repo, treehouse repo</code>
- <code>`curl install.sh | grep` -&gt; confirmed REPO=kunchenguid/no-mistakes, real installer</code>
- <code>`no-mistakes --help` / `no-mistakes axi --help` / `no-mistakes rerun --help` -&gt; doctor, init, axi run, axi respond, rerun all exist</code>
- <code>`gh auth refresh --help` / `gh auth setup-git --help` -&gt; both subcommands exist and accept the documented flags</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
