### PR TITLE
fix: pin nix-build to flake-locked nixpkgs and extract package.nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ on:
     paths-ignore:
       - .release-please-manifest.json
       - CHANGELOG.md
+      - default.nix
       - flake.nix
+      - package.nix
 
 jobs:
   check:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,6 +20,8 @@ on:
     paths:
       - "flake.nix"
       - "flake.lock"
+      - "default.nix"
+      - "package.nix"
       - "go.mod"
       - "go.sum"
       - ".github/workflows/nix.yml"
@@ -28,14 +30,16 @@ on:
     # release-please opens its release PR with GITHUB_TOKEN, which creates a
     # pull_request run that can only sit in action_required. Its output set
     # is exactly these files (release-please-config.json extra-files includes
-    # flake.nix), so excluding them means no run is ever created on a release
-    # PR. Mirrors ci.yml. A flake.nix-only logic change that doesn't touch
+    # the Nix package files), so excluding them means no run is ever created
+    # on a release PR. Mirrors ci.yml. A flake.nix-only logic change that doesn't touch
     # any other file won't trigger PR CI here — the push trigger above covers
     # it post-merge, and workflow_dispatch allows manual runs.
     paths-ignore:
       - .release-please-manifest.json
       - CHANGELOG.md
+      - default.nix
       - flake.nix
+      - package.nix
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -31,7 +31,7 @@ on:
     # pull_request run that can only sit in action_required. Its output set
     # is exactly these files (release-please-config.json extra-files includes
     # the Nix package files), so excluding them means no run is ever created
-    # on a release PR. Mirrors ci.yml. A flake.nix-only logic change that doesn't touch
+    # on a release PR. Mirrors ci.yml. A Nix-package-file-only logic change that doesn't touch
     # any other file won't trigger PR CI here — the push trigger above covers
     # it post-merge, and workflow_dispatch allows manual runs.
     paths-ignore:

--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -3,8 +3,8 @@ name: update-vendor-hash
 on:
   pull_request:
     # vendorHash tracks the Go module graph (go.mod / go.sum), not the
-    # release-please version bump in flake.nix. Keeping flake.nix out of
-    # this paths filter means release PRs create no run here.
+    # release-please version bumps in the Nix package files. Keeping those
+    # files out of this paths filter means release PRs create no run here.
     paths:
       - go.mod
       - go.sum
@@ -41,22 +41,22 @@ jobs:
           fi
 
           echo "Updating vendorHash to $correct_hash"
-          sed -i "s|vendorHash = \".*\";|vendorHash = \"$correct_hash\";|" flake.nix
+          sed -i "s|vendorHash = \".*\";|vendorHash = \"$correct_hash\";|" package.nix
 
           # Verify it builds now
           nix build
 
       - name: Commit if changed
         run: |
-          git diff --quiet flake.nix && exit 0
+          git diff --quiet package.nix && exit 0
 
           if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-            echo "::warning::vendorHash is out of date, but the PR head is a fork (${{ github.event.pull_request.head.repo.full_name }}) that this workflow's token cannot push to. The build above already verified the corrected vendorHash - update flake.nix manually on the fork, or push from a branch on ${{ github.repository }}, before merging."
+            echo "::warning::vendorHash is out of date, but the PR head is a fork (${{ github.event.pull_request.head.repo.full_name }}) that this workflow's token cannot push to. The build above already verified the corrected vendorHash - update package.nix manually on the fork, or push from a branch on ${{ github.repository }}, before merging."
             exit 1
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add flake.nix
+          git add package.nix
           git commit -m "chore: update nix vendorHash"
           git push

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {}
+, version ? "2.3.0" # x-release-please-version
+}:
+
+pkgs.callPackage ./package.nix { inherit version; }

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,11 @@
-{ pkgs ? import <nixpkgs> {}
-, version ? "2.3.0" # x-release-please-version
-}:
-
-pkgs.callPackage ./package.nix { inherit version; }
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) {
+  src = ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1775126147,
@@ -18,6 +34,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -30,45 +30,13 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          treehouse = pkgs.buildGoModule {
-            pname = "treehouse";
-            inherit version;
-            src = pkgs.lib.cleanSource ./.;
-            vendorHash = "sha256-z8IndcHcZ6nLqhLtAYul3ppddpOA4AHGQWIlfYY/pfI=";
-            ldflags = [
-              "-X main.version=v${version}"
-            ];
-            # python3 is required by .github/scripts/no-mistakes-gate.sh,
-            # which the test suite (TestNoMistakesGateDecisions) executes via
-            # bash to parse pipeline attestation JSON. Without it the gate
-            # falls through to the wrong error path and tests fail in the
-            # Nix sandbox.
-            nativeCheckInputs = [
-              pkgs.git
-              pkgs.python3
-            ];
-            # The cmd/ package's e2e tests (cmd/e2e_test.go) build the
-            # treehouse binary, create git repos with bare remotes, and
-            # spawn treehouse as a subprocess — all of which require network
-            # access and unrestricted filesystem that the Nix sandbox does
-            # not provide. The project's own CI (.github/workflows/ci.yml)
-            # runs `go test ./...` on ubuntu, macOS, and Windows, which is
-            # more comprehensive than the Nix sandbox can do. The Nix CI
-            # workflow (.github/workflows/nix.yml) validates the binary with
-            # `nix run .#default -- --version` instead.
-            doCheck = false;
-            meta = {
-              description = "Git worktree pool manager for parallel AI coding agent workflows";
-              homepage = "https://github.com/kunchenguid/treehouse";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "treehouse";
-              platforms = systems;
-            };
+          treehouse = import ./default.nix {
+            inherit pkgs version;
           };
         in
         {
           default = treehouse;
-          treehouse = treehouse;
+          inherit treehouse;
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,8 @@
     # nixpkgs-unstable input covers all four target systems. Revisit when
     # nixpkgs-unstable drops x86_64-darwin and a -darwin branch with Go
     # 1.25+ exists.
+    flake-compat.url = "github:edolstra/flake-compat";
+    flake-compat.flake = false;
   };
 
   outputs =
@@ -30,9 +32,7 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          treehouse = import ./default.nix {
-            inherit pkgs version;
-          };
+          treehouse = pkgs.callPackage ./package.nix { inherit version; };
         in
         {
           default = treehouse;

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -76,10 +76,18 @@ func TestStaleJJAuthenticationRequiresSignedInventory(t *testing.T) {
 	if err := os.RemoveAll(worktree); err != nil {
 		t.Fatal(err)
 	}
+	// Create the forged file at a temporary path before removing the original
+	// auth file so the new file is guaranteed a different inode. On Linux tmpfs
+	// a remove-then-create at the same path can reuse the freed inode, which
+	// would make fileIdentity match and the fail-closed check non-deterministic.
+	forgedPath := authPath + ".forged"
+	if err := os.WriteFile(forgedPath, []byte("forged user data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Remove(authPath); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(authPath, []byte("forged user data"), 0o600); err != nil {
+	if err := os.Rename(forgedPath, authPath); err != nil {
 		t.Fatal(err)
 	}
 

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildGoModule
+, git
+, python3
+, version ? "2.3.0" # x-release-please-version
+}:
+
+buildGoModule {
+  pname = "treehouse";
+  inherit version;
+
+  src = lib.cleanSource ./.;
+  vendorHash = "sha256-z8IndcHcZ6nLqhLtAYul3ppddpOA4AHGQWIlfYY/pfI=";
+
+  ldflags = [
+    "-X main.version=v${version}"
+  ];
+
+  # python3 is required by .github/scripts/no-mistakes-gate.sh, which the
+  # test suite (TestNoMistakesGateDecisions) executes via bash to parse
+  # pipeline attestation JSON. Without it the gate falls through to the
+  # wrong error path and tests fail in the Nix sandbox.
+  nativeCheckInputs = [
+    git
+    python3
+  ];
+
+  # The cmd/ package's e2e tests build the treehouse binary, create git repos
+  # with bare remotes, and spawn treehouse as a subprocess — all of which
+  # require network access and unrestricted filesystem access that the Nix
+  # sandbox does not provide. The project's own CI runs `go test ./...` on
+  # ubuntu, macOS, and Windows, which is more comprehensive than the Nix
+  # sandbox can do.
+  doCheck = false;
+
+  meta = {
+    description = "Git worktree pool manager for parallel AI coding agent workflows";
+    homepage = "https://github.com/kunchenguid/treehouse";
+    license = lib.licenses.mit;
+    mainProgram = "treehouse";
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,9 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
-        "flake.nix"
+        "default.nix",
+        "flake.nix",
+        "package.nix"
       ]
     }
   },

--- a/release_ci_exclusions_test.go
+++ b/release_ci_exclusions_test.go
@@ -413,7 +413,7 @@ func TestExpectedReleaseOutputsIncludesConfiguredExtraFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{".release-please-manifest.json", "CHANGELOG.md", "flake.nix"}
+	want := []string{".release-please-manifest.json", "CHANGELOG.md", "default.nix", "flake.nix", "package.nix"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("expected %v, got %v", want, got)
 	}


### PR DESCRIPTION
## Intent

Fix the ambient nixpkgs bug in default.nix that greptile flagged on PR #135: the previous default.nix used import <nixpkgs> {} which pulls whatever ambient channel the user has, potentially lacking Go 1.25.5 (the flake deliberately pins nixpkgs-unstable for this) or having dropped x86_64-darwin (nixpkgs 26.11+ removes it). Replace with a flake-compat shim that reads the locked nixpkgs from flake.lock, guaranteeing the traditional nix-build path uses the same toolchain and platform support as the flake. Also change flake.nix to call package.nix directly via callPackage instead of importing default.nix (avoids circular import now that default.nix imports the flake via flake-compat). x86_64-darwin support must be preserved — that is the whole point of the PR.

## What Changed
- Replaced the ambient `import <nixpkgs> {}` in `default.nix` with a flake-compat shim that reads the locked nixpkgs from `flake.lock`, so the traditional `nix-build` path uses the same pinned toolchain and x86_64-darwin support as the flake.
- Extracted the `buildGoModule` definition from `flake.nix` into `package.nix` and switched `flake.nix` to `pkgs.callPackage ./package.nix`, avoiding the circular import created by `default.nix` importing the flake via flake-compat.
- Updated CI workflows, `release-please-config.json` extra-files, and the vendor-hash workflow to track `package.nix`/`default.nix` (vendorHash now lives in `package.nix`); fixed a `pool_test.go` case to write the forged auth file at a temp path before rename so it gets a distinct inode on Linux tmpfs.

## Risk Assessment

✅ Low: The change is a well-bounded Nix packaging refactor: the flake-compat shim matches the canonical pattern, callPackage correctly avoids the circular import, x86_64-darwin is preserved, and all workflow/test updates are internally consistent.

## Testing

<code>Drove all five nix-related scenarios live against the real Nix toolchain on this x86_64-darwin host. The flake-compat shim in default.nix builds a working treehouse binary using the locked nixpkgs-unstable (Go 1.26.1), while the old `import &lt;nixpkgs&gt; {}` pattern throws because the ambient channel (nixpkgs-26.11) dropped x86_64-darwin — directly demonstrating the bug the PR fixes. Both nix-build and nix build produce the identical derivation, proving the shim uses the same locked nixpkgs as the flake. All four systems evaluate via flake check. No circular import: flake.nix calls package.nix via callPackage, default.nix imports the flake via flake-compat. The flaky-test fix passes 5x.</code>

- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Traditional nix-build via default.nix produces a working binary (flake-compat shim reads locked nixpkgs) | ✅ pass | live | nix-build-traditional.log + nix-build-binary-version.log: nix-build produces /nix/store/xpxmy1q2k3f495ad6a56mk533kj3s1m7-treehouse-2.3.0, binary reports v2.3.0 |
| Flake path (nix build .#default) still works after package.nix extraction via callPackage | ✅ pass | live | nix-build-flake.log + nix-flake-binary-version.log: nix build .#default succeeds, binary reports v2.3.0 |
| Adversarial: flake-compat shim uses locked nixpkgs, not ambient channel (old import &lt;nixpkgs&gt; {} would fail on x86_64-darwin) | ✅ pass | live | adversarial-ambient-vs-shim.log + derivation-comparison.log: old `import &lt;nixpkgs&gt; {}` throws &#39;Nixpkgs 26.11 has dropped support for x86_64-darwin&#39;; new shim builds successfully; both nix-build and ni… |
| x86_64-darwin support preserved across all four target systems | ✅ pass | live | nix-flake-check.log: nix flake check --all-systems --no-build passes for aarch64-darwin, x86_64-darwin, aarch64-linux, x86_64-linux; actual builds ran on x86_64-darwin and succeeded |
| No circular import: flake.nix calls package.nix via callPackage, default.nix imports flake via flake-compat | ✅ pass | live | Both nix-build (default.nix -&gt; flake-compat -&gt; flake.nix -&gt; callPackage package.nix) and nix build .#default (flake.nix -&gt; callPackage package.nix) succeed, proving no circular dependency |
| nix build .#treehouse (second CI target in nix.yml) builds and runs | ✅ pass | live | Built .#treehouse, binary reports v2.3.0 |

<details>
<summary>Evidence: Adversarial: ambient nixpkgs throws on x86_64-darwin vs flake-compat shim succeeds</summary>

<code>=== ADVERSARIAL: old default.nix pattern (import &lt;nixpkgs&gt; {}) on this x86_64-darwin host ===&#10;Evaluating: (import &lt;nixpkgs&gt; {}).go.version&#10;error:&#10;error: Nixpkgs 26.11 has dropped support for x86_64-darwin.&#10;&#10;=== FIX: new default.nix (flake-compat shim reading flake.lock) ===&#10;nix-build succeeds and produces:&#10;/nix/store/xpxmy1q2k3f495ad6a56mk533kj3s1m7-treehouse-2.3.0&#10;&#10;=== Binary from nix-build works ===&#10;v2.3.0</code>

```text
=== ADVERSARIAL: old default.nix pattern (import <nixpkgs> {}) on this x86_64-darwin host ===
Evaluating: (import <nixpkgs> {}).go.version
error:
       error: Nixpkgs 26.11 has dropped support for x86_64-darwin.

EXIT_CODE=0

=== FIX: new default.nix (flake-compat shim reading flake.lock) ===
nix-build succeeds and produces:
/nix/store/xpxmy1q2k3f495ad6a56mk533kj3s1m7-treehouse-2.3.0

=== Binary from nix-build works ===
v2.3.0
```
</details>
<details>
<summary>Evidence: Derivation identity: nix-build and nix build .#default produce same .drv</summary>

<code>=== nix-build (default.nix flake-compat shim) deriver ===&#10;/nix/store/0wl8s5i09p3qchaixsin3inplp0m95gy-treehouse-2.3.0.drv&#10;&#10;=== nix build .#default (flake path) derivation ===&#10;0wl8s5i09p3qchaixsin3inplp0m95gy-treehouse-2.3.0.drv&#10;&#10;=== Go version used (from derivation env) ===&#10;nativeBuildInputs: /nix/store/yv6jj27racylbfjw6a1cdr91ndxbgyf6-go-1.26.1&#10;system: x86_64-darwin</code>

```text
=== nix-build (default.nix flake-compat shim) deriver ===
/nix/store/0wl8s5i09p3qchaixsin3inplp0m95gy-treehouse-2.3.0.drv

=== nix build .#default (flake path) derivation ===
0wl8s5i09p3qchaixsin3inplp0m95gy-treehouse-2.3.0.drv

=== Go version used (from derivation env) ===
nativeBuildInputs: /nix/store/yv6jj27racylbfjw6a1cdr91ndxbgyf6-go-1.26.1
system: x86_64-darwin
```
</details>
<details>
<summary>Evidence: nix flake check --all-systems --no-build (all 4 systems pass)</summary>

<code>evaluating flake...&#10;checking flake output &#39;apps&#39;...&#10;checking app &#39;apps.x86_64-darwin.treehouse&#39;...&#10;evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin&#10;checking derivation packages.x86_64-darwin.treehouse...&#10;derivation evaluated to /nix/store/0wl8s5i09p3qchaixsin3inplp0m95gy-treehouse-2.3.0.drv&#10;... (all 4 systems: aarch64-darwin, x86_64-darwin, aarch64-linux, x86_64-linux evaluated, exit 0)</code>

```text
evaluating flake...
checking flake output 'apps'...
checking app 'apps.aarch64-darwin.treehouse'...
checking app 'apps.aarch64-darwin.default'...
checking app 'apps.x86_64-darwin.treehouse'...
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
checking app 'apps.x86_64-darwin.default'...
checking app 'apps.aarch64-linux.treehouse'...
checking app 'apps.aarch64-linux.default'...
checking app 'apps.x86_64-linux.treehouse'...
checking app 'apps.x86_64-linux.default'...
checking flake output 'packages'...
checking derivation packages.x86_64-darwin.treehouse...
derivation evaluated to /nix/store/0wl8s5i09p3qchaixsin3inplp0m95gy-treehouse-2.3.0.drv
checking derivation packages.x86_64-darwin.default...
derivation evaluated to /nix/store/0wl8s5i09p3qchaixsin3inplp0m95gy-treehouse-2.3.0.drv
checking derivation packages.x86_64-linux.treehouse...
derivation evaluated to /nix/store/0cm7ahm2y64g3k1ihqqlb9y9ypbp043j-treehouse-2.3.0.drv
checking derivation packages.x86_64-linux.default...
derivation evaluated to /nix/store/0cm7ahm2y64g3k1ihqqlb9y9ypbp043j-treehouse-2.3.0.drv
checking derivation packages.aarch64-darwin.treehouse...
derivation evaluated to /nix/store/5dlblh22xvkzc1rkhp70wsbsw0p9zw24-treehouse-2.3.0.drv
checking derivation packages.aarch64-darwin.default...
derivation evaluated to /nix/store/5dlblh22xvkzc1rkhp70wsbsw0p9zw24-treehouse-2.3.0.drv
checking derivation packages.aarch64-linux.treehouse...
derivation evaluated to /nix/store/5pa2c9537zv69q23h82q6zq1vsyjfknc-treehouse-2.3.0.drv
checking derivation packages.aarch64-linux.default...
derivation evaluated to /nix/store/5pa2c9537zv69q23h82q6zq1vsyjfknc-treehouse-2.3.0.drv
```
</details>
<details>
<summary>Evidence: nix-build traditional path (default.nix flake-compat shim)</summary>

<code>evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin&#10;/nix/store/xpxmy1q2k3f495ad6a56mk533kj3s1m7-treehouse-2.3.0</code>

```text
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
/nix/store/xpxmy1q2k3f495ad6a56mk533kj3s1m7-treehouse-2.3.0
```
</details>
<details>
<summary>Evidence: nix-build with empty NIX_PATH (shim does not need ambient nixpkgs)</summary>

<code>evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin&#10;/nix/store/xpxmy1q2k3f495ad6a56mk533kj3s1m7-treehouse-2.3.0&#10;EXIT=0</code>

```text
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
/nix/store/xpxmy1q2k3f495ad6a56mk533kj3s1m7-treehouse-2.3.0
```
</details>
<details>
<summary>Evidence: Flaky-test fix passes 5x (TestStaleJJAuthenticationRequiresSignedInventory)</summary>

`ok github.com/kunchenguid/treehouse/internal/pool 0.265s`

```text
ok  	github.com/kunchenguid/treehouse/internal/pool	0.265s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a2da4c526353111af6b8ac52ee9043558f265ec9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":6,"total":6}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 6 of 6 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Traditional nix-build via default.nix produces a working binary (flake-compat shim reads locked nixpkgs) | ✅ pass | live | nix-build-traditional.log + nix-build-binary-version.log: nix-build produces /nix/store/xpxmy1q2k3f495ad6a56mk533kj3s1m7-treehouse-2.3.0, binary reports v2.3.0 |
| Flake path (nix build .#default) still works after package.nix extraction via callPackage | ✅ pass | live | nix-build-flake.log + nix-flake-binary-version.log: nix build .#default succeeds, binary reports v2.3.0 |
| Adversarial: flake-compat shim uses locked nixpkgs, not ambient channel (old import &lt;nixpkgs&gt; {} would fail on x86_64-darwin) | ✅ pass | live | adversarial-ambient-vs-shim.log + derivation-comparison.log: old `import &lt;nixpkgs&gt; {}` throws &#39;Nixpkgs 26.11 has dropped support for x86_64-darwin&#39;; new shim builds successfully; both nix-build and ni… |
| x86_64-darwin support preserved across all four target systems | ✅ pass | live | nix-flake-check.log: nix flake check --all-systems --no-build passes for aarch64-darwin, x86_64-darwin, aarch64-linux, x86_64-linux; actual builds ran on x86_64-darwin and succeeded |
| No circular import: flake.nix calls package.nix via callPackage, default.nix imports flake via flake-compat | ✅ pass | live | Both nix-build (default.nix -&gt; flake-compat -&gt; flake.nix -&gt; callPackage package.nix) and nix build .#default (flake.nix -&gt; callPackage package.nix) succeed, proving no circular dependency |
| nix build .#treehouse (second CI target in nix.yml) builds and runs | ✅ pass | live | Built .#treehouse, binary reports v2.3.0 |

- <code>`nix flake check --all-systems --no-build` (validates all 4 systems incl. x86_64-darwin evaluate)</code>
- <code>`nix build .#default --print-build-logs` (flake path after package.nix extraction)</code>
- <code>`./result/bin/treehouse --version` after `nix build .#default` (reports v2.3.0)</code>
- <code>`nix-build` (traditional path via default.nix flake-compat shim)</code>
- <code>`./result/bin/treehouse --version` after `nix-build` (reports v2.3.0)</code>
- <code>`env -u NIX_PATH NIX_PATH= nix-build` (shim works without ambient nixpkgs path)</code>
- <code>`nix-store --query --deriver` vs `nix derivation show .#default` (derivation identity comparison)</code>
- <code>`nix-instantiate --eval -E &#39;(import &lt;nixpkgs&gt; {}).go.version&#39;` (adversarial: old pattern throws on x86_64-darwin)</code>
- <code>`nix build .#treehouse --print-build-logs` (second CI target in nix.yml)</code>
- <code>`go test ./internal/pool/ -run TestStaleJJAuthenticationRequiresSignedInventory -count=5` (flaky-test fix on branch)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
